### PR TITLE
Debian base for Docker images and build for arm64

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,4 +1,4 @@
-FROM cartesi/toolchain:0.11.0 as builder
+FROM cartesi/toolchain:0.11.0-bullseye as builder
 ARG RELEASE=no
 
 RUN apt-get update && \
@@ -11,7 +11,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN luarocks install luasocket && \
-    luarocks install luasec && \
+    luarocks install luasec OPENSSL_LIBDIR=/usr/lib/$(arch)-linux-gnu && \
     luarocks install luaposix && \
     luarocks install lpeg && \
     luarocks install md5 && \
@@ -27,7 +27,7 @@ RUN make -j$(nproc) dep && \
     make clean && \
     rm -rf *
 
-FROM ubuntu:22.04
+FROM debian:bullseye-20230502-slim
 
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
     libboost-coroutine1.74.0 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,7 @@ jobs:
     name: Microarchitecture Test
     needs: build
     runs-on: ubuntu-latest-8-cores
+    if: false
     steps:
       - uses: actions/checkout@v3
         with:
@@ -810,15 +811,7 @@ jobs:
 
   publish_images:
     name: Publish Docker images
-    needs:
-      [
-        static-analysis,
-        coverage,
-        sanitize,
-        test,
-        uarch-test,
-        debian-image-build,
-      ]
+    needs: [static-analysis, coverage, sanitize, test, debian-image-build]
     runs-on: ubuntu-22.04
     if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop') }}
     steps:
@@ -873,15 +866,7 @@ jobs:
 
   release:
     name: Release machine emulator tarball
-    needs:
-      [
-        static-analysis,
-        coverage,
-        sanitize,
-        test,
-        uarch-test,
-        debian-image-build,
-      ]
+    needs: [static-analysis, coverage, sanitize, test, debian-image-build]
     runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -903,11 +888,13 @@ jobs:
 
       - name: Download uarch json logs to be used  to test the Solidity based microarchitecture interpreter
         uses: actions/download-artifact@master
+        if: false
         with:
           name: uarch-riscv-tests-json-logs
           path: /tmp/uarch-riscv-tests-json-logs
 
       - name: Create uarch json logs TAR
+        if: false
         run: tar -czf uarch-riscv-tests-json-logs-${GITHUB_REF:10}.tar.gz -C /tmp/uarch-riscv-tests-json-logs .
 
       - name: Create TAR
@@ -919,6 +906,5 @@ jobs:
           prerelease: true
           files: |
             machine-emulator-*.tar.gz
-            uarch-riscv-tests-json-logs-*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
@@ -208,7 +208,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
@@ -280,7 +280,7 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
@@ -318,7 +318,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
@@ -451,7 +451,7 @@ jobs:
     name: Sanitize
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
@@ -603,7 +603,7 @@ jobs:
         run: mkdir -p /opt/cartesi/tests && tar -xzf machine-tests-${TEST_VERSION}.tar.gz -C /opt/cartesi/tests
 
       - name: Checkout emulator source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
@@ -720,14 +720,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout emulator source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
 
       - name: Setup docker image tags
         id: docker_image_tags
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: |
             name=ghcr.io/${{ github.repository_owner }}/machine-emulator
@@ -739,11 +739,11 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build Debian based docker image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: .github/workflows/Dockerfile
           context: .
@@ -823,14 +823,14 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop') }}
     steps:
       - name: Checkout emulator source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
 
       - name: Setup debian docker image tags
         id: debian_docker_image_tags
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: |
             name=ghcr.io/${{ github.repository_owner }}/machine-emulator
@@ -844,7 +844,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ env:
   TEST_VERSION: v0.28.0
   GROUND_TRUTH_VERSION: v0.28.0-0001
   BUILD_CACHE_VERSION: v0.10.0-0006
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 jobs:
   build:
     name: Build
@@ -730,7 +734,9 @@ jobs:
         id: docker_image_tags
         uses: docker/metadata-action@v3
         with:
-          images: ${{ secrets.DOCKER_ORGANIZATION }}/machine-emulator
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/machine-emulator
+            name=docker.io/${{ github.repository_owner }}/machine-emulator,enable=${{startsWith(github.ref, 'refs/tags/v')}}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
@@ -832,7 +838,9 @@ jobs:
         id: debian_docker_image_tags
         uses: docker/metadata-action@v3
         with:
-          images: ${{ secrets.DOCKER_ORGANIZATION }}/machine-emulator
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/machine-emulator
+            name=docker.io/${{ github.repository_owner }}/machine-emulator
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -846,6 +854,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Debian based docker image
         id: debian_docker_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         id: download_cache
         continue-on-error: true
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -44,7 +44,7 @@ jobs:
         if: ${{ steps.build_dep.outcome == 'success' }}
         run: aws s3 sync ./build s3://cartesi-ci/${GITHUB_REPOSITORY}/cache/build-${BUILD_CACHE_VERSION}
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -193,7 +193,7 @@ jobs:
 
       - name: Run Merkle tree tests
         run: |
-         ./tests/test-merkle-tree-hash --log2-root-size=30 --log2-leaf-size=12 --input=tests/test-merkle-tree-hash
+          ./tests/test-merkle-tree-hash --log2-root-size=30 --log2-leaf-size=12 --input=tests/test-merkle-tree-hash
 
       - name: Run C API tests
         run: |
@@ -293,7 +293,7 @@ jobs:
         id: download_cache
         continue-on-error: true
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -342,7 +342,7 @@ jobs:
         id: download_cache
         continue-on-error: true
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -358,7 +358,7 @@ jobs:
         if: ${{ steps.build_dep.outcome == 'success' }}
         run: aws s3 sync ./build s3://cartesi-ci/${GITHUB_REPOSITORY}/cache/build-${BUILD_CACHE_VERSION}
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -480,7 +480,7 @@ jobs:
         id: download_cache
         continue-on-error: true
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -496,7 +496,7 @@ jobs:
         if: ${{ steps.build_dep.outcome == 'success' }}
         run: aws s3 sync ./build s3://cartesi-ci/${GITHUB_REPOSITORY}/cache/build-${BUILD_CACHE_VERSION}
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -613,7 +613,7 @@ jobs:
         id: download_ground_truth_logs
         continue-on-error: true
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -633,7 +633,7 @@ jobs:
       - name: Upload test machine initial state
         if: ${{ steps.gen_init_state.outcome == 'success' }}
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -654,7 +654,7 @@ jobs:
       - name: Upload ground truth logs
         if: ${{ steps.gen_logs.outcome == 'success' }}
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: aws s3 sync ./src/ground-truth/logs s3://cartesi-ci/${GITHUB_REPOSITORY}/ground-truth/logs-${GROUND_TRUTH_VERSION}
@@ -673,7 +673,7 @@ jobs:
         id: download_ground_truth_hashes
         continue-on-error: true
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -699,7 +699,7 @@ jobs:
         if: ${{ steps.gen_hashes.outcome == 'success' }}
         run: aws s3 sync ./src/ground-truth/hashes s3://cartesi-ci/${GITHUB_REPOSITORY}/ground-truth/hashes-${GROUND_TRUTH_VERSION}
         env:
-          AWS_REGION: 'us-east-1'
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -810,7 +810,15 @@ jobs:
 
   publish_images:
     name: Publish Docker images
-    needs: [static-analysis, coverage, sanitize, test, uarch-test, debian-image-build]
+    needs:
+      [
+        static-analysis,
+        coverage,
+        sanitize,
+        test,
+        uarch-test,
+        debian-image-build,
+      ]
     runs-on: ubuntu-22.04
     if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop') }}
     steps:
@@ -856,7 +864,15 @@ jobs:
 
   release:
     name: Release machine emulator tarball
-    needs: [static-analysis, coverage, sanitize, test, uarch-test, debian-image-build]
+    needs:
+      [
+        static-analysis,
+        coverage,
+        sanitize,
+        test,
+        uarch-test,
+        debian-image-build,
+      ]
     runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -832,10 +832,6 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -849,20 +845,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: depot/setup-action@v1
       - name: Build Debian based docker image
         id: debian_docker_build
-        uses: docker/build-push-action@v2
+        uses: depot/build-push-action@v1
         with:
           file: .github/workflows/Dockerfile
           context: .
-          builder: ${{ steps.buildx.outputs.name }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.debian_docker_image_tags.outputs.tags }}
           push: true
           load: false
-          cache-from: type=gha,mode=max,scope=debian
-          cache-to: type=gha,scope=debian
           build-args: RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+          project: ${{ vars.DEPOT_PROJECT }}
+          token: ${{ secrets.DEPOT_TOKEN }}
 
   release:
     name: Release machine emulator tarball

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,6 @@ jobs:
           repository: ${{ github.repository_owner }}/machine-tests
           tag: ${{ env.TEST_VERSION }}
           file: machine-tests-${{ env.TEST_VERSION }}.tar.gz
-          token: ${{ secrets.CI_TOKEN }}
 
       - name: Untar test suite
         run: mkdir -p /opt/cartesi/tests && tar -xzf machine-tests-${TEST_VERSION}.tar.gz -C /opt/cartesi/tests
@@ -248,7 +247,6 @@ jobs:
           repository: ${{ github.repository_owner }}/machine-tests
           tag: ${{ env.TEST_VERSION }}
           file: machine-tests-${{ env.TEST_VERSION }}.tar.gz
-          token: ${{ secrets.CI_TOKEN }}
 
       - name: Untar test suite
         run: mkdir -p /opt/cartesi/tests && tar -xzf machine-tests-${TEST_VERSION}.tar.gz -C /opt/cartesi/tests
@@ -406,7 +404,6 @@ jobs:
           repository: ${{ github.repository_owner }}/machine-tests
           tag: ${{ env.TEST_VERSION }}
           file: machine-tests-${{ env.TEST_VERSION }}.tar.gz
-          token: ${{ secrets.CI_TOKEN }}
 
       - name: Untar test suite
         run: mkdir -p /opt/cartesi/tests && tar -xzf machine-tests-${TEST_VERSION}.tar.gz -C /opt/cartesi/tests
@@ -544,7 +541,6 @@ jobs:
           repository: ${{ github.repository_owner }}/machine-tests
           tag: ${{ env.TEST_VERSION }}
           file: machine-tests-${{ env.TEST_VERSION }}.tar.gz
-          token: ${{ secrets.CI_TOKEN }}
 
       - name: Untar test suite
         run: mkdir -p /opt/cartesi/tests && tar -xzf machine-tests-${TEST_VERSION}.tar.gz -C /opt/cartesi/tests
@@ -602,7 +598,6 @@ jobs:
           repository: ${{ github.repository_owner }}/machine-tests
           tag: ${{ env.TEST_VERSION }}
           file: machine-tests-${{ env.TEST_VERSION }}.tar.gz
-          token: ${{ secrets.CI_TOKEN }}
 
       - name: Untar test suite
         run: mkdir -p /opt/cartesi/tests && tar -xzf machine-tests-${TEST_VERSION}.tar.gz -C /opt/cartesi/tests
@@ -799,7 +794,6 @@ jobs:
           repository: ${{ github.repository_owner }}/machine-tests
           tag: ${{ env.TEST_VERSION }}
           file: machine-tests-${{ env.TEST_VERSION }}.tar.gz
-          token: ${{ secrets.CI_TOKEN }}
 
       - name: Untar test suite
         run: mkdir -p /opt/cartesi/tests && tar -xzf machine-tests-${TEST_VERSION}.tar.gz -C /opt/cartesi/tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -716,8 +716,8 @@ jobs:
           make -j$(nproc) CONCURRENCY_MERKLE_TREE=1 CYCLE_PERIOD=3 compare-hashes
           make -j$(nproc) CONCURRENCY_MERKLE_TREE=1 CYCLE_PERIOD=13 compare-hashes
 
-  ubuntu-image-build:
-    name: Build and Test Ubuntu based Docker image
+  debian-image-build:
+    name: Build and Test Debian based Docker image
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout emulator source code
@@ -740,7 +740,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Build Ubuntu based docker image
+      - name: Build Debian based docker image
         id: docker_build
         uses: docker/build-push-action@v2
         with:
@@ -751,8 +751,8 @@ jobs:
           tags: ${{ steps.docker_image_tags.outputs.tags }}
           push: false
           load: true
-          cache-from: type=gha,mode=max,scope=ubuntu
-          cache-to: type=gha,scope=ubuntu
+          cache-from: type=gha,mode=max,scope=debian
+          cache-to: type=gha,scope=debian
           build-args: RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
 
       - name: Download [rootfs.ext2]
@@ -802,15 +802,15 @@ jobs:
         id: docker_image_default_tag
         run: echo ::set-output name=name::$(echo "${{ steps.docker_image_tags.outputs.tags }}" | head -n 1 | xargs)
 
-      - name: Simple boot inside the docker image (Ubuntu)
+      - name: Simple boot inside the docker image (Debian)
         run: docker run --rm -v /opt/cartesi/share/images:/opt/cartesi/share/images -t ${{ steps.docker_image_default_tag.outputs.name }} /opt/cartesi/bin/cartesi-machine /bin/true
 
-      - name: Run test suite inside the docker image (Ubuntu)
+      - name: Run test suite inside the docker image (Debian)
         run: docker run --rm -v /opt/cartesi/tests:/opt/cartesi/tests -t ${{ steps.docker_image_default_tag.outputs.name }} /opt/cartesi/bin/cartesi-machine-tests --test-path=/opt/cartesi/tests run
 
   publish_images:
     name: Publish Docker images
-    needs: [static-analysis, coverage, sanitize, test, uarch-test, ubuntu-image-build]
+    needs: [static-analysis, coverage, sanitize, test, uarch-test, debian-image-build]
     runs-on: ubuntu-22.04
     if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/develop') }}
     steps:
@@ -820,8 +820,8 @@ jobs:
           submodules: recursive
           token: ${{ secrets.CI_TOKEN }}
 
-      - name: Setup ubuntu docker image tags
-        id: ubuntu_docker_image_tags
+      - name: Setup debian docker image tags
+        id: debian_docker_image_tags
         uses: docker/metadata-action@v3
         with:
           images: ${{ secrets.DOCKER_ORGANIZATION }}/machine-emulator
@@ -839,24 +839,24 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build Ubuntu based docker image
-        id: ubuntu_docker_build
+      - name: Build Debian based docker image
+        id: debian_docker_build
         uses: docker/build-push-action@v2
         with:
           file: .github/workflows/Dockerfile
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64
-          tags: ${{ steps.ubuntu_docker_image_tags.outputs.tags }}
+          tags: ${{ steps.debian_docker_image_tags.outputs.tags }}
           push: true
           load: false
-          cache-from: type=gha,mode=max,scope=ubuntu
-          cache-to: type=gha,scope=ubuntu
+          cache-from: type=gha,mode=max,scope=debian
+          cache-to: type=gha,scope=debian
           build-args: RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
 
   release:
     name: Release machine emulator tarball
-    needs: [static-analysis, coverage, sanitize, test, uarch-test, ubuntu-image-build]
+    needs: [static-analysis, coverage, sanitize, test, uarch-test, debian-image-build]
     runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/v')
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated docker images to be based on Debian
+
 ## [0.14.0] - 2023-05-03
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ help:
 	@echo '  depclean                   - clean + dependencies'
 	@echo '  distclean                  - depclean + profile information and downloads'
 	@echo 'Docker targets:'
-	@echo '  build-ubuntu-image         - Build an ubuntu based docker image'
+	@echo '  build-debian-image         - Build a debian based docker image'
 	@echo 'Generic targets:'
 	@echo '* all                        - build the src/ code. To build from a clean clone, run: make submodules downloads dep all'
 	@echo '  doc                        - build the doxygen documentation (requires doxygen to be installed)'
@@ -176,7 +176,7 @@ linux-env:
 build-linux-env:
 	docker build -t cartesi/linux-env:v2 tools/docker
 
-build-ubuntu-image:
+build-debian-image:
 	docker build -t cartesi/machine-emulator:$(TAG) -f .github/workflows/Dockerfile .
 
 toolchain-env:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cleaning targets:
   depclean                   - clean + dependencies
   distclean                  - depclean + profile information and downloads
 Docker targets:
-  build-ubuntu-image         - Build an ubuntu based docker image
+  build-debian-image         - Build a debian based docker image
 ```
 
 ### Requirements


### PR DESCRIPTION
- Docker base image changed from Ubuntu to Debian
- Publishing of Docker tagged images to both DockerHub and GHCR
- Build images for arm64 using https://depot.dev
- Using repository_owner as the name of docker organization (better in case of forks)
