### PR TITLE
Add static analysis and formatting for Lua code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,7 +286,18 @@ jobs:
       - name: Install Ubuntu dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libreadline-dev libboost-context-dev libboost-coroutine-dev libboost-filesystem-dev libssl-dev libc-ares-dev zlib1g-dev ca-certificates patchelf automake cmake clang-tidy-14 clang-format-14 lua5.4 liblua5.4-dev lua-socket libb64-dev libcrypto++-dev nlohmann-json3-dev
+          sudo apt-get install -y libreadline-dev libboost-context-dev libboost-coroutine-dev libboost-filesystem-dev libssl-dev libc-ares-dev zlib1g-dev ca-certificates patchelf automake cmake clang-tidy-14 clang-format-14 lua5.4 liblua5.4-dev luarocks lua-socket libb64-dev libcrypto++-dev nlohmann-json3-dev
+
+      - name: Install lua test dependencies
+        run: |
+          sudo luarocks install --lua-version=5.4 luacheck
+
+      - name: Install StyLua
+        run: |
+          sudo apt-get install -y wget unzip
+          wget https://github.com/JohnnyMorganz/StyLua/releases/download/v0.17.1/stylua-linux-x86_64.zip -O /tmp/stylua-linux-x86_64.zip
+          echo "c44231ca27bdcc3801682efd8b4460efb94f6c22 /tmp/stylua-linux-x86_64.zip" | sha1sum -c
+          sudo unzip /tmp/stylua-linux-x86_64.zip stylua -d /usr/bin
 
       - name: Download cache of third-party build
         run: aws s3 sync s3://cartesi-ci/${GITHUB_REPOSITORY}/cache/build-${BUILD_CACHE_VERSION} ./build && test -f ./build/`uname`_`uname -m`/lib/libcryptopp.so.7
@@ -303,8 +314,14 @@ jobs:
       - name: Setup update-alternatives for clang-format
         run: sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 120
 
-      - name: Check format
+      - name: Check format (C++)
         run: make check-format
+
+      - name: Check format (Lua)
+        run: make check-format-lua
+
+      - name: Check Lua
+        run: make check-lua
 
       - name: Setup update-alternatives for clang-tidy
         run: sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added static analysis for Lua code
+- Added code formatter for Lua code
 - Added --version and --version-json command-line options in cartesi-machine
 - Added --skip-root-hash-check command line option to speed up machine loading in tests
 - Added --skip-version-check command line option to allow testing old machine snapshots

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ $(COREPROTO):
 	$(info gprc-interfaces submodule not initialized!)
 	@exit 1
 grpc: | $(COREPROTO)
-hash luacartesi grpc test test-all lint coverage check-format format:
+hash luacartesi grpc test test-all lint coverage check-format check-format-lua check-lua format format-lua:
 	@eval $$($(MAKE) -s --no-print-directory env); $(MAKE) -C $(SRCDIR) $@
 riscv-arch-tests:
 	@eval $$($(MAKE) -s --no-print-directory env); $(MAKE) -C third-party/riscv-arch-tests

--- a/src/Makefile
+++ b/src/Makefile
@@ -263,6 +263,9 @@ CLANG_FORMAT_UARCH_FILES:=$(filter-out %uarch-printf%,$(strip $(CLANG_FORMAT_UAR
 CLANG_FORMAT_FILES:=$(wildcard *.cpp) $(wildcard *.c) $(wildcard *.h) $(wildcard *.hpp) $(CLANG_FORMAT_UARCH_FILES)
 CLANG_FORMAT_FILES:=$(filter-out %.pb.h,$(strip $(CLANG_FORMAT_FILES)))
 
+STYLUA=stylua
+STYLUA_FLAGS=--indent-type Spaces --collapse-simple-statement Always
+
 EMPTY:=
 SPACE:=$(EMPTY) $(EMPTY)
 CLANG_TIDY_HEADER_FILTER=$(PWD)/($(subst $(SPACE),|,$(LINTER_HEADERS)))
@@ -294,7 +297,7 @@ endif
 
 all: luacartesi grpc hash c-api jsonrpc-remote-cartesi-machine
 
-.PHONY: all generate use clean test lint format check-format luacartesi grpc hash docker c-api compile_flags.txt
+.PHONY: all generate use clean test lint format format-lua check-format check-format-lua luacartesi grpc hash docker c-api compile_flags.txt
 
 CARTESI_OBJS:= \
 	pma-driver.o \
@@ -444,6 +447,15 @@ format:
 
 check-format:
 	@$(CLANG_FORMAT) -Werror --dry-run $(CLANG_FORMAT_FILES)
+
+format-lua:
+	@$(STYLUA) $(STYLUA_FLAGS) .
+
+check-format-lua:
+	@$(STYLUA) $(STYLUA_FLAGS) --check .
+
+check-lua:
+	luacheck .
 
 fs.ext2: fs/*
 	genext2fs -f -i 512 -b 8192 -d fs fs.ext2

--- a/src/cartesi-machine-stored-hash.lua
+++ b/src/cartesi-machine-stored-hash.lua
@@ -16,11 +16,12 @@
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 --
 
-local util = require"cartesi.util"
+local util = require("cartesi.util")
 
 local f = assert(
     io.open(assert(arg[1], "missing machine name") .. "/hash", "rb"),
-    string.format("unable to open machine '%s'", tostring(arg[1])))
+    string.format("unable to open machine '%s'", tostring(arg[1]))
+)
 local h = assert(f:read("a"), "unable to read hash")
 f:close()
 print(util.hexhash(h))

--- a/src/cartesi-machine-tests.lua
+++ b/src/cartesi-machine-tests.lua
@@ -16,279 +16,279 @@
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 --
 
-local cartesi = require"cartesi"
-local util = require"cartesi.util"
+local cartesi = require("cartesi")
+local util = require("cartesi.util")
 
 -- Tests Cases
 -- format {"ram_image_file", number_of_cycles, halt_payload, yield_payloads}
 local riscv_tests = {
-  {"rv64mi-p-access.bin", 144},
-  {"rv64mi-p-breakpoint.bin", 115},
-  {"rv64mi-p-csr.bin", 297},
-  {"rv64mi-p-illegal.bin", 361},
-  {"rv64mi-p-ld-misaligned.bin", 369},
-  {"rv64mi-p-lh-misaligned.bin", 121},
-  {"rv64mi-p-lw-misaligned.bin", 181},
-  {"rv64mi-p-ma_addr.bin", 742},
-  {"rv64mi-p-ma_fetch.bin", 138},
-  {"rv64mi-p-mcsr.bin", 103},
-  {"rv64mi-p-sbreak.bin", 111},
-  {"rv64mi-p-scall.bin", 95},
-  {"rv64mi-p-sd-misaligned.bin", 389},
-  {"rv64mi-p-sh-misaligned.bin", 129},
-  {"rv64mi-p-sw-misaligned.bin", 185},
-  {"rv64si-p-csr.bin", 196},
-  {"rv64si-p-dirty.bin", 177},
-  {"rv64si-p-icache-alias.bin", 227},
-  {"rv64si-p-ma_fetch.bin", 125},
-  {"rv64si-p-sbreak.bin", 105},
-  {"rv64si-p-scall.bin", 112},
-  {"rv64si-p-wfi.bin", 91},
-  {"rv64ua-p-amoadd_d.bin", 108},
-  {"rv64ua-p-amoadd_w.bin", 105},
-  {"rv64ua-p-amoand_d.bin", 105},
-  {"rv64ua-p-amoand_w.bin", 104},
-  {"rv64ua-p-amomax_d.bin", 104},
-  {"rv64ua-p-amomax_w.bin", 104},
-  {"rv64ua-p-amomaxu_d.bin", 104},
-  {"rv64ua-p-amomaxu_w.bin", 104},
-  {"rv64ua-p-amomin_d.bin", 104},
-  {"rv64ua-p-amomin_w.bin", 104},
-  {"rv64ua-p-amominu_d.bin", 104},
-  {"rv64ua-p-amominu_w.bin", 104},
-  {"rv64ua-p-amoor_d.bin", 103},
-  {"rv64ua-p-amoor_w.bin", 103},
-  {"rv64ua-p-amoswap_d.bin", 105},
-  {"rv64ua-p-amoswap_w.bin", 104},
-  {"rv64ua-p-amoxor_d.bin", 106},
-  {"rv64ua-p-amoxor_w.bin", 108},
-  {"rv64ua-p-lrsc.bin", 6280},
-  {"rv64ua-v-amoadd_d.bin", 10597},
-  {"rv64ua-v-amoadd_w.bin", 10594},
-  {"rv64ua-v-amoand_d.bin", 10606},
-  {"rv64ua-v-amoand_w.bin", 10605},
-  {"rv64ua-v-amomax_d.bin", 10587},
-  {"rv64ua-v-amomax_w.bin", 10587},
-  {"rv64ua-v-amomaxu_d.bin", 10587},
-  {"rv64ua-v-amomaxu_w.bin", 10587},
-  {"rv64ua-v-amomin_d.bin", 10587},
-  {"rv64ua-v-amomin_w.bin", 10587},
-  {"rv64ua-v-amominu_d.bin", 10593},
-  {"rv64ua-v-amominu_w.bin", 10593},
-  {"rv64ua-v-amoor_d.bin", 10586},
-  {"rv64ua-v-amoor_w.bin", 10586},
-  {"rv64ua-v-amoswap_d.bin", 10606},
-  {"rv64ua-v-amoswap_w.bin", 10605},
-  {"rv64ua-v-amoxor_d.bin", 10589},
-  {"rv64ua-v-amoxor_w.bin", 10591},
-  {"rv64ua-v-lrsc.bin", 16763},
-  {"rv64ui-p-add.bin", 509},
-  {"rv64ui-p-addi.bin", 284},
-  {"rv64ui-p-addiw.bin", 281},
-  {"rv64ui-p-addw.bin", 504},
-  {"rv64ui-p-and.bin", 584},
-  {"rv64ui-p-andi.bin", 255},
-  {"rv64ui-p-auipc.bin", 98},
-  {"rv64ui-p-beq.bin", 330},
-  {"rv64ui-p-bge.bin", 348},
-  {"rv64ui-p-bgeu.bin", 438},
-  {"rv64ui-p-blt.bin", 330},
-  {"rv64ui-p-bltu.bin", 416},
-  {"rv64ui-p-bne.bin", 330},
-  {"rv64ui-p-fence_i.bin", 340},
-  {"rv64ui-p-jal.bin", 94},
-  {"rv64ui-p-jalr.bin", 154},
-  {"rv64ui-p-lb.bin", 292},
-  {"rv64ui-p-lbu.bin", 292},
-  {"rv64ui-p-ld.bin", 474},
-  {"rv64ui-p-lh.bin", 308},
-  {"rv64ui-p-lhu.bin", 317},
-  {"rv64ui-p-lui.bin", 104},
-  {"rv64ui-p-lw.bin", 322},
-  {"rv64ui-p-lwu.bin", 356},
-  {"rv64ui-p-or.bin", 617},
-  {"rv64ui-p-ori.bin", 248},
-  {"rv64ui-p-sb.bin", 493},
-  {"rv64ui-p-sh.bin", 546},
-  {"rv64ui-p-sw.bin", 553},
-  {"rv64ui-p-sd.bin", 665},
-  {"rv64ui-p-simple.bin", 80},
-  {"rv64ui-p-sll.bin", 579},
-  {"rv64ui-p-slli.bin", 309},
-  {"rv64ui-p-slliw.bin", 316},
-  {"rv64ui-p-sllw.bin", 579},
-  {"rv64ui-p-slt.bin", 498},
-  {"rv64ui-p-slti.bin", 276},
-  {"rv64ui-p-sltiu.bin", 276},
-  {"rv64ui-p-sltu.bin", 515},
-  {"rv64ui-p-sra.bin", 551},
-  {"rv64ui-p-srai.bin", 297},
-  {"rv64ui-p-sraiw.bin", 343},
-  {"rv64ui-p-sraw.bin", 591},
-  {"rv64ui-p-srl.bin", 593},
-  {"rv64ui-p-srli.bin", 318},
-  {"rv64ui-p-srliw.bin", 325},
-  {"rv64ui-p-srlw.bin", 585},
-  {"rv64ui-p-sub.bin", 500},
-  {"rv64ui-p-subw.bin", 496},
-  {"rv64ui-p-xor.bin", 612},
-  {"rv64ui-p-xori.bin", 246},
-  {"rv64ui-v-add.bin", 6777},
-  {"rv64ui-v-addi.bin", 6552},
-  {"rv64ui-v-addiw.bin", 6549},
-  {"rv64ui-v-addw.bin", 6772},
-  {"rv64ui-v-and.bin", 6852},
-  {"rv64ui-v-andi.bin", 6523},
-  {"rv64ui-v-auipc.bin", 6365},
-  {"rv64ui-v-beq.bin", 6598},
-  {"rv64ui-v-bge.bin", 6616},
-  {"rv64ui-v-bgeu.bin", 6706},
-  {"rv64ui-v-blt.bin", 6598},
-  {"rv64ui-v-bltu.bin", 6684},
-  {"rv64ui-v-bne.bin", 6598},
-  {"rv64ui-v-fence_i.bin", 10854},
-  {"rv64ui-v-jal.bin", 6362},
-  {"rv64ui-v-jalr.bin", 6422},
-  {"rv64ui-v-lb.bin", 11263},
-  {"rv64ui-v-lbu.bin", 11263},
-  {"rv64ui-v-ld.bin", 11445},
-  {"rv64ui-v-lh.bin", 11279},
-  {"rv64ui-v-lhu.bin", 11288},
-  {"rv64ui-v-lui.bin", 6372},
-  {"rv64ui-v-lw.bin", 11293},
-  {"rv64ui-v-lwu.bin", 11327},
-  {"rv64ui-v-or.bin", 6885},
-  {"rv64ui-v-ori.bin", 6516},
-  {"rv64ui-v-sb.bin", 10976},
-  {"rv64ui-v-sd.bin", 15851},
-  {"rv64ui-v-sh.bin", 11029},
-  {"rv64ui-v-simple.bin", 6348},
-  {"rv64ui-v-sll.bin", 6847},
-  {"rv64ui-v-slli.bin", 6577},
-  {"rv64ui-v-slliw.bin", 6584},
-  {"rv64ui-v-sllw.bin", 6847},
-  {"rv64ui-v-slt.bin", 6766},
-  {"rv64ui-v-slti.bin", 6544},
-  {"rv64ui-v-sltiu.bin", 6544},
-  {"rv64ui-v-sltu.bin", 6783},
-  {"rv64ui-v-sra.bin", 6819},
-  {"rv64ui-v-srai.bin", 6565},
-  {"rv64ui-v-sraiw.bin", 6611},
-  {"rv64ui-v-sraw.bin", 11562},
-  {"rv64ui-v-srl.bin", 6861},
-  {"rv64ui-v-srli.bin", 6586},
-  {"rv64ui-v-srliw.bin", 6593},
-  {"rv64ui-v-srlw.bin", 6853},
-  {"rv64ui-v-sub.bin", 6768},
-  {"rv64ui-v-subw.bin", 6764},
-  {"rv64ui-v-sw.bin", 11036},
-  {"rv64ui-v-xor.bin", 6880},
-  {"rv64ui-v-xori.bin", 6514},
-  {"rv64um-p-div.bin", 140},
-  {"rv64um-p-divu.bin", 146},
-  {"rv64um-p-divuw.bin", 138},
-  {"rv64um-p-divw.bin", 135},
-  {"rv64um-p-mul.bin", 499},
-  {"rv64um-p-mulh.bin", 507},
-  {"rv64um-p-mulhsu.bin", 507},
-  {"rv64um-p-mulhu.bin", 539},
-  {"rv64um-p-mulw.bin", 438},
-  {"rv64um-p-rem.bin", 139},
-  {"rv64um-p-remu.bin", 140},
-  {"rv64um-p-remuw.bin", 135},
-  {"rv64um-p-remw.bin", 141},
-  {"rv64um-v-div.bin", 6408},
-  {"rv64um-v-divu.bin", 6414},
-  {"rv64um-v-divuw.bin", 6406},
-  {"rv64um-v-divw.bin", 6403},
-  {"rv64um-v-mul.bin", 6767},
-  {"rv64um-v-mulh.bin", 6775},
-  {"rv64um-v-mulhsu.bin", 6775},
-  {"rv64um-v-mulhu.bin", 6807},
-  {"rv64um-v-mulw.bin", 6706},
-  {"rv64um-v-rem.bin", 6407},
-  {"rv64um-v-remu.bin", 6408},
-  {"rv64um-v-remuw.bin", 6403},
-  {"rv64um-v-remw.bin", 6409},
--- C extension tests
-  {"rv64uc-p-rvc.bin", 299},
-  {"rv64uc-v-rvc.bin", 15501},
--- float tests
-  {"rv64uf-p-fadd.bin", 214},
-  {"rv64uf-p-fclass.bin", 151},
-  {"rv64uf-p-fcmp.bin", 264},
-  {"rv64uf-p-fcvt.bin", 156},
-  {"rv64uf-p-fcvt_w.bin", 554},
-  {"rv64uf-p-fdiv.bin", 175},
-  {"rv64uf-p-fmadd.bin", 240},
-  {"rv64uf-p-fmin.bin", 318},
-  {"rv64uf-p-ldst.bin", 110},
-  {"rv64uf-p-move.bin", 259},
-  {"rv64uf-p-recoding.bin", 117},
-  {"rv64uf-v-fadd.bin", 11183},
-  {"rv64uf-v-fclass.bin", 6417},
-  {"rv64uf-v-fcmp.bin", 11233},
-  {"rv64uf-v-fcvt.bin", 11125},
-  {"rv64uf-v-fcvt_w.bin", 16226},
-  {"rv64uf-v-fdiv.bin", 11144},
-  {"rv64uf-v-fmadd.bin", 11209},
-  {"rv64uf-v-fmin.bin", 11287},
-  {"rv64uf-v-ldst.bin", 10625},
-  {"rv64uf-v-move.bin", 6525},
-  {"rv64uf-v-recoding.bin", 11086},
-  {"rv64ud-p-fadd.bin", 214},
-  {"rv64ud-p-fclass.bin", 157},
-  {"rv64ud-p-fcmp.bin", 264},
-  {"rv64ud-p-fcvt.bin", 196},
-  {"rv64ud-p-fcvt_w.bin", 614},
-  {"rv64ud-p-fdiv.bin", 188},
-  {"rv64ud-p-fmadd.bin", 240},
-  {"rv64ud-p-fmin.bin", 318},
-  {"rv64ud-p-ldst.bin", 129},
-  {"rv64ud-p-move.bin", 1034},
-  {"rv64ud-p-recoding.bin", 142},
-  {"rv64ud-p-structural.bin", 207},
-  {"rv64ud-v-fadd.bin", 11183},
-  {"rv64ud-v-fclass.bin", 6423},
-  {"rv64ud-v-fcmp.bin", 11233},
-  {"rv64ud-v-fcvt.bin", 11165},
-  {"rv64ud-v-fcvt_w.bin", 16286},
-  {"rv64ud-v-fdiv.bin", 11157},
-  {"rv64ud-v-fmadd.bin", 11209},
-  {"rv64ud-v-fmin.bin", 11287},
-  {"rv64ud-v-ldst.bin", 10620},
-  {"rv64ud-v-move.bin", 12003},
-  {"rv64ud-v-recoding.bin", 10663},
-  {"rv64ud-v-structural.bin", 6473},
-  {"fclass.bin", 457},
-  {"fcvt.bin", 17614},
-  {"fcmp.bin", 46787},
-  {"funary.bin", 2834},
-  {"fbinary_s.bin", 204284},
-  {"fbinary_d.bin", 204284},
-  {"fternary_s.bin", 216784},
-  {"fternary_d.bin", 216784},
--- cartesi tests
-  {"ebreak.bin", 21},
-  {"pte_reserved_exception.bin", 34},
-  {"sd_pma_overflow.bin", 16},
-  {"xpie_exceptions.bin", 51},
-  {"dont_write_x0.bin", 68},
-  {"mcycle_write.bin", 18},
-  {"lrsc_semantics.bin", 35},
-  {"csr_counters.bin", 741},
-  {"csr_semantics.bin", 382},
-  {"amo.bin", 166},
-  {"access.bin", 101},
-  {"interrupts.bin", 8209},
-  {"mtime_interrupt.bin", 16404},
-  {"illegal_insn.bin", 976},
-  {"version_check.bin", 30},
-  {"translate_vaddr.bin", 347},
-  {"htif_invalid_ops.bin", 113},
-  {"clint_ops.bin", 137},
-  {"shadow_ops.bin", 118},
-  {"compressed.bin", 414},
+    { "rv64mi-p-access.bin", 144 },
+    { "rv64mi-p-breakpoint.bin", 115 },
+    { "rv64mi-p-csr.bin", 297 },
+    { "rv64mi-p-illegal.bin", 361 },
+    { "rv64mi-p-ld-misaligned.bin", 369 },
+    { "rv64mi-p-lh-misaligned.bin", 121 },
+    { "rv64mi-p-lw-misaligned.bin", 181 },
+    { "rv64mi-p-ma_addr.bin", 742 },
+    { "rv64mi-p-ma_fetch.bin", 138 },
+    { "rv64mi-p-mcsr.bin", 103 },
+    { "rv64mi-p-sbreak.bin", 111 },
+    { "rv64mi-p-scall.bin", 95 },
+    { "rv64mi-p-sd-misaligned.bin", 389 },
+    { "rv64mi-p-sh-misaligned.bin", 129 },
+    { "rv64mi-p-sw-misaligned.bin", 185 },
+    { "rv64si-p-csr.bin", 196 },
+    { "rv64si-p-dirty.bin", 177 },
+    { "rv64si-p-icache-alias.bin", 227 },
+    { "rv64si-p-ma_fetch.bin", 125 },
+    { "rv64si-p-sbreak.bin", 105 },
+    { "rv64si-p-scall.bin", 112 },
+    { "rv64si-p-wfi.bin", 91 },
+    { "rv64ua-p-amoadd_d.bin", 108 },
+    { "rv64ua-p-amoadd_w.bin", 105 },
+    { "rv64ua-p-amoand_d.bin", 105 },
+    { "rv64ua-p-amoand_w.bin", 104 },
+    { "rv64ua-p-amomax_d.bin", 104 },
+    { "rv64ua-p-amomax_w.bin", 104 },
+    { "rv64ua-p-amomaxu_d.bin", 104 },
+    { "rv64ua-p-amomaxu_w.bin", 104 },
+    { "rv64ua-p-amomin_d.bin", 104 },
+    { "rv64ua-p-amomin_w.bin", 104 },
+    { "rv64ua-p-amominu_d.bin", 104 },
+    { "rv64ua-p-amominu_w.bin", 104 },
+    { "rv64ua-p-amoor_d.bin", 103 },
+    { "rv64ua-p-amoor_w.bin", 103 },
+    { "rv64ua-p-amoswap_d.bin", 105 },
+    { "rv64ua-p-amoswap_w.bin", 104 },
+    { "rv64ua-p-amoxor_d.bin", 106 },
+    { "rv64ua-p-amoxor_w.bin", 108 },
+    { "rv64ua-p-lrsc.bin", 6280 },
+    { "rv64ua-v-amoadd_d.bin", 10597 },
+    { "rv64ua-v-amoadd_w.bin", 10594 },
+    { "rv64ua-v-amoand_d.bin", 10606 },
+    { "rv64ua-v-amoand_w.bin", 10605 },
+    { "rv64ua-v-amomax_d.bin", 10587 },
+    { "rv64ua-v-amomax_w.bin", 10587 },
+    { "rv64ua-v-amomaxu_d.bin", 10587 },
+    { "rv64ua-v-amomaxu_w.bin", 10587 },
+    { "rv64ua-v-amomin_d.bin", 10587 },
+    { "rv64ua-v-amomin_w.bin", 10587 },
+    { "rv64ua-v-amominu_d.bin", 10593 },
+    { "rv64ua-v-amominu_w.bin", 10593 },
+    { "rv64ua-v-amoor_d.bin", 10586 },
+    { "rv64ua-v-amoor_w.bin", 10586 },
+    { "rv64ua-v-amoswap_d.bin", 10606 },
+    { "rv64ua-v-amoswap_w.bin", 10605 },
+    { "rv64ua-v-amoxor_d.bin", 10589 },
+    { "rv64ua-v-amoxor_w.bin", 10591 },
+    { "rv64ua-v-lrsc.bin", 16763 },
+    { "rv64ui-p-add.bin", 509 },
+    { "rv64ui-p-addi.bin", 284 },
+    { "rv64ui-p-addiw.bin", 281 },
+    { "rv64ui-p-addw.bin", 504 },
+    { "rv64ui-p-and.bin", 584 },
+    { "rv64ui-p-andi.bin", 255 },
+    { "rv64ui-p-auipc.bin", 98 },
+    { "rv64ui-p-beq.bin", 330 },
+    { "rv64ui-p-bge.bin", 348 },
+    { "rv64ui-p-bgeu.bin", 438 },
+    { "rv64ui-p-blt.bin", 330 },
+    { "rv64ui-p-bltu.bin", 416 },
+    { "rv64ui-p-bne.bin", 330 },
+    { "rv64ui-p-fence_i.bin", 340 },
+    { "rv64ui-p-jal.bin", 94 },
+    { "rv64ui-p-jalr.bin", 154 },
+    { "rv64ui-p-lb.bin", 292 },
+    { "rv64ui-p-lbu.bin", 292 },
+    { "rv64ui-p-ld.bin", 474 },
+    { "rv64ui-p-lh.bin", 308 },
+    { "rv64ui-p-lhu.bin", 317 },
+    { "rv64ui-p-lui.bin", 104 },
+    { "rv64ui-p-lw.bin", 322 },
+    { "rv64ui-p-lwu.bin", 356 },
+    { "rv64ui-p-or.bin", 617 },
+    { "rv64ui-p-ori.bin", 248 },
+    { "rv64ui-p-sb.bin", 493 },
+    { "rv64ui-p-sh.bin", 546 },
+    { "rv64ui-p-sw.bin", 553 },
+    { "rv64ui-p-sd.bin", 665 },
+    { "rv64ui-p-simple.bin", 80 },
+    { "rv64ui-p-sll.bin", 579 },
+    { "rv64ui-p-slli.bin", 309 },
+    { "rv64ui-p-slliw.bin", 316 },
+    { "rv64ui-p-sllw.bin", 579 },
+    { "rv64ui-p-slt.bin", 498 },
+    { "rv64ui-p-slti.bin", 276 },
+    { "rv64ui-p-sltiu.bin", 276 },
+    { "rv64ui-p-sltu.bin", 515 },
+    { "rv64ui-p-sra.bin", 551 },
+    { "rv64ui-p-srai.bin", 297 },
+    { "rv64ui-p-sraiw.bin", 343 },
+    { "rv64ui-p-sraw.bin", 591 },
+    { "rv64ui-p-srl.bin", 593 },
+    { "rv64ui-p-srli.bin", 318 },
+    { "rv64ui-p-srliw.bin", 325 },
+    { "rv64ui-p-srlw.bin", 585 },
+    { "rv64ui-p-sub.bin", 500 },
+    { "rv64ui-p-subw.bin", 496 },
+    { "rv64ui-p-xor.bin", 612 },
+    { "rv64ui-p-xori.bin", 246 },
+    { "rv64ui-v-add.bin", 6777 },
+    { "rv64ui-v-addi.bin", 6552 },
+    { "rv64ui-v-addiw.bin", 6549 },
+    { "rv64ui-v-addw.bin", 6772 },
+    { "rv64ui-v-and.bin", 6852 },
+    { "rv64ui-v-andi.bin", 6523 },
+    { "rv64ui-v-auipc.bin", 6365 },
+    { "rv64ui-v-beq.bin", 6598 },
+    { "rv64ui-v-bge.bin", 6616 },
+    { "rv64ui-v-bgeu.bin", 6706 },
+    { "rv64ui-v-blt.bin", 6598 },
+    { "rv64ui-v-bltu.bin", 6684 },
+    { "rv64ui-v-bne.bin", 6598 },
+    { "rv64ui-v-fence_i.bin", 10854 },
+    { "rv64ui-v-jal.bin", 6362 },
+    { "rv64ui-v-jalr.bin", 6422 },
+    { "rv64ui-v-lb.bin", 11263 },
+    { "rv64ui-v-lbu.bin", 11263 },
+    { "rv64ui-v-ld.bin", 11445 },
+    { "rv64ui-v-lh.bin", 11279 },
+    { "rv64ui-v-lhu.bin", 11288 },
+    { "rv64ui-v-lui.bin", 6372 },
+    { "rv64ui-v-lw.bin", 11293 },
+    { "rv64ui-v-lwu.bin", 11327 },
+    { "rv64ui-v-or.bin", 6885 },
+    { "rv64ui-v-ori.bin", 6516 },
+    { "rv64ui-v-sb.bin", 10976 },
+    { "rv64ui-v-sd.bin", 15851 },
+    { "rv64ui-v-sh.bin", 11029 },
+    { "rv64ui-v-simple.bin", 6348 },
+    { "rv64ui-v-sll.bin", 6847 },
+    { "rv64ui-v-slli.bin", 6577 },
+    { "rv64ui-v-slliw.bin", 6584 },
+    { "rv64ui-v-sllw.bin", 6847 },
+    { "rv64ui-v-slt.bin", 6766 },
+    { "rv64ui-v-slti.bin", 6544 },
+    { "rv64ui-v-sltiu.bin", 6544 },
+    { "rv64ui-v-sltu.bin", 6783 },
+    { "rv64ui-v-sra.bin", 6819 },
+    { "rv64ui-v-srai.bin", 6565 },
+    { "rv64ui-v-sraiw.bin", 6611 },
+    { "rv64ui-v-sraw.bin", 11562 },
+    { "rv64ui-v-srl.bin", 6861 },
+    { "rv64ui-v-srli.bin", 6586 },
+    { "rv64ui-v-srliw.bin", 6593 },
+    { "rv64ui-v-srlw.bin", 6853 },
+    { "rv64ui-v-sub.bin", 6768 },
+    { "rv64ui-v-subw.bin", 6764 },
+    { "rv64ui-v-sw.bin", 11036 },
+    { "rv64ui-v-xor.bin", 6880 },
+    { "rv64ui-v-xori.bin", 6514 },
+    { "rv64um-p-div.bin", 140 },
+    { "rv64um-p-divu.bin", 146 },
+    { "rv64um-p-divuw.bin", 138 },
+    { "rv64um-p-divw.bin", 135 },
+    { "rv64um-p-mul.bin", 499 },
+    { "rv64um-p-mulh.bin", 507 },
+    { "rv64um-p-mulhsu.bin", 507 },
+    { "rv64um-p-mulhu.bin", 539 },
+    { "rv64um-p-mulw.bin", 438 },
+    { "rv64um-p-rem.bin", 139 },
+    { "rv64um-p-remu.bin", 140 },
+    { "rv64um-p-remuw.bin", 135 },
+    { "rv64um-p-remw.bin", 141 },
+    { "rv64um-v-div.bin", 6408 },
+    { "rv64um-v-divu.bin", 6414 },
+    { "rv64um-v-divuw.bin", 6406 },
+    { "rv64um-v-divw.bin", 6403 },
+    { "rv64um-v-mul.bin", 6767 },
+    { "rv64um-v-mulh.bin", 6775 },
+    { "rv64um-v-mulhsu.bin", 6775 },
+    { "rv64um-v-mulhu.bin", 6807 },
+    { "rv64um-v-mulw.bin", 6706 },
+    { "rv64um-v-rem.bin", 6407 },
+    { "rv64um-v-remu.bin", 6408 },
+    { "rv64um-v-remuw.bin", 6403 },
+    { "rv64um-v-remw.bin", 6409 },
+    -- C extension tests
+    { "rv64uc-p-rvc.bin", 299 },
+    { "rv64uc-v-rvc.bin", 15501 },
+    -- float tests
+    { "rv64uf-p-fadd.bin", 214 },
+    { "rv64uf-p-fclass.bin", 151 },
+    { "rv64uf-p-fcmp.bin", 264 },
+    { "rv64uf-p-fcvt.bin", 156 },
+    { "rv64uf-p-fcvt_w.bin", 554 },
+    { "rv64uf-p-fdiv.bin", 175 },
+    { "rv64uf-p-fmadd.bin", 240 },
+    { "rv64uf-p-fmin.bin", 318 },
+    { "rv64uf-p-ldst.bin", 110 },
+    { "rv64uf-p-move.bin", 259 },
+    { "rv64uf-p-recoding.bin", 117 },
+    { "rv64uf-v-fadd.bin", 11183 },
+    { "rv64uf-v-fclass.bin", 6417 },
+    { "rv64uf-v-fcmp.bin", 11233 },
+    { "rv64uf-v-fcvt.bin", 11125 },
+    { "rv64uf-v-fcvt_w.bin", 16226 },
+    { "rv64uf-v-fdiv.bin", 11144 },
+    { "rv64uf-v-fmadd.bin", 11209 },
+    { "rv64uf-v-fmin.bin", 11287 },
+    { "rv64uf-v-ldst.bin", 10625 },
+    { "rv64uf-v-move.bin", 6525 },
+    { "rv64uf-v-recoding.bin", 11086 },
+    { "rv64ud-p-fadd.bin", 214 },
+    { "rv64ud-p-fclass.bin", 157 },
+    { "rv64ud-p-fcmp.bin", 264 },
+    { "rv64ud-p-fcvt.bin", 196 },
+    { "rv64ud-p-fcvt_w.bin", 614 },
+    { "rv64ud-p-fdiv.bin", 188 },
+    { "rv64ud-p-fmadd.bin", 240 },
+    { "rv64ud-p-fmin.bin", 318 },
+    { "rv64ud-p-ldst.bin", 129 },
+    { "rv64ud-p-move.bin", 1034 },
+    { "rv64ud-p-recoding.bin", 142 },
+    { "rv64ud-p-structural.bin", 207 },
+    { "rv64ud-v-fadd.bin", 11183 },
+    { "rv64ud-v-fclass.bin", 6423 },
+    { "rv64ud-v-fcmp.bin", 11233 },
+    { "rv64ud-v-fcvt.bin", 11165 },
+    { "rv64ud-v-fcvt_w.bin", 16286 },
+    { "rv64ud-v-fdiv.bin", 11157 },
+    { "rv64ud-v-fmadd.bin", 11209 },
+    { "rv64ud-v-fmin.bin", 11287 },
+    { "rv64ud-v-ldst.bin", 10620 },
+    { "rv64ud-v-move.bin", 12003 },
+    { "rv64ud-v-recoding.bin", 10663 },
+    { "rv64ud-v-structural.bin", 6473 },
+    { "fclass.bin", 457 },
+    { "fcvt.bin", 17614 },
+    { "fcmp.bin", 46787 },
+    { "funary.bin", 2834 },
+    { "fbinary_s.bin", 204284 },
+    { "fbinary_d.bin", 204284 },
+    { "fternary_s.bin", 216784 },
+    { "fternary_d.bin", 216784 },
+    -- cartesi tests
+    { "ebreak.bin", 21 },
+    { "pte_reserved_exception.bin", 34 },
+    { "sd_pma_overflow.bin", 16 },
+    { "xpie_exceptions.bin", 51 },
+    { "dont_write_x0.bin", 68 },
+    { "mcycle_write.bin", 18 },
+    { "lrsc_semantics.bin", 35 },
+    { "csr_counters.bin", 741 },
+    { "csr_semantics.bin", 382 },
+    { "amo.bin", 166 },
+    { "access.bin", 101 },
+    { "interrupts.bin", 8209 },
+    { "mtime_interrupt.bin", 16404 },
+    { "illegal_insn.bin", 976 },
+    { "version_check.bin", 30 },
+    { "translate_vaddr.bin", 347 },
+    { "htif_invalid_ops.bin", 113 },
+    { "clint_ops.bin", 137 },
+    { "shadow_ops.bin", 118 },
+    { "compressed.bin", 414 },
 }
 
 local log_proofs = false
@@ -297,10 +297,10 @@ local log_annotations = false
 -- Microarchitecture configuration
 local uarch
 
-
 -- Print help and exit
 local function help()
-    io.stderr:write(string.format([=[
+    io.stderr:write(string.format(
+        [=[
 Usage:
 
   %s [options] <command>
@@ -394,7 +394,9 @@ or a left shift (e.g., 2 << 20).
 
 <host> can be a host name, IPv4 or IPv6 address.
 
-]=], arg[0]))
+]=],
+        arg[0]
+    ))
     os.exit()
 end
 
@@ -422,121 +424,164 @@ local cleanup = {}
 --     if callback returns true, the option is accepted.
 --     if callback returns false, the option is rejected.
 local options = {
-    { "^%-%-h$", function(all)
-        if not all then return false end
-        help()
-    end },
-    { "^%-%-help$", function(all)
-        if not all then return false end
-        help()
-    end },
-    { "^%-%-remote%-address%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        remote_address = o
-        return true
-    end },
-    { "^%-%-remote%-protocol%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        remote_protocol = o
-        return true
-    end },
-    { "^%-%-checkin%-address%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        checkin_address = o
-        return true
-    end },
-    { "^%-%-output%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        output = o
-        return true
-    end },
-    { "^%-%-json%-test%-list$", function(all)
-        if not all then return false end
-        json_list = true
-        return true
-    end },
-    { "^%-%-test%-path%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        test_path = o
-        return true
-    end },
-    { "^%-%-test%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        test_pattern = o
-        return true
-    end },
-    { "^%-%-jobs%=([0-9]+)$", function(o)
-        if not o or #o < 1 then return false end
-        jobs = tonumber(o)
-        assert(jobs and jobs >= 1, 'invalid number of jobs')
-        return true
-    end },
-    { "^%-%-log%-proofs$", function(o)
-        if not o then return false end
-        log_proofs = true
-        return true
-    end },
-    { "^%-%-log%-annotations$", function(o)
-        if not o then return false end
-        log_annotations = true
-        return true
-    end },
-    { "^(%-%-periodic%-action%=(.*))$", function(all, v)
-        if not v then return false end
-        string.gsub(v, "^([^%,]+),(.+)$", function(p, s)
-            periodic_action_period = assert(util.parse_number(p), "invalid period " .. all)
-            periodic_action_start = assert(util.parse_number(s), "invalid start " .. all)
-        end)
-        if periodic_action_period == math.maxinteger then
-            periodic_action_period = assert(util.parse_number(v), "invalid period " .. all)
-            periodic_action_start = 0
-        end
-        assert(periodic_action_period > 0, "invalid period " ..
-            periodic_action_period)
-        periodic_action = true
-        return true
-    end },
-    { "^(%-%-concurrency%=(.+))$", function(all, opts)
-        if not opts then return false end
-        local c = util.parse_options(opts, {
-            update_merkle_tree = true
-        })
-        c.update_merkle_tree = assert(util.parse_number(c.update_merkle_tree),
-                "invalid update_merkle_tree number in " .. all)
-        concurrency_update_merkle_tree = c.update_merkle_tree
-        return true
-    end },
-    { "^%-%-uarch%-ram%-image%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        uarch = uarch or {}
-        uarch.ram = uarch.ram or {}
-        uarch.ram.image_filename = o
-        return true
-    end },
-    { "^%-%-uarch%-ram%-length%=(.+)$", function(n)
-        if not n then return false end
-        uarch = uarch or {}
-        uarch.ram = uarch.ram or {}
-        uarch.ram.length = assert(util.parse_number(n), "invalid microarchitecture RAM length " .. n)
-        return true
-    end },
-    { ".*", function(all)
-        error("unrecognized option " .. all)
-    end }
+    {
+        "^%-%-h$",
+        function(all)
+            if not all then return false end
+            help()
+        end,
+    },
+    {
+        "^%-%-help$",
+        function(all)
+            if not all then return false end
+            help()
+        end,
+    },
+    {
+        "^%-%-remote%-address%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            remote_address = o
+            return true
+        end,
+    },
+    {
+        "^%-%-remote%-protocol%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            remote_protocol = o
+            return true
+        end,
+    },
+    {
+        "^%-%-checkin%-address%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            checkin_address = o
+            return true
+        end,
+    },
+    {
+        "^%-%-output%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            output = o
+            return true
+        end,
+    },
+    {
+        "^%-%-json%-test%-list$",
+        function(all)
+            if not all then return false end
+            json_list = true
+            return true
+        end,
+    },
+    {
+        "^%-%-test%-path%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            test_path = o
+            return true
+        end,
+    },
+    {
+        "^%-%-test%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            test_pattern = o
+            return true
+        end,
+    },
+    {
+        "^%-%-jobs%=([0-9]+)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            jobs = tonumber(o)
+            assert(jobs and jobs >= 1, "invalid number of jobs")
+            return true
+        end,
+    },
+    {
+        "^%-%-log%-proofs$",
+        function(o)
+            if not o then return false end
+            log_proofs = true
+            return true
+        end,
+    },
+    {
+        "^%-%-log%-annotations$",
+        function(o)
+            if not o then return false end
+            log_annotations = true
+            return true
+        end,
+    },
+    {
+        "^(%-%-periodic%-action%=(.*))$",
+        function(all, v)
+            if not v then return false end
+            string.gsub(v, "^([^%,]+),(.+)$", function(p, s)
+                periodic_action_period = assert(util.parse_number(p), "invalid period " .. all)
+                periodic_action_start = assert(util.parse_number(s), "invalid start " .. all)
+            end)
+            if periodic_action_period == math.maxinteger then
+                periodic_action_period = assert(util.parse_number(v), "invalid period " .. all)
+                periodic_action_start = 0
+            end
+            assert(periodic_action_period > 0, "invalid period " .. periodic_action_period)
+            periodic_action = true
+            return true
+        end,
+    },
+    {
+        "^(%-%-concurrency%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            local c = util.parse_options(opts, {
+                update_merkle_tree = true,
+            })
+            c.update_merkle_tree =
+                assert(util.parse_number(c.update_merkle_tree), "invalid update_merkle_tree number in " .. all)
+            concurrency_update_merkle_tree = c.update_merkle_tree
+            return true
+        end,
+    },
+    {
+        "^%-%-uarch%-ram%-image%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            uarch = uarch or {}
+            uarch.ram = uarch.ram or {}
+            uarch.ram.image_filename = o
+            return true
+        end,
+    },
+    {
+        "^%-%-uarch%-ram%-length%=(.+)$",
+        function(n)
+            if not n then return false end
+            uarch = uarch or {}
+            uarch.ram = uarch.ram or {}
+            uarch.ram.length = assert(util.parse_number(n), "invalid microarchitecture RAM length " .. n)
+            return true
+        end,
+    },
+    { ".*", function(all) error("unrecognized option " .. all) end },
 }
 
 local values = {}
 
 -- Process command line options
-for _, argument in ipairs({...}) do
-    if argument:sub(1,1) == "-" then
+for _, argument in ipairs({ ... }) do
+    if argument:sub(1, 1) == "-" then
         for _, option in ipairs(options) do
-            if option[2](argument:match(option[1])) then
-                break
-            end
+            if option[2](argument:match(option[1])) then break end
         end
     else
-        values[#values+1] = argument
+        values[#values + 1] = argument
     end
 end
 
@@ -545,14 +590,10 @@ assert(test_path, "missing test path")
 
 if remote_address then
     protocol = require("cartesi." .. remote_protocol)
-    if remote_protocol == "grpc" then
-        assert(checkin_address, "checkin address missing")
-    end
+    if remote_protocol == "grpc" then assert(checkin_address, "checkin address missing") end
 end
 
-local function advance_machine(machine, max_mcycle)
-    return machine:run(max_mcycle)
-end
+local function advance_machine(machine, max_mcycle) return machine:run(max_mcycle) end
 
 local function run_machine(machine, ctx, max_mcycle, advance_machine_fn)
     advance_machine_fn = advance_machine_fn or advance_machine
@@ -567,9 +608,7 @@ local function run_machine(machine, ctx, max_mcycle, advance_machine_fn)
 end
 
 local function advance_machine_with_uarch(machine)
-    if machine:run_uarch() == cartesi.UARCH_BREAK_REASON_UARCH_HALTED then
-        machine:reset_uarch_state()
-    end
+    if machine:run_uarch() == cartesi.UARCH_BREAK_REASON_UARCH_HALTED then machine:reset_uarch_state() end
 end
 
 local function run_machine_with_uarch(machine, ctx, max_mcycle)
@@ -578,10 +617,10 @@ end
 
 local function connect()
     local remote_stub = protocol.stub(remote_address, checkin_address)
-    local version = assert(remote_stub.get_version(),
-        "could not connect to remote cartesi machine at " .. remote_address)
+    local version =
+        assert(remote_stub.get_version(), "could not connect to remote cartesi machine at " .. remote_address)
     local shutdown = function() remote_stub.shutdown() end
-    local mt = { __gc = function() pcall(shutdown) end}
+    local mt = { __gc = function() pcall(shutdown) end }
     setmetatable(cleanup, mt)
     return remote_stub, version
 end
@@ -592,49 +631,44 @@ local function build_machine(test_name)
             -- Request automatic default values for versioning CSRs
             mimpid = -1,
             marchid = -1,
-            mvendorid = -1
+            mvendorid = -1,
         },
         rom = {
-            image_filename = test_path .. "/bootstrap.bin"
+            image_filename = test_path .. "/bootstrap.bin",
         },
         ram = {
             length = 32 << 20,
-            image_filename = test_path .. "/" .. test_name
+            image_filename = test_path .. "/" .. test_name,
         },
         htif = {
             console_getchar = false,
             yield_progress = false,
-            yield_rollup = false
+            yield_rollup = false,
         },
-        flash_drive = {{
-          start = 0x80000000000000,
-          length = 0x40000,
-        }}
+        flash_drive = { {
+            start = 0x80000000000000,
+            length = 0x40000,
+        } },
     }
-    if uarch then
-        config.uarch = uarch
-    end
+    if uarch then config.uarch = uarch end
     local runtime = {
         concurrency = {
-            update_merkle_tree = concurrency_update_merkle_tree
-        }
+            update_merkle_tree = concurrency_update_merkle_tree,
+        },
     }
     if remote_address then
-      if not remote then
-        remote = connect()
-      end
-      return assert(remote.machine(config, runtime))
+        if not remote then remote = connect() end
+        return assert(remote.machine(config, runtime))
     end
     return assert(cartesi.machine(config, runtime))
 end
 
-local function destroy_machine(machine)
-    machine:destroy()
-end
+local function destroy_machine(machine) machine:destroy() end
 
 local function print_machine(test_name, expected_cycles)
     if not uarch then
-        print(string.format("./cartesi-machine.lua \
+        print(string.format(
+            "./cartesi-machine.lua \
  --ram-length=32Mi\
  --rom-image='%s'\
  --ram-image='%s'\
@@ -642,10 +676,12 @@ local function print_machine(test_name, expected_cycles)
  --max-mcycle=%d ",
             test_path .. "/bootstrap.bin",
             test_path .. "/" .. test_name,
-            2*expected_cycles
+            2 * expected_cycles
         ))
     else
-        print(string.format("./cartesi-machine.lua \
+        print(
+            string.format(
+                "./cartesi-machine.lua \
  --ram-length=32Mi\
  --rom-image='%s'\
  --ram-image='%s'\
@@ -653,16 +689,17 @@ local function print_machine(test_name, expected_cycles)
  --uarch-ram-length=%d\
  --uarch-ram-image=%s\
  --max-mcycle=%d ",
-            test_path .. "/bootstrap.bin",
-            test_path .. "/" .. test_name,
-            uarch.ram.length,
-            uarch.ram.image_filename,
-            2*expected_cycles
-        ))
+                test_path .. "/bootstrap.bin",
+                test_path .. "/" .. test_name,
+                uarch.ram.length,
+                uarch.ram.image_filename,
+                2 * expected_cycles
+            )
+        )
     end
 end
 
-local function add_error(ctx,  msg, ...)
+local function add_error(ctx, msg, ...)
     local e = string.format(msg, ...)
     ctx.failed = true
     ctx.errors[#ctx.errors + 1] = e
@@ -671,20 +708,22 @@ end
 local function check_test_result(ctx)
     io.write(ctx.ram_image, ": ")
     if #ctx.expected_yield_payloads ~= (ctx.yield_payload_index - 1) then
-        add_error(ctx, "yielded %d times, expected %d",
-          ctx.yield_payload_index-1, #ctx.expected_yield_payloads)
+        add_error(ctx, "yielded %d times, expected %d", ctx.yield_payload_index - 1, #ctx.expected_yield_payloads)
     end
     if ctx.read_htif_tohost_data >> 1 ~= ctx.expected_halt_payload then
-        add_error(ctx, "returned halt payload %d, expected %d",
-          ctx.read_htif_tohost_data >> 1, ctx.expected_halt_payload)
+        add_error(
+            ctx,
+            "returned halt payload %d, expected %d",
+            ctx.read_htif_tohost_data >> 1,
+            ctx.expected_halt_payload
+        )
     end
     if ctx.cycles ~= ctx.expected_cycles then
-        add_error(ctx, "terminated with mcycle = %d, expected %d",
-          ctx.cycles, ctx.expected_cycles)
+        add_error(ctx, "terminated with mcycle = %d, expected %d", ctx.cycles, ctx.expected_cycles)
     end
     if ctx.failed then
         print("failed")
-        for _,e in pairs(ctx.errors) do
+        for _, e in pairs(ctx.errors) do
             print(string.format("%s: %s", ctx.ram_image, e))
         end
     else
@@ -693,13 +732,13 @@ local function check_test_result(ctx)
 end
 
 local function run_parallel(contexts)
-    local unistd = require 'posix.unistd'
-    local syswait = require 'posix.sys.wait'
+    local unistd = require("posix.unistd")
+    local syswait = require("posix.sys.wait")
     local pids = {}
     local running_jobs = 0
     -- sort to run slower tests first to maximize utilization of CPU cores
     table.sort(contexts, function(a, b) return b.expected_cycles < a.expected_cycles end)
-    for _,ctx in ipairs(contexts) do
+    for _, ctx in ipairs(contexts) do
         do -- run test in parallel
             local pid = assert(unistd.fork())
             if pid == 0 then -- child
@@ -716,10 +755,8 @@ local function run_parallel(contexts)
         while running_jobs >= jobs do
             -- wait a child to finish
             local pid, reason, exitcode = syswait.wait(-1)
-            if pid and pid > 0 and reason ~= 'running' then
-                if not (reason == 'exited' and exitcode == 0) then
-                    add_error("unexpected child process exit")
-                end
+            if pid and pid > 0 and reason ~= "running" then
+                if not (reason == "exited" and exitcode == 0) then add_error("unexpected child process exit") end
                 pids[pid] = nil
                 running_jobs = running_jobs - 1
                 break
@@ -729,7 +766,7 @@ local function run_parallel(contexts)
     -- wait all children
     for pid in pairs(pids) do
         local retpid, reason, exitcode = syswait.wait(pid)
-        if not (retpid == pid and reason == 'exited' and exitcode == 0) then
+        if not (retpid == pid and reason == "exited" and exitcode == 0) then
             add_error("unexpected child process exit")
         end
         pids[pid] = nil
@@ -760,8 +797,7 @@ local function run_tests(tests, target)
             yield_payload_index = 1,
             failed = false,
             cycles = 0,
-            errors = {}
-
+            errors = {},
         }
     end
     -- run
@@ -773,9 +809,7 @@ local function run_tests(tests, target)
     -- collect results
     local error_count = 0
     for _, ctx in pairs(contexts) do
-        if ctx.failed then
-            error_count = error_count + 1
-        end
+        if ctx.failed then error_count = error_count + 1 end
     end
     -- print summary
     if error_count > 0 then
@@ -804,13 +838,16 @@ local function hash(tests)
                 next_action_cycle = periodic_action_start
                 if next_action_cycle <= total_cycles then
                     next_action_cycle = next_action_cycle
-                      + ((((total_cycles-periodic_action_start)//periodic_action_period)+1) * periodic_action_period)
+                        + (
+                            (((total_cycles - periodic_action_start) // periodic_action_period) + 1)
+                            * periodic_action_period
+                        )
                 end
             end
             local status = machine:run_uarch(initial_cycle + (next_action_cycle - total_cycles))
             local final_cycle = machine:read_uarch_cycle()
             total_cycles = total_cycles + (final_cycle - initial_cycle)
-            if not periodic_action or total_cycles ==  next_action_cycle then
+            if not periodic_action or total_cycles == next_action_cycle then
                 out:write(machine:read_mcycle(), " ", final_cycle, " ", util.hexhash(machine:get_root_hash()), "\n")
                 total_cycles = total_cycles + 1
             end
@@ -822,9 +859,14 @@ local function hash(tests)
         if machine:read_htif_tohost_data() >> 1 ~= expected_payload or machine:read_mcycle() ~= expected_cycles then
             os.exit(1, true)
         end
-        out:write(machine:read_mcycle(), " ",
-                  machine:read_uarch_cycle(), " ",
-                  util.hexhash(machine:get_root_hash()), "\n")
+        out:write(
+            machine:read_mcycle(),
+            " ",
+            machine:read_uarch_cycle(),
+            " ",
+            util.hexhash(machine:get_root_hash()),
+            "\n"
+        )
         machine:destroy()
     end
 end
@@ -860,31 +902,33 @@ local function step(tests)
         local max_mcycle = 2 * expected_cycles
         while math.ult(machine:read_mcycle(), max_mcycle) do
             local uarch_cycle_increment = 0
-            local next_action_uarch_cycle;
+            local next_action_uarch_cycle
             if periodic_action then
                 next_action_uarch_cycle = periodic_action_start
                 if next_action_uarch_cycle <= total_uarch_cycles then
                     next_action_uarch_cycle = next_action_uarch_cycle
-                      + ((((total_uarch_cycles-periodic_action_start)//periodic_action_period)+1)
-                          * periodic_action_period)
+                        + (
+                            (((total_uarch_cycles - periodic_action_start) // periodic_action_period) + 1)
+                            * periodic_action_period
+                        )
                 end
                 uarch_cycle_increment = next_action_uarch_cycle - total_uarch_cycles
             end
-             local init_uarch_cycle = machine:read_uarch_cycle()
+            local init_uarch_cycle = machine:read_uarch_cycle()
             machine:run_uarch(machine:read_uarch_cycle() + uarch_cycle_increment)
-             local final_uarch_cycle = machine:read_uarch_cycle()
+            local final_uarch_cycle = machine:read_uarch_cycle()
             total_uarch_cycles = total_uarch_cycles + (final_uarch_cycle - init_uarch_cycle)
             if machine:read_uarch_halt_flag() then
                 machine:reset_uarch_state()
                 if machine:read_iflags_H() then break end
             end
-            if not periodic_action or total_uarch_cycles ==  next_action_uarch_cycle then
+            if not periodic_action or total_uarch_cycles == next_action_uarch_cycle then
                 local init_mcycle = machine:read_mcycle()
                 init_uarch_cycle = machine:read_uarch_cycle()
                 local log = machine:step_uarch(log_type)
                 local final_mcycle = machine:read_mcycle()
                 final_uarch_cycle = machine:read_uarch_cycle()
-                if total_logged_steps > 0 then out:write(',\n') end
+                if total_logged_steps > 0 then out:write(",\n") end
                 util.dump_json_log(log, init_mcycle, init_uarch_cycle, final_mcycle, final_uarch_cycle, out, 3)
                 total_uarch_cycles = total_uarch_cycles + 1
                 total_logged_steps = total_logged_steps + 1
@@ -895,8 +939,11 @@ local function step(tests)
             end
         end
         indentout(out, 2, "]\n")
-        if tests[i+1] then indentout(out, 1, "},\n")
-        else indentout(out, 1, "}\n") end
+        if tests[i + 1] then
+            indentout(out, 1, "},\n")
+        else
+            indentout(out, 1, "}\n")
+        end
         if machine:read_htif_tohost_data() >> 1 ~= expected_payload or machine:read_mcycle() ~= expected_cycles then
             os.exit(1, true)
         end
@@ -917,12 +964,12 @@ local function list(tests)
     if json_list then
         local out = io.stdout
         local indentout = util.indentout
-        out:write("{\n  \"tests\": [\n")
+        out:write('{\n  "tests": [\n')
         for i, test in ipairs(tests) do
             if i ~= 1 then out:write(",\n") end
             indentout(out, 2, "{\n")
-            indentout(out, 3, "\"file\": \"" .. test[1] .. "\",\n")
-            indentout(out, 3, "\"mcycle\": " .. test[2] .. "\n")
+            indentout(out, 3, '"file": "' .. test[1] .. '",\n')
+            indentout(out, 3, '"mcycle": ' .. test[2] .. "\n")
             indentout(out, 2, "}")
         end
         out:write("\n  ]\n}\n")
@@ -942,15 +989,13 @@ end
 
 local selected_tests = {}
 for _, test in ipairs(riscv_tests) do
-    if select_test(test[1], test_pattern) then
-        selected_tests[#selected_tests+1] = test
-    end
+    if select_test(test[1], test_pattern) then selected_tests[#selected_tests + 1] = test end
 end
 
 local function build_both_machines(test_name)
     return {
         host = build_machine(test_name),
-        uarch = build_machine(test_name)
+        uarch = build_machine(test_name),
     }
 end
 
@@ -965,16 +1010,21 @@ local function run_host_and_uarch_machines(target, ctx, max_mcycle)
     local host_cycles = host_machine:read_mcycle()
     local uarch_cycles = uarch_machine:read_mcycle()
     assert(host_cycles == uarch_cycles)
-    if  host_cycles ~= uarch_cycles then
-        add_error(ctx,"host_cycles ~= uarch_cycles: %d ~= %d", host_cycles, uarch_cycles)
+    if host_cycles ~= uarch_cycles then
+        add_error(ctx, "host_cycles ~= uarch_cycles: %d ~= %d", host_cycles, uarch_cycles)
         return 0
     end
     while math.ult(host_cycles, max_mcycle) do
         local host_hash = host_machine:get_root_hash()
         local uarch_hash = uarch_machine:get_root_hash()
         if host_hash ~= uarch_hash then
-            add_error(ctx,"Hash mismatch at mcycle %d: %s ~= %s",
-              host_cycles, util.hexhash(host_hash), util.hexhash(uarch_hash))
+            add_error(
+                ctx,
+                "Hash mismatch at mcycle %d: %s ~= %s",
+                host_cycles,
+                util.hexhash(host_hash),
+                util.hexhash(uarch_hash)
+            )
             break
         end
         host_machine:run(1 + host_cycles)
@@ -982,14 +1032,18 @@ local function run_host_and_uarch_machines(target, ctx, max_mcycle)
         host_cycles = host_machine:read_mcycle()
         uarch_cycles = uarch_machine:read_mcycle()
         if host_cycles ~= uarch_cycles then
-            add_error(ctx,"host_cycles ~= uarch_cycles: %d ~= %d", host_cycles, uarch_cycles)
+            add_error(ctx, "host_cycles ~= uarch_cycles: %d ~= %d", host_cycles, uarch_cycles)
             break
         end
         local host_iflags_H = host_machine:read_iflags_H()
         local uarch_iflags_H = uarch_machine:read_iflags_H()
         if host_iflags_H ~= uarch_iflags_H then
-            add_error(ctx,"host_iflags_H ~= uarch_iflags_H: %s ~= %s",
-              tostring(host_iflags_H),  tostring(uarch_iflags_H))
+            add_error(
+                ctx,
+                "host_iflags_H ~= uarch_iflags_H: %s ~= %s",
+                tostring(host_iflags_H),
+                tostring(uarch_iflags_H)
+            )
             break
         end
         if host_iflags_H then break end
@@ -997,8 +1051,12 @@ local function run_host_and_uarch_machines(target, ctx, max_mcycle)
     local host_htif_tohost_data = host_machine:read_htif_tohost_data()
     local uarch_htif_tohost_data = uarch_machine:read_htif_tohost_data()
     if host_htif_tohost_data ~= uarch_htif_tohost_data then
-        add_error(ctx, "host_htif_tohost_data ~= uarch_htif_tohost_data: %d ~= %d",
-          host_htif_tohost_data, uarch_htif_tohost_data)
+        add_error(
+            ctx,
+            "host_htif_tohost_data ~= uarch_htif_tohost_data: %d ~= %d",
+            host_htif_tohost_data,
+            uarch_htif_tohost_data
+        )
     end
     ctx.read_htif_tohost_data = host_htif_tohost_data
     return host_cycles
@@ -1009,29 +1067,40 @@ local targets = {
     host = {
         build = build_machine,
         run = run_machine,
-        destroy = destroy_machine
+        destroy = destroy_machine,
     },
     -- Run test on microarchitecture-based emulator
     uarch = {
         build = build_machine,
         run = run_machine_with_uarch,
-        destroy = destroy_machine
+        destroy = destroy_machine,
     },
     -- Run test on both architectures: macro and micro; comparing root hashes after every mcycle
     host_and_uarch = {
         build = build_both_machines,
         run = run_host_and_uarch_machines,
-        destroy = destroy_both_machines
-    }
+        destroy = destroy_both_machines,
+    },
 }
 
-if #selected_tests < 1 then error("no test selected")
-elseif command == "run" then run_tests(selected_tests, targets.host)
-elseif command == "run_uarch" then run_tests(selected_tests, targets.uarch)
-elseif command == "run_host_and_uarch" then run_tests(selected_tests, targets.host_and_uarch)
-elseif command == "hash" then hash(selected_tests)
-elseif command == "step" then step(selected_tests)
-elseif command == "dump" then dump(selected_tests)
-elseif command == "list" then list(selected_tests)
-elseif command == "machine" then print_machines(selected_tests)
-else error("command not found") end
+if #selected_tests < 1 then
+    error("no test selected")
+elseif command == "run" then
+    run_tests(selected_tests, targets.host)
+elseif command == "run_uarch" then
+    run_tests(selected_tests, targets.uarch)
+elseif command == "run_host_and_uarch" then
+    run_tests(selected_tests, targets.host_and_uarch)
+elseif command == "hash" then
+    hash(selected_tests)
+elseif command == "step" then
+    step(selected_tests)
+elseif command == "dump" then
+    dump(selected_tests)
+elseif command == "list" then
+    list(selected_tests)
+elseif command == "machine" then
+    print_machines(selected_tests)
+else
+    error("command not found")
+end

--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -16,12 +16,10 @@
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 --
 
-local cartesi = require"cartesi"
-local util = require"cartesi.util"
+local cartesi = require("cartesi")
+local util = require("cartesi.util")
 
-local function stderr_unsilenceable(fmt, ...)
-    io.stderr:write(string.format(fmt, ...))
-end
+local function stderr_unsilenceable(fmt, ...) io.stderr:write(string.format(fmt, ...)) end
 local stderr = stderr_unsilenceable
 
 local function adjust_images_path(path)
@@ -31,7 +29,8 @@ end
 
 -- Print help and exit
 local function help()
-    stderr([=[
+    stderr(
+        [=[
 Usage:
 
   %s [options] [command] [arguments]
@@ -380,7 +379,9 @@ or a left shift (e.g., 2 << 20).
 
 <host> can be a host name, IPv4 or IPv6 address.
 
-]=], arg[0])
+]=],
+        arg[0]
+    )
     os.exit()
 end
 
@@ -391,13 +392,13 @@ local checkin_address
 local remote_shutdown = false
 local remote_create = true
 local remote_destroy = true
-local images_path = adjust_images_path(os.getenv('CARTESI_IMAGES_PATH'))
+local images_path = adjust_images_path(os.getenv("CARTESI_IMAGES_PATH"))
 local flash_image_filename = { root = images_path .. "rootfs.ext2" }
 local flash_label_order = { "root" }
-local flash_shared = { }
-local flash_start = { }
-local flash_length = { }
-local memory_range_replace = { }
+local flash_shared = {}
+local flash_start = {}
+local flash_length = {}
+local memory_range_replace = {}
 local ram_image_filename = images_path .. "linux.bin"
 local ram_length = 64 << 20
 local rom_image_filename = images_path .. "rom.bin"
@@ -441,17 +442,14 @@ local function parse_memory_range(opts, what, all)
         filename = true,
         shared = true,
         length = true,
-        start = true
+        start = true,
     })
     f.image_filename = f.filename
     f.filename = nil
     if f.image_filename == true then f.image_filename = "" end
-    assert(not f.shared or f.shared == true,
-        "invalid " .. what .. " shared value in " .. all)
-    f.start = assert(util.parse_number(f.start),
-        "invalid " .. what .. " start in " .. all)
-    f.length = assert(util.parse_number(f.length),
-        "invalid " .. what .. " length in " .. all)
+    assert(not f.shared or f.shared == true, "invalid " .. what .. " shared value in " .. all)
+    f.start = assert(util.parse_number(f.start), "invalid " .. what .. " start in " .. all)
+    f.length = assert(util.parse_number(f.length), "invalid " .. what .. " length in " .. all)
     return f
 end
 
@@ -463,508 +461,646 @@ end
 --     if callback returns true, the option is accepted.
 --     if callback returns false, the option is rejected.
 local options = {
-    { "^%-h$", function(all)
-        if not all then return false end
-        help()
-        return true
-    end },
-    { "^%-%-help$", function(all)
-        if not all then return false end
-        help()
-        return true
-    end },
-    { "^%-%-version$", function(all)
-        if not all then return false end
-        print(string.format("cartesi-machine %s", cartesi.VERSION))
-        if cartesi.GIT_COMMIT then
-          print(string.format("git commit: %s", cartesi.GIT_COMMIT))
-        end
-        if cartesi.BUILD_TIME then
-          print(string.format("build time: %s", cartesi.BUILD_TIME))
-        end
-        print(string.format("platform: %s", cartesi.PLATFORM))
-        print(string.format("compiler: %s", cartesi.COMPILER))
-        print("Copyright 2019-2023 Cartesi Pte. Ltd.")
-        os.exit()
-        return true
-    end },
-    { "^%-%-version%-json$", function(all)
-        if not all then return false end
-        print("{")
-        print(string.format('  "version": "%s",', cartesi.VERSION))
-        print(string.format('  "version_major": %d,', cartesi.VERSION_MAJOR))
-        print(string.format('  "version_minor": %d,', cartesi.VERSION_MINOR))
-        print(string.format('  "version_patch": %d,', cartesi.VERSION_PATCH))
-        print(string.format('  "version_label": "%s",', cartesi.VERSION_LABEL))
-        print(string.format('  "marchid": %d,', cartesi.MARCHID))
-        print(string.format('  "mimpid": %d,', cartesi.MIMPID))
-        -- the following works only when luaposix is available in the system
-        local ok, stdlib = pcall(require, 'posix.stdlib')
-        if ok and stdlib then
-          -- use realpath to get images real filenames,
-          -- tools could use this information to detect rom/linux/rootfs versions
-          local rom_image = stdlib.realpath(images_path .. 'rom.bin')
-          local ram_image = stdlib.realpath(images_path .. 'linux.bin')
-          local rootfs_image = stdlib.realpath(images_path .. 'rootfs.ext2')
-          if rom_image then
-            print(string.format('  "default_rom_image": "%s",', rom_image))
-          end
-          if ram_image then
-            print(string.format('  "default_ram_image": "%s",', ram_image))
-          end
-          if rootfs_image then
-            print(string.format('  "default_rootfs_image": "%s",', rootfs_image))
-          end
-        end
-        if cartesi.GIT_COMMIT then
-          print(string.format('  "git_commit": "%s",', cartesi.GIT_COMMIT))
-        end
-        if cartesi.BUILD_TIME then
-          print(string.format('  "build_time": "%s",', cartesi.BUILD_TIME))
-        end
-        print(string.format('  "compiler": "%s",', cartesi.COMPILER))
-        print(string.format('  "platform": "%s"', cartesi.PLATFORM))
-        print("}")
-        os.exit()
-        return true
-    end },
-    { "^%-%-rom%-image%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        rom_image_filename = o
-        return true
-    end },
-    { "^%-%-no%-rom%-bootargs$", function(all)
-        if not all then return false end
-        rom_bootargs = ""
-        return true
-    end },
-    { "^%-%-append%-rom%-bootargs%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        append_rom_bootargs = o
-        return true
-    end },
-    { "^%-%-ram%-length%=(.+)$", function(n)
-        if not n then return false end
-        ram_length = assert(util.parse_number(n), "invalid RAM length " .. n)
-        return true
-    end },
-    { "^%-%-ram%-image%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        ram_image_filename = o
-        return true
-    end },
-    { "^%-%-no%-ram%-image$", function(all)
-        if not all then return false end
-        ram_image_filename = ""
-        return true
-    end },
-    { "^%-%-uarch%-ram%-length%=(.+)$", function(n)
-        if not n then return false end
-        uarch = uarch or {}
-        uarch.ram = uarch.ram or {}
-        uarch.ram.length = assert(util.parse_number(n), "invalid microarchitecture RAM length " .. n)
-        return true
-    end },
-    { "^%-%-uarch%-ram%-image%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        uarch = uarch or {}
-        uarch.ram = uarch.ram or {}
-        uarch.ram.image_filename = o
-        return true
-    end },
-    { "^%-%-htif%-console%-getchar$", function(all)
-        if not all then return false end
-        htif_console_getchar = true
-        return true
-    end },
-    { "^%-i$", function(all)
-        if not all then return false end
-        htif_console_getchar = true
-        return true
-    end },
-    { "^%-%-htif%-yield%-manual$", function(all)
-        if not all then return false end
-        htif_yield_manual = true
-        return true
-    end },
-    { "^%-%-htif%-yield%-automatic$", function(all)
-        if not all then return false end
-        htif_yield_automatic = true
-        return true
-    end },
-    { "^%-%-rollup$", function(all)
-        if not all then return false end
-        rollup = rollup or {}
-        rollup.rx_buffer = { start = 0x60000000, length = 2 << 20 }
-        rollup.tx_buffer = { start = 0x60200000, length = 2 << 20 }
-        rollup.input_metadata = { start = 0x60400000, length = 4096 }
-        rollup.voucher_hashes = { start = 0x60600000, length = 2 << 20 }
-        rollup.notice_hashes = { start = 0x60800000, length = 2 << 20 }
-        htif_yield_automatic = true
-        htif_yield_manual = true
-        return true
-    end },
-    { "^(%-%-flash%-drive%=(.+))$", function(all, opts)
-        if not opts then return false end
-        local f = util.parse_options(opts, {
-            label = true,
-            filename = true,
-            shared = true,
-            length = true,
-            start = true
-        })
-        assert(f.label, "missing flash drive label in " .. all)
-        f.image_filename = f.filename
-        f.filename = nil
-        if f.image_filename == true then f.image_filename = "" end
-        assert(not f.shared or f.shared == true,
-            "invalid flash drive shared value in " .. all)
-        if f.start then
-            f.start = assert(util.parse_number(f.start),
-                "invalid flash drive start in " .. all)
-        end
-        if f.length then
-            f.length = assert(util.parse_number(f.length),
-                "invalid flash drive length in " .. all)
-        end
-        local d = f.label
-        if not flash_image_filename[d] then
-            flash_label_order[#flash_label_order+1] = d
-            flash_image_filename[d] = ""
-        end
-        flash_image_filename[d] = f.image_filename or
-            flash_image_filename[d]
-        flash_start[d] = f.start or flash_start[d]
-        flash_length[d] = f.length or flash_length[d]
-        flash_shared[d] = f.shared or flash_shared[d]
-        return true
-    end },
-    { "^(%-%-replace%-flash%-drive%=(.+))$", function(all, opts)
-        if not opts then return false end
-        memory_range_replace[#memory_range_replace+1] =
-            parse_memory_range(opts, "flash drive", all)
-        return true
-    end },
-    { "^(%-%-replace%-memory%-range%=(.+))$", function(all, opts)
-        if not opts then return false end
-        memory_range_replace[#memory_range_replace+1] =
-            parse_memory_range(opts, "flash drive", all)
-        return true
-    end },
-    { "^(%-%-rollup%-advance%-state%=(.+))$", function(all, opts)
-        if not opts then return false end
-        local r = util.parse_options(opts, {
-            epoch_index = true,
-            input = true,
-            input_metadata = true,
-            input_index_begin = true,
-            input_index_end = true,
-            voucher = true,
-            voucher_hashes = true,
-            notice = true,
-            notice_hashes = true,
-            report = true,
-            hashes = true,
-        })
-        assert(not r.hashes or r.hashes == true, "invalid hashes value in " .. all)
-        r.epoch_index = assert(util.parse_number(r.epoch_index), "invalid epoch index in " .. all)
-        r.input = r.input or "epoch-%e-input-%i.bin"
-        r.input_metadata = r.input_metadata or "epoch-%e-input-metadata-%i.bin"
-        r.input_index_begin = r.input_index_begin or 0
-        r.input_index_begin = assert(util.parse_number(r.input_index_begin), "invalid input index begin in " .. all)
-        r.input_index_end = r.input_index_end or 0
-        r.input_index_end = assert(util.parse_number(r.input_index_end), "invalid input index end in " .. all)
-        r.voucher = r.voucher or "epoch-%e-input-%i-voucher-%o.bin"
-        r.voucher_hashes = r.voucher_hashes or "epoch-%e-input-%i-voucher-hashes.bin"
-        r.notice = r.notice or "epoch-%e-input-%i-notice-%o.bin"
-        r.notice_hashes = r.notice_hashes or "epoch-%e-input-%i-notice-hashes.bin"
-        r.report = r.report or "epoch-%e-input-%i-report-%o.bin"
-        r.next_input_index = r.input_index_begin
-        rollup_advance = r
-        return true
-    end },
-    { "^(%-%-rollup%-inspect%-state%=(.+))$", function(_, opts)
-        if not opts then return false end
-        local r = util.parse_options(opts, {
-            query = true,
-            report = true,
-        })
-        r.query = r.query or "query.bin"
-        r.report = r.report or "query-report-%o.bin"
-        rollup_inspect = r
-        return true
-    end },
-    { "^%-%-rollup%-inspect%-state$", function(all)
-        if not all then return false end
-        rollup_inspect = {
-            query = "query.bin",
-            report = "query-report-%o.bin"
-        }
-        return true
-    end },
-    { "^(%-%-concurrency%=(.+))$", function(all, opts)
-        if not opts then return false end
-        local c = util.parse_options(opts, {
-            update_merkle_tree = true
-        })
-        c.update_merkle_tree = assert(util.parse_number(c.update_merkle_tree),
-                "invalid update_merkle_tree number in " .. all)
-        concurrency_update_merkle_tree = c.update_merkle_tree
-        return true
-    end },
-    { "^%-%-htif%-no%-console%-putchar$", function(all)
-        if not all then return false end
-        htif_no_console_putchar = true
-        return true
-    end },
-    { "^%-%-skip%-root%-hash%-check$", function(all)
-        if not all then return false end
-        skip_root_hash_check = true
-        return true
-    end },
-    { "^%-%-skip%-version%-check$", function(all)
-        if not all then return false end
-        skip_version_check = true
-        return true
-    end },
-    { "^(%-%-initial%-proof%=(.+))$", function(all, opts)
-        if not opts then return false end
-        local p = util.parse_options(opts, {
-            address = true,
-            log2_size = true,
-            filename = true
-        })
-        p.cmdline = all
-        p.address = assert(util.parse_number(p.address),
-            "invalid address in " .. all)
-        p.log2_size = assert(util.parse_number(p.log2_size),
-            "invalid log2_size in " .. all)
-        assert(p.log2_size >= 3,
-            "log2_size must be at least 3 in " .. all)
-        initial_proof[#initial_proof+1] = p
-        return true
-    end },
-    { "^(%-%-final%-proof%=(.+))$", function(all, opts)
-        if not opts then return false end
-        local p = util.parse_options(opts, {
-            address = true,
-            log2_size = true,
-            filename = true
-        })
-        p.cmdline = all
-        p.address = assert(util.parse_number(p.address),
-            "invalid address in " .. all)
-        p.log2_size = assert(util.parse_number(p.log2_size),
-            "invalid log2_size in " .. all)
-        assert(p.log2_size >= 3,
-            "log2_size must be at least 3 in " .. all)
-        final_proof[#final_proof+1] = p
-        return true
-    end },
-    { "^%-%-no%-root%-flash%-drive$", function(all)
-        if not all then return false end
-        assert(flash_image_filename.root and flash_label_order[1] == "root",
-                 "no root flash drive to remove")
-        flash_image_filename.root = nil
-        flash_start.root = nil
-        flash_length.root = nil
-        flash_shared.root = nil
-        table.remove(flash_label_order, 1)
-        rom_bootargs = "console=hvc0"
-        return true
-    end },
-    { "^%-%-dump%-pmas$", function(all)
-        if not all then return false end
-        dump_pmas = true
-        return true
-    end },
-    { "%-%-assert%-rolling%-template", function(all)
-        if not all then return false end
-        assert_rolling_template = true
-        return true
-    end },
-    { "%-%-quiet", function(all)
-        if not all then return false end
-        stderr = function() end
-        quiet = true
-        return true
-    end },
-    { "^%-%-step%-uarch$", function(all)
-        if not all then return false end
-        step_uarch = true
-        return true
-    end },
-    { "^(%-%-max%-mcycle%=(.*))$", function(all, n)
-        if not n then return false end
-        max_mcycle = assert(util.parse_number(n), "invalid option " .. all)
-        return true
-    end },
-    { "^(%-%-max%-uarch%-cycle%=(.*))$", function(all, n)
-        if not n then return false end
-        max_uarch_cycle = assert(util.parse_number(n), "invalid option " .. all)
-        return true
-    end },
-    { "^%-%-auto%-reset%-uarch%-state$", function(all)
-        if not all then return false end
-        auto_reset_uarch_state = true
-        return true
-    end },
-    { "^%-%-load%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        load_dir = o
-        return true
-    end },
-    { "^%-%-store%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        store_dir = o
-        return true
-    end },
-    { "^%-%-remote%-address%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        remote_address = o
-        return true
-    end },
-    { "^%-%-remote%-protocol%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        remote_protocol = o
-        return true
-    end },
-    { "^%-%-checkin%-address%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        checkin_address = o
-        return true
-    end },
-    { "^%-%-remote%-shutdown$", function(o)
-        if not o then return false end
-        remote_shutdown = true
-        return true
-    end },
-    { "^%-%-no%-remote%-create$", function(o)
-        if not o then return false end
-        remote_create = false
-        return true
-    end },
-    { "^%-%-no%-remote%-destroy$", function(o)
-        if not o then return false end
-        remote_destroy = false
-        return true
-    end },
-    { "^%-%-json%-steps%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        json_steps = o
-        return true
-    end },
-    { "^%-%-initial%-hash$", function(all)
-        if not all then return false end
-        initial_hash = true
-        return true
-    end },
-    { "^%-%-final%-hash$", function(all)
-        if not all then return false end
-        final_hash = true
-        return true
-    end },
-    { "^(%-%-periodic%-hashes%=(.*))$", function(all, v)
-        if not v then return false end
-        string.gsub(v, "^([^%,]+),(.+)$", function(p, s)
-            periodic_hashes_period = assert(util.parse_number(p),
-                "invalid period " .. all)
-            periodic_hashes_start = assert(util.parse_number(s),
-                "invalid start " .. all)
-        end)
-        if periodic_hashes_period == math.maxinteger then
-            periodic_hashes_period = assert(util.parse_number(v),
-                "invalid period " .. all)
-            periodic_hashes_start = 0
-        end
-        initial_hash = true
-        final_hash = true
-        return true
-    end },
-    { "^%-%-store%-config(%=?)(%g*)$", function(o, v)
-        if not o then return false end
-        if o == '=' then
-            if not v or #v < 1 then return false end
-            store_config = v
-        else
-            store_config = stderr
-        end
-        return true
-    end },
-    { "^%-%-load%-config%=(%g*)$", function(o)
-        if not o or #o < 1 then return false end
-        load_config = o
-        return true
-    end },
-    { "^(%-%-rollup%-rx%-buffer%=(.+))$", function(all, opts)
-        if not opts then return false end
-        rollup = rollup or {}
-        rollup.rx_buffer = parse_memory_range(opts, "rollup rx buffer", all)
-        return true
-    end },
-    { "^(%-%-rollup%-tx%-buffer%=(.+))$", function(all, opts)
-        if not opts then return false end
-        rollup = rollup or {}
-        rollup.tx_buffer = parse_memory_range(opts, "tx buffer", all)
-        return true
-    end },
-    { "^(%-%-rollup%-input%-metadata%=(.+))$", function(all, opts)
-        if not opts then return false end
-        rollup = rollup or {}
-        rollup.input_metadata = parse_memory_range(opts, "rollup input metadata", all)
-        return true
-    end },
-    { "^(%-%-rollup%-voucher%-hashes%=(.+))$", function(all, opts)
-        if not opts then return false end
-        rollup = rollup or {}
-        rollup.voucher_hashes = parse_memory_range(opts, "rollup voucher hashes", all)
-        return true
-    end },
-    { "^(%-%-rollup%-notice%-hashes%=(.+))$", function(all, opts)
-        if not opts then return false end
-        rollup = rollup or {}
-        rollup.notice_hashes = parse_memory_range(opts, "rollup notice hashes", all)
-        return true
-    end },
-    { "^%-%-gdb(%=?)(.*)$", function(o, address)
-        if o == '='  and #o > 0 then
-          gdb_address = address
-          return true
-        elseif o == '' then
-          gdb_address = '127.0.0.1:1234'
-          return true
-        end
-        return false
-    end },
-    { ".*", function(all)
-        if not all then return false end
-        local not_option = all:sub(1,1) ~= "-"
-        if not_option or all == "--" then
-          cmdline_opts_finished = true
-          if not_option then exec_arguments = { all } end
-          return true
-        end
-        error("unrecognized option " .. all)
-    end }
+    {
+        "^%-h$",
+        function(all)
+            if not all then return false end
+            help()
+            return true
+        end,
+    },
+    {
+        "^%-%-help$",
+        function(all)
+            if not all then return false end
+            help()
+            return true
+        end,
+    },
+    {
+        "^%-%-version$",
+        function(all)
+            if not all then return false end
+            print(string.format("cartesi-machine %s", cartesi.VERSION))
+            if cartesi.GIT_COMMIT then print(string.format("git commit: %s", cartesi.GIT_COMMIT)) end
+            if cartesi.BUILD_TIME then print(string.format("build time: %s", cartesi.BUILD_TIME)) end
+            print(string.format("platform: %s", cartesi.PLATFORM))
+            print(string.format("compiler: %s", cartesi.COMPILER))
+            print("Copyright 2019-2023 Cartesi Pte. Ltd.")
+            os.exit()
+            return true
+        end,
+    },
+    {
+        "^%-%-version%-json$",
+        function(all)
+            if not all then return false end
+            print("{")
+            print(string.format('  "version": "%s",', cartesi.VERSION))
+            print(string.format('  "version_major": %d,', cartesi.VERSION_MAJOR))
+            print(string.format('  "version_minor": %d,', cartesi.VERSION_MINOR))
+            print(string.format('  "version_patch": %d,', cartesi.VERSION_PATCH))
+            print(string.format('  "version_label": "%s",', cartesi.VERSION_LABEL))
+            print(string.format('  "marchid": %d,', cartesi.MARCHID))
+            print(string.format('  "mimpid": %d,', cartesi.MIMPID))
+            -- the following works only when luaposix is available in the system
+            local ok, stdlib = pcall(require, "posix.stdlib")
+            if ok and stdlib then
+                -- use realpath to get images real filenames,
+                -- tools could use this information to detect rom/linux/rootfs versions
+                local rom_image = stdlib.realpath(images_path .. "rom.bin")
+                local ram_image = stdlib.realpath(images_path .. "linux.bin")
+                local rootfs_image = stdlib.realpath(images_path .. "rootfs.ext2")
+                if rom_image then print(string.format('  "default_rom_image": "%s",', rom_image)) end
+                if ram_image then print(string.format('  "default_ram_image": "%s",', ram_image)) end
+                if rootfs_image then print(string.format('  "default_rootfs_image": "%s",', rootfs_image)) end
+            end
+            if cartesi.GIT_COMMIT then print(string.format('  "git_commit": "%s",', cartesi.GIT_COMMIT)) end
+            if cartesi.BUILD_TIME then print(string.format('  "build_time": "%s",', cartesi.BUILD_TIME)) end
+            print(string.format('  "compiler": "%s",', cartesi.COMPILER))
+            print(string.format('  "platform": "%s"', cartesi.PLATFORM))
+            print("}")
+            os.exit()
+            return true
+        end,
+    },
+    {
+        "^%-%-rom%-image%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            rom_image_filename = o
+            return true
+        end,
+    },
+    {
+        "^%-%-no%-rom%-bootargs$",
+        function(all)
+            if not all then return false end
+            rom_bootargs = ""
+            return true
+        end,
+    },
+    {
+        "^%-%-append%-rom%-bootargs%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            append_rom_bootargs = o
+            return true
+        end,
+    },
+    {
+        "^%-%-ram%-length%=(.+)$",
+        function(n)
+            if not n then return false end
+            ram_length = assert(util.parse_number(n), "invalid RAM length " .. n)
+            return true
+        end,
+    },
+    {
+        "^%-%-ram%-image%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            ram_image_filename = o
+            return true
+        end,
+    },
+    {
+        "^%-%-no%-ram%-image$",
+        function(all)
+            if not all then return false end
+            ram_image_filename = ""
+            return true
+        end,
+    },
+    {
+        "^%-%-uarch%-ram%-length%=(.+)$",
+        function(n)
+            if not n then return false end
+            uarch = uarch or {}
+            uarch.ram = uarch.ram or {}
+            uarch.ram.length = assert(util.parse_number(n), "invalid microarchitecture RAM length " .. n)
+            return true
+        end,
+    },
+    {
+        "^%-%-uarch%-ram%-image%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            uarch = uarch or {}
+            uarch.ram = uarch.ram or {}
+            uarch.ram.image_filename = o
+            return true
+        end,
+    },
+    {
+        "^%-%-htif%-console%-getchar$",
+        function(all)
+            if not all then return false end
+            htif_console_getchar = true
+            return true
+        end,
+    },
+    {
+        "^%-i$",
+        function(all)
+            if not all then return false end
+            htif_console_getchar = true
+            return true
+        end,
+    },
+    {
+        "^%-%-htif%-yield%-manual$",
+        function(all)
+            if not all then return false end
+            htif_yield_manual = true
+            return true
+        end,
+    },
+    {
+        "^%-%-htif%-yield%-automatic$",
+        function(all)
+            if not all then return false end
+            htif_yield_automatic = true
+            return true
+        end,
+    },
+    {
+        "^%-%-rollup$",
+        function(all)
+            if not all then return false end
+            rollup = rollup or {}
+            rollup.rx_buffer = { start = 0x60000000, length = 2 << 20 }
+            rollup.tx_buffer = { start = 0x60200000, length = 2 << 20 }
+            rollup.input_metadata = { start = 0x60400000, length = 4096 }
+            rollup.voucher_hashes = { start = 0x60600000, length = 2 << 20 }
+            rollup.notice_hashes = { start = 0x60800000, length = 2 << 20 }
+            htif_yield_automatic = true
+            htif_yield_manual = true
+            return true
+        end,
+    },
+    {
+        "^(%-%-flash%-drive%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            local f = util.parse_options(opts, {
+                label = true,
+                filename = true,
+                shared = true,
+                length = true,
+                start = true,
+            })
+            assert(f.label, "missing flash drive label in " .. all)
+            f.image_filename = f.filename
+            f.filename = nil
+            if f.image_filename == true then f.image_filename = "" end
+            assert(not f.shared or f.shared == true, "invalid flash drive shared value in " .. all)
+            if f.start then f.start = assert(util.parse_number(f.start), "invalid flash drive start in " .. all) end
+            if f.length then f.length = assert(util.parse_number(f.length), "invalid flash drive length in " .. all) end
+            local d = f.label
+            if not flash_image_filename[d] then
+                flash_label_order[#flash_label_order + 1] = d
+                flash_image_filename[d] = ""
+            end
+            flash_image_filename[d] = f.image_filename or flash_image_filename[d]
+            flash_start[d] = f.start or flash_start[d]
+            flash_length[d] = f.length or flash_length[d]
+            flash_shared[d] = f.shared or flash_shared[d]
+            return true
+        end,
+    },
+    {
+        "^(%-%-replace%-flash%-drive%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            memory_range_replace[#memory_range_replace + 1] = parse_memory_range(opts, "flash drive", all)
+            return true
+        end,
+    },
+    {
+        "^(%-%-replace%-memory%-range%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            memory_range_replace[#memory_range_replace + 1] = parse_memory_range(opts, "flash drive", all)
+            return true
+        end,
+    },
+    {
+        "^(%-%-rollup%-advance%-state%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            local r = util.parse_options(opts, {
+                epoch_index = true,
+                input = true,
+                input_metadata = true,
+                input_index_begin = true,
+                input_index_end = true,
+                voucher = true,
+                voucher_hashes = true,
+                notice = true,
+                notice_hashes = true,
+                report = true,
+                hashes = true,
+            })
+            assert(not r.hashes or r.hashes == true, "invalid hashes value in " .. all)
+            r.epoch_index = assert(util.parse_number(r.epoch_index), "invalid epoch index in " .. all)
+            r.input = r.input or "epoch-%e-input-%i.bin"
+            r.input_metadata = r.input_metadata or "epoch-%e-input-metadata-%i.bin"
+            r.input_index_begin = r.input_index_begin or 0
+            r.input_index_begin = assert(util.parse_number(r.input_index_begin), "invalid input index begin in " .. all)
+            r.input_index_end = r.input_index_end or 0
+            r.input_index_end = assert(util.parse_number(r.input_index_end), "invalid input index end in " .. all)
+            r.voucher = r.voucher or "epoch-%e-input-%i-voucher-%o.bin"
+            r.voucher_hashes = r.voucher_hashes or "epoch-%e-input-%i-voucher-hashes.bin"
+            r.notice = r.notice or "epoch-%e-input-%i-notice-%o.bin"
+            r.notice_hashes = r.notice_hashes or "epoch-%e-input-%i-notice-hashes.bin"
+            r.report = r.report or "epoch-%e-input-%i-report-%o.bin"
+            r.next_input_index = r.input_index_begin
+            rollup_advance = r
+            return true
+        end,
+    },
+    {
+        "^(%-%-rollup%-inspect%-state%=(.+))$",
+        function(_, opts)
+            if not opts then return false end
+            local r = util.parse_options(opts, {
+                query = true,
+                report = true,
+            })
+            r.query = r.query or "query.bin"
+            r.report = r.report or "query-report-%o.bin"
+            rollup_inspect = r
+            return true
+        end,
+    },
+    {
+        "^%-%-rollup%-inspect%-state$",
+        function(all)
+            if not all then return false end
+            rollup_inspect = {
+                query = "query.bin",
+                report = "query-report-%o.bin",
+            }
+            return true
+        end,
+    },
+    {
+        "^(%-%-concurrency%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            local c = util.parse_options(opts, {
+                update_merkle_tree = true,
+            })
+            c.update_merkle_tree =
+                assert(util.parse_number(c.update_merkle_tree), "invalid update_merkle_tree number in " .. all)
+            concurrency_update_merkle_tree = c.update_merkle_tree
+            return true
+        end,
+    },
+    {
+        "^%-%-htif%-no%-console%-putchar$",
+        function(all)
+            if not all then return false end
+            htif_no_console_putchar = true
+            return true
+        end,
+    },
+    {
+        "^%-%-skip%-root%-hash%-check$",
+        function(all)
+            if not all then return false end
+            skip_root_hash_check = true
+            return true
+        end,
+    },
+    {
+        "^%-%-skip%-version%-check$",
+        function(all)
+            if not all then return false end
+            skip_version_check = true
+            return true
+        end,
+    },
+    {
+        "^(%-%-initial%-proof%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            local p = util.parse_options(opts, {
+                address = true,
+                log2_size = true,
+                filename = true,
+            })
+            p.cmdline = all
+            p.address = assert(util.parse_number(p.address), "invalid address in " .. all)
+            p.log2_size = assert(util.parse_number(p.log2_size), "invalid log2_size in " .. all)
+            assert(p.log2_size >= 3, "log2_size must be at least 3 in " .. all)
+            initial_proof[#initial_proof + 1] = p
+            return true
+        end,
+    },
+    {
+        "^(%-%-final%-proof%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            local p = util.parse_options(opts, {
+                address = true,
+                log2_size = true,
+                filename = true,
+            })
+            p.cmdline = all
+            p.address = assert(util.parse_number(p.address), "invalid address in " .. all)
+            p.log2_size = assert(util.parse_number(p.log2_size), "invalid log2_size in " .. all)
+            assert(p.log2_size >= 3, "log2_size must be at least 3 in " .. all)
+            final_proof[#final_proof + 1] = p
+            return true
+        end,
+    },
+    {
+        "^%-%-no%-root%-flash%-drive$",
+        function(all)
+            if not all then return false end
+            assert(flash_image_filename.root and flash_label_order[1] == "root", "no root flash drive to remove")
+            flash_image_filename.root = nil
+            flash_start.root = nil
+            flash_length.root = nil
+            flash_shared.root = nil
+            table.remove(flash_label_order, 1)
+            rom_bootargs = "console=hvc0"
+            return true
+        end,
+    },
+    {
+        "^%-%-dump%-pmas$",
+        function(all)
+            if not all then return false end
+            dump_pmas = true
+            return true
+        end,
+    },
+    {
+        "%-%-assert%-rolling%-template",
+        function(all)
+            if not all then return false end
+            assert_rolling_template = true
+            return true
+        end,
+    },
+    {
+        "%-%-quiet",
+        function(all)
+            if not all then return false end
+            stderr = function() end
+            quiet = true
+            return true
+        end,
+    },
+    {
+        "^%-%-step%-uarch$",
+        function(all)
+            if not all then return false end
+            step_uarch = true
+            return true
+        end,
+    },
+    {
+        "^(%-%-max%-mcycle%=(.*))$",
+        function(all, n)
+            if not n then return false end
+            max_mcycle = assert(util.parse_number(n), "invalid option " .. all)
+            return true
+        end,
+    },
+    {
+        "^(%-%-max%-uarch%-cycle%=(.*))$",
+        function(all, n)
+            if not n then return false end
+            max_uarch_cycle = assert(util.parse_number(n), "invalid option " .. all)
+            return true
+        end,
+    },
+    {
+        "^%-%-auto%-reset%-uarch%-state$",
+        function(all)
+            if not all then return false end
+            auto_reset_uarch_state = true
+            return true
+        end,
+    },
+    {
+        "^%-%-load%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            load_dir = o
+            return true
+        end,
+    },
+    {
+        "^%-%-store%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            store_dir = o
+            return true
+        end,
+    },
+    {
+        "^%-%-remote%-address%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            remote_address = o
+            return true
+        end,
+    },
+    {
+        "^%-%-remote%-protocol%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            remote_protocol = o
+            return true
+        end,
+    },
+    {
+        "^%-%-checkin%-address%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            checkin_address = o
+            return true
+        end,
+    },
+    {
+        "^%-%-remote%-shutdown$",
+        function(o)
+            if not o then return false end
+            remote_shutdown = true
+            return true
+        end,
+    },
+    {
+        "^%-%-no%-remote%-create$",
+        function(o)
+            if not o then return false end
+            remote_create = false
+            return true
+        end,
+    },
+    {
+        "^%-%-no%-remote%-destroy$",
+        function(o)
+            if not o then return false end
+            remote_destroy = false
+            return true
+        end,
+    },
+    {
+        "^%-%-json%-steps%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            json_steps = o
+            return true
+        end,
+    },
+    {
+        "^%-%-initial%-hash$",
+        function(all)
+            if not all then return false end
+            initial_hash = true
+            return true
+        end,
+    },
+    {
+        "^%-%-final%-hash$",
+        function(all)
+            if not all then return false end
+            final_hash = true
+            return true
+        end,
+    },
+    {
+        "^(%-%-periodic%-hashes%=(.*))$",
+        function(all, v)
+            if not v then return false end
+            string.gsub(v, "^([^%,]+),(.+)$", function(p, s)
+                periodic_hashes_period = assert(util.parse_number(p), "invalid period " .. all)
+                periodic_hashes_start = assert(util.parse_number(s), "invalid start " .. all)
+            end)
+            if periodic_hashes_period == math.maxinteger then
+                periodic_hashes_period = assert(util.parse_number(v), "invalid period " .. all)
+                periodic_hashes_start = 0
+            end
+            initial_hash = true
+            final_hash = true
+            return true
+        end,
+    },
+    {
+        "^%-%-store%-config(%=?)(%g*)$",
+        function(o, v)
+            if not o then return false end
+            if o == "=" then
+                if not v or #v < 1 then return false end
+                store_config = v
+            else
+                store_config = stderr
+            end
+            return true
+        end,
+    },
+    {
+        "^%-%-load%-config%=(%g*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            load_config = o
+            return true
+        end,
+    },
+    {
+        "^(%-%-rollup%-rx%-buffer%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            rollup = rollup or {}
+            rollup.rx_buffer = parse_memory_range(opts, "rollup rx buffer", all)
+            return true
+        end,
+    },
+    {
+        "^(%-%-rollup%-tx%-buffer%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            rollup = rollup or {}
+            rollup.tx_buffer = parse_memory_range(opts, "tx buffer", all)
+            return true
+        end,
+    },
+    {
+        "^(%-%-rollup%-input%-metadata%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            rollup = rollup or {}
+            rollup.input_metadata = parse_memory_range(opts, "rollup input metadata", all)
+            return true
+        end,
+    },
+    {
+        "^(%-%-rollup%-voucher%-hashes%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            rollup = rollup or {}
+            rollup.voucher_hashes = parse_memory_range(opts, "rollup voucher hashes", all)
+            return true
+        end,
+    },
+    {
+        "^(%-%-rollup%-notice%-hashes%=(.+))$",
+        function(all, opts)
+            if not opts then return false end
+            rollup = rollup or {}
+            rollup.notice_hashes = parse_memory_range(opts, "rollup notice hashes", all)
+            return true
+        end,
+    },
+    {
+        "^%-%-gdb(%=?)(.*)$",
+        function(o, address)
+            if o == "=" and #o > 0 then
+                gdb_address = address
+                return true
+            elseif o == "" then
+                gdb_address = "127.0.0.1:1234"
+                return true
+            end
+            return false
+        end,
+    },
+    {
+        ".*",
+        function(all)
+            if not all then return false end
+            local not_option = all:sub(1, 1) ~= "-"
+            if not_option or all == "--" then
+                cmdline_opts_finished = true
+                if not_option then exec_arguments = { all } end
+                return true
+            end
+            error("unrecognized option " .. all)
+        end,
+    },
 }
 
 -- Process command line options
 for _, a in ipairs(arg) do
     if not cmdline_opts_finished then
-      for _, option in ipairs(options) do
-          if option[2](a:match(option[1])) then
-              break
-          end
-      end
+        for _, option in ipairs(options) do
+            if option[2](a:match(option[1])) then break end
+        end
     else
-      exec_arguments[#exec_arguments+1] = a
+        exec_arguments[#exec_arguments + 1] = a
     end
 end
 
 local function get_file_length(filename)
     local file = io.open(filename, "rb")
     if not file then return nil end
-    local size = file:seek("end")    -- get file size
+    local size = file:seek("end") -- get file size
     file:close()
     return size
 end
@@ -974,9 +1110,7 @@ local function print_root_hash(machine, print)
 end
 
 local function store_memory_range(r, indent, output)
-    local function comment_default(u, v)
-        output(u == v and " -- default\n" or "\n")
-    end
+    local function comment_default(u, v) output(u == v and " -- default\n" or "\n") end
     output("{\n")
     output("%s  start = 0x%x,", indent, r.start)
     comment_default(0, r.start)
@@ -991,9 +1125,7 @@ local function store_memory_range(r, indent, output)
 end
 
 local function store_machine_config(config, output)
-    local function comment_default(u, v)
-        output(u == v and " -- default\n" or "\n")
-    end
+    local function comment_default(u, v) output(u == v and " -- default\n" or "\n") end
 
     local def
     if remote then
@@ -1007,7 +1139,7 @@ local function store_machine_config(config, output)
     local processor = config.processor or { x = {} }
     for i = 1, 31 do
         local xi = processor.x[i] or def.processor.x[i]
-        output("      0x%x,",  xi)
+        output("      0x%x,", xi)
         comment_default(xi, def.processor.x[i])
     end
     output("    },\n")
@@ -1015,24 +1147,22 @@ local function store_machine_config(config, output)
     for i = 0, 31 do
         local xi = processor.f[i] or def.processor.f[i]
         if i == 0 then
-          output("      [0] = 0x%x,",  xi)
+            output("      [0] = 0x%x,", xi)
         else
-          output("      0x%x,",  xi)
+            output("      0x%x,", xi)
         end
         comment_default(xi, def.processor.f[i])
     end
     output("    },\n")
     local order = {}
-    for i,v in pairs(def.processor) do
-        if type(v) == "number" then
-            order[#order+1] = i
-        end
+    for i, v in pairs(def.processor) do
+        if type(v) == "number" then order[#order + 1] = i end
     end
     table.sort(order)
-    for _,csr in ipairs(order) do
+    for _, csr in ipairs(order) do
         local c = processor[csr] or def.processor[csr]
         output("    %s = 0x%x,", csr, c)
-        comment_default(c,  def.processor[csr])
+        comment_default(c, def.processor[csr])
     end
     output("  },\n")
     local ram = config.ram or {}
@@ -1102,15 +1232,15 @@ local function store_machine_config(config, output)
     output("    processor = {\n")
     output("      x = {\n")
     for i = 1, 31 do
-        local xi = uarch.processor.x[i] or def.uarch.processor.x[i]
-        output("        0x%x,",  xi)
+        local xi = config.uarch.processor.x[i] or def.uarch.processor.x[i]
+        output("        0x%x,", xi)
         comment_default(xi, def.uarch.processor.x[i])
     end
     output("      },\n")
-    output("      pc = 0x%x,", uarch.processor.pc or def.uarch.processor.pc)
-    comment_default(uarch.processor.pc, def.uarch.processor.pc)
-    output("      cycle = 0x%x", uarch.processor.cycle or def.uarch.processor.cycle)
-    comment_default(uarch.processor.cycle, def.uarch.processor.cycle)
+    output("      pc = 0x%x,", config.uarch.processor.pc or def.uarch.processor.pc)
+    comment_default(config.uarch.processor.pc, def.uarch.processor.pc)
+    output("      cycle = 0x%x", config.uarch.processor.cycle or def.uarch.processor.cycle)
+    comment_default(config.uarch.processor.cycle, def.uarch.processor.cycle)
     output("    },\n")
     output("  }\n")
     output("}\n")
@@ -1122,24 +1252,31 @@ local function resolve_flash_lengths(label_order, image_filename, length)
         local len = length[label]
         local filelen
         if filename and filename ~= "" then
-            filelen = assert(get_file_length(filename), string.format(
-                "unable to find length of flash drive '%s' image file '%s'",
-                label, filename))
+            filelen = assert(
+                get_file_length(filename),
+                string.format("unable to find length of flash drive '%s' image file '%s'", label, filename)
+            )
             if len and len ~= filelen then
-                error(string.format("flash drive '%s' length (%u) and image file '%s' length (%u) do not match", label,
-                    len, filename, filelen))
+                error(
+                    string.format(
+                        "flash drive '%s' length (%u) and image file '%s' length (%u) do not match",
+                        label,
+                        len,
+                        filename,
+                        filelen
+                    )
+                )
             else
                 length[label] = filelen
             end
         elseif not len then
-            error(string.format(
-                "flash drive '%s' nas no length or image file", label))
+            error(string.format("flash drive '%s' nas no length or image file", label))
         end
     end
 end
 
 local function resolve_flash_starts(label_order, start)
-    local auto_start = 1<<55
+    local auto_start = 1 << 55
     if next(start) == nil then
         for _, label in ipairs(label_order) do
             start[label] = auto_start
@@ -1151,27 +1288,28 @@ local function resolve_flash_starts(label_order, start)
         for _, label in ipairs(label_order) do
             local quoted = string.format("'%s'", label)
             if start[label] then
-                found[#found+1] = quoted
+                found[#found + 1] = quoted
             else
-                missing[#missing+1] = quoted
+                missing[#missing + 1] = quoted
             end
         end
         if #missing > 0 then
-            error(string.format("flash drive start set for %s but missing for %s",
-                table.concat(found, ", "), table.concat(missing, ", ")))
+            error(
+                string.format(
+                    "flash drive start set for %s but missing for %s",
+                    table.concat(found, ", "),
+                    table.concat(missing, ", ")
+                )
+            )
         end
     end
 end
 
 local function dump_value_proofs(machine, desired_proofs, has_htif_console_getchar)
-    if #desired_proofs > 0 then
-        assert(not has_htif_console_getchar,
-            "proofs are meaningless in interactive mode")
-    end
+    if #desired_proofs > 0 then assert(not has_htif_console_getchar, "proofs are meaningless in interactive mode") end
     for _, desired in ipairs(desired_proofs) do
         local proof = machine:get_proof(desired.address, desired.log2_size)
-        local out = desired.filename and assert(io.open(desired.filename, "wb"))
-            or io.stdout
+        local out = desired.filename and assert(io.open(desired.filename, "wb")) or io.stdout
         out:write("{\n")
         util.dump_json_proof(proof, out, 1)
         out:write("}\n")
@@ -1187,9 +1325,7 @@ local function append(a, b)
 end
 
 local function create_machine(config_or_dir, runtime)
-    if remote then
-        return remote.machine(config_or_dir, runtime)
-    end
+    if remote then return remote.machine(config_or_dir, runtime) end
     return cartesi.machine(config_or_dir, runtime)
 end
 
@@ -1206,22 +1342,24 @@ if remote_address then
     stderr("Connected: remote version is %d.%d.%d\n", v.major, v.minor, v.patch)
     local shutdown = function() remote.shutdown() end
     if remote_shutdown then
-        setmetatable(remote_shutdown_deleter, { __gc = function()
-            stderr("Shutting down remote cartesi machine\n")
-            pcall(shutdown)
-        end })
+        setmetatable(remote_shutdown_deleter, {
+            __gc = function()
+                stderr("Shutting down remote cartesi machine\n")
+                pcall(shutdown)
+            end,
+        })
     end
 end
 
 local runtime = {
     concurrency = {
-        update_merkle_tree = concurrency_update_merkle_tree
+        update_merkle_tree = concurrency_update_merkle_tree,
     },
     htif = {
         no_console_putchar = htif_no_console_putchar,
     },
     skip_root_hash_check = skip_root_hash_check,
-    skip_version_check = skip_version_check
+    skip_version_check = skip_version_check,
 }
 
 local main_machine
@@ -1241,20 +1379,20 @@ else
             -- Request automatic default values for versioning CSRs
             mimpid = -1,
             marchid = -1,
-            mvendorid = -1
+            mvendorid = -1,
         },
         rom = {
             image_filename = rom_image_filename,
-            bootargs = rom_bootargs
+            bootargs = rom_bootargs,
         },
         ram = {
             image_filename = ram_image_filename,
-            length = ram_length
+            length = ram_length,
         },
         htif = {
             console_getchar = htif_console_getchar,
             yield_automatic = htif_yield_automatic,
-            yield_manual = htif_yield_manual
+            yield_manual = htif_yield_manual,
         },
         rollup = rollup,
         uarch = uarch,
@@ -1262,31 +1400,27 @@ else
     }
     local mtdparts = {}
     for i, label in ipairs(flash_label_order) do
-        config.flash_drive[#config.flash_drive+1] = {
+        config.flash_drive[#config.flash_drive + 1] = {
             image_filename = flash_image_filename[label],
             shared = flash_shared[label],
             start = flash_start[label],
-            length = flash_length[label]
+            length = flash_length[label],
         }
-        mtdparts[#mtdparts+1] = string.format("flash.%d:-(%s)", i-1, label)
+        mtdparts[#mtdparts + 1] = string.format("flash.%d:-(%s)", i - 1, label)
     end
     if #mtdparts > 0 then
-        config.rom.bootargs = append(config.rom.bootargs, "mtdparts=" ..
-            table.concat(mtdparts, ";"))
+        config.rom.bootargs = append(config.rom.bootargs, "mtdparts=" .. table.concat(mtdparts, ";"))
     end
 
-    config.rom.bootargs = append(
-        append(config.rom.bootargs, append_rom_bootargs),
-        quiet and ' splash=no' or '')
+    config.rom.bootargs = append(append(config.rom.bootargs, append_rom_bootargs), quiet and " splash=no" or "")
 
     if #exec_arguments > 0 then
-        config.rom.bootargs = append(config.rom.bootargs, "-- " ..
-            table.concat(exec_arguments, " "))
+        config.rom.bootargs = append(config.rom.bootargs, "-- " .. table.concat(exec_arguments, " "))
     end
 
     if load_config then
         local env = {}
-        local ok, ret = loadfile(load_config, 't', env)
+        local ok, ret = loadfile(load_config, "t", env)
         if ok then
             local chunk = ok
             ok, ret = pcall(chunk)
@@ -1295,7 +1429,7 @@ else
             stderr("Failed to load machine config (%s):\n", load_config)
             error(ret)
         end
-        config = setmetatable(ret, {__index = config})
+        config = setmetatable(ret, { __index = config })
     end
 
     main_machine = create_machine(config, runtime)
@@ -1304,13 +1438,13 @@ end
 -- obtain config from instantiated machine
 local main_config = main_machine:get_initial_config()
 
-for _,r in ipairs(memory_range_replace) do
+for _, r in ipairs(memory_range_replace) do
     main_machine:replace_memory_range(r)
 end
 
 if type(store_config) == "string" then
     store_config = assert(io.open(store_config, "w"))
-    store_machine_config(main_config, function (...) store_config:write(string.format(...)) end)
+    store_machine_config(main_config, function(...) store_config:write(string.format(...)) end)
     store_config:close()
 end
 
@@ -1329,9 +1463,7 @@ local htif_yield_mode = {
     [cartesi.machine.HTIF_YIELD_AUTOMATIC] = "Automatic",
 }
 
-local function is_power_of_two(value)
-    return value > 0 and ((value & (value - 1)) == 0)
-end
+local function is_power_of_two(value) return value > 0 and ((value & (value - 1)) == 0) end
 
 local function ilog2(value)
     value = assert(math.tointeger(value), "expected integer")
@@ -1347,12 +1479,16 @@ end
 local function check_rollup_memory_range_config(range, name)
     assert(range, string.format("rollup range %s must be defined", name))
     assert(not range.shared, string.format("rollup range %s cannot be shared", name))
-    assert(is_power_of_two(range.length), string.format("rollup range %s length not a power of two (%u)", name,
-        range.length))
+    assert(
+        is_power_of_two(range.length),
+        string.format("rollup range %s length not a power of two (%u)", name, range.length)
+    )
     local log = ilog2(range.length)
     local aligned_start = (range.start >> log) << log
-    assert(aligned_start == range.start,
-        string.format("rollup range %s start not aligned to its power of two size", name))
+    assert(
+        aligned_start == range.start,
+        string.format("rollup range %s start not aligned to its power of two size", name)
+    )
     range.image_filename = nil
 end
 
@@ -1372,7 +1508,7 @@ end
 local function get_and_print_yield(machine, htif)
     local cmd, reason, data = get_yield(machine)
     if cmd == cartesi.machine.HTIF_YIELD_AUTOMATIC and reason == cartesi.machine.HTIF_YIELD_REASON_PROGRESS then
-        stderr("Progress: %6.2f" .. (htif.console_getchar and "\n" or "\r"), data/10)
+        stderr("Progress: %6.2f" .. (htif.console_getchar and "\n" or "\r"), data / 10)
     else
         local cmd_str = htif_yield_mode[cmd] or "Unknown"
         local reason_str = htif_yield_reason[reason] or "unknown"
@@ -1389,10 +1525,8 @@ local function save_rollup_hashes(machine, range, filename)
     local zeros = string.rep("\0", hash_len)
     local offset = 0
     while offset < range.length do
-        local hash = machine:read_memory(range.start+offset, 32)
-        if hash == zeros then
-            break
-        end
+        local hash = machine:read_memory(range.start + offset, 32)
+        if hash == zeros then break end
         assert(f:write(hash))
         offset = offset + hash_len
     end
@@ -1402,9 +1536,7 @@ end
 local function instantiate_filename(pattern, values)
     -- replace escaped % with something safe
     pattern = string.gsub(pattern, "%\\%%", "\0")
-    pattern = string.gsub(pattern, "%%(%a)", function(s)
-        return values[s] or s
-    end)
+    pattern = string.gsub(pattern, "%%(%a)", function(s) return values[s] or s end)
     -- restore escaped %
     return (string.gsub(pattern, "\0", "%"))
 end
@@ -1439,61 +1571,61 @@ local function load_rollup_query(machine, config, inspect)
 end
 
 local function save_rollup_advance_state_voucher(machine, config, advance)
-    local values = { e = advance.epoch_index, i = advance.next_input_index-1, o =  advance.voucher_index }
+    local values = { e = advance.epoch_index, i = advance.next_input_index - 1, o = advance.voucher_index }
     local name = instantiate_filename(advance.voucher, values)
     stderr("Storing %s\n", name)
     local f = assert(io.open(name, "wb"))
     -- skip address and offset to reach payload length
-    local length = string.unpack(">I8", machine:read_memory(config.start+3*32-8, 8))
+    local length = string.unpack(">I8", machine:read_memory(config.start + 3 * 32 - 8, 8))
     -- add address, offset, and payload length to amount to be read
-    length = length+3*32
+    length = length + 3 * 32
     assert(f:write(machine:read_memory(config.start, length)))
     f:close()
 end
 
 local function save_rollup_advance_state_notice(machine, config, advance)
-    local values = { e = advance.epoch_index, i = advance.next_input_index-1, o =  advance.notice_index }
+    local values = { e = advance.epoch_index, i = advance.next_input_index - 1, o = advance.notice_index }
     local name = instantiate_filename(advance.notice, values)
     stderr("Storing %s\n", name)
     local f = assert(io.open(name, "wb"))
     -- skip offset to reach payload length
-    local length = string.unpack(">I8", machine:read_memory(config.start+2*32-8, 8))
+    local length = string.unpack(">I8", machine:read_memory(config.start + 2 * 32 - 8, 8))
     -- add offset and payload length to amount to be read
-    length = length+2*32
+    length = length + 2 * 32
     assert(f:write(machine:read_memory(config.start, length)))
     f:close()
 end
 
 local function dump_exception(machine, config)
     -- skip offset to reach payload length
-    local length = string.unpack(">I8", machine:read_memory(config.start+2*32-8, 8))
+    local length = string.unpack(">I8", machine:read_memory(config.start + 2 * 32 - 8, 8))
     -- add offset and payload length to amount to be read
-    local payload = machine:read_memory(config.start+2*32, length)
-    stderr("Rollup exception with payload: %q\n", payload);
+    local payload = machine:read_memory(config.start + 2 * 32, length)
+    stderr("Rollup exception with payload: %q\n", payload)
 end
 
 local function save_rollup_advance_state_report(machine, config, advance)
-    local values = { e = advance.epoch_index, i = advance.next_input_index-1, o =  advance.report_index }
+    local values = { e = advance.epoch_index, i = advance.next_input_index - 1, o = advance.report_index }
     local name = instantiate_filename(advance.report, values)
     stderr("Storing %s\n", name)
     local f = assert(io.open(name, "wb"))
     -- skip offset to reach payload length
-    local length = string.unpack(">I8", machine:read_memory(config.start+2*32-8, 8))
+    local length = string.unpack(">I8", machine:read_memory(config.start + 2 * 32 - 8, 8))
     -- add offset and payload length to amount to be read
-    length = length+2*32
+    length = length + 2 * 32
     assert(f:write(machine:read_memory(config.start, length)))
     f:close()
 end
 
 local function save_rollup_inspect_state_report(machine, config, inspect)
-    local values = { o =  inspect.report_index }
+    local values = { o = inspect.report_index }
     local name = instantiate_filename(inspect.report, values)
     stderr("Storing %s\n", name)
     local f = assert(io.open(name, "wb"))
     -- skip offset to reach payload length
-    local length = string.unpack(">I8", machine:read_memory(config.start+2*32-8, 8))
+    local length = string.unpack(">I8", machine:read_memory(config.start + 2 * 32 - 8, 8))
     -- add offset and payload length to amount to be read
-    length = length+2*32
+    length = length + 2 * 32
     assert(f:write(machine:read_memory(config.start, length)))
     f:close()
 end
@@ -1527,9 +1659,9 @@ if json_steps then
         local final_mcycle = machine:read_mcycle()
         local final_uarch_cycle = machine:read_uarch_cycle()
         -- Save log recorded during micro step
-        if steps_count > 1 then json_steps:write(',\n') end
-        util.dump_json_log(log, init_mcycle,  init_uarch_cycle, final_mcycle, final_uarch_cycle,  json_steps, 1)
-        if  machine:read_uarch_halt_flag() then
+        if steps_count > 1 then json_steps:write(",\n") end
+        util.dump_json_log(log, init_mcycle, init_uarch_cycle, final_mcycle, final_uarch_cycle, json_steps, 1)
+        if machine:read_uarch_halt_flag() then
             -- microarchitecture halted because it finished interpreting a whole mcycle
             machine:reset_iflags_Y() -- move past any potential yield
             -- Reset uarch_halt_flag in order to allow interpreting the next mcycle
@@ -1541,27 +1673,23 @@ if json_steps then
         end
         stderr("%u.%u -> %u.%u\n", init_mcycle, init_uarch_cycle, final_mcycle, final_uarch_cycle)
     end
-    json_steps:write('\n]\n')
+    json_steps:write("\n]\n")
     json_steps:close()
-    if store_dir then
-        store_machine(machine, config, store_dir)
-    end
+    if store_dir then store_machine(machine, config, store_dir) end
 else
     local gdb_stub
     if gdb_address then
-        assert(periodic_hashes_start == 0 and periodic_hashes_period == math.maxinteger,
-          "periodic hashing is not supported when debugging")
-        gdb_stub = require"cartesi.gdbstub".new(machine)
-        local address, port = gdb_address:match('^(.*):(%d+)$')
+        assert(
+            periodic_hashes_start == 0 and periodic_hashes_period == math.maxinteger,
+            "periodic hashing is not supported when debugging"
+        )
+        gdb_stub = require("cartesi.gdbstub").new(machine)
+        local address, port = gdb_address:match("^(.*):(%d+)$")
         assert(address and port, "invalid address for GDB")
         gdb_stub:listen_and_wait_gdb(address, tonumber(port))
     end
-    if config.htif.console_getchar then
-        stderr("Running in interactive mode!\n")
-    end
-    if store_config == stderr then
-        store_machine_config(config, stderr)
-    end
+    if config.htif.console_getchar then stderr("Running in interactive mode!\n") end
+    if store_config == stderr then store_machine_config(config, stderr) end
     if rollup_advance or rollup_inspect then
         check_rollup_htif_config(config.htif)
         assert(config.rollup, "rollup device must be present")
@@ -1600,9 +1728,9 @@ else
     while math.ult(cycles, max_mcycle) do
         local next_mcycle = math.min(next_hash_mcycle, max_mcycle)
         if gdb_stub and gdb_stub:is_connected() then
-          gdb_stub:run(next_mcycle)
+            gdb_stub:run(next_mcycle)
         else
-          machine:run(next_mcycle)
+            machine:run(next_mcycle)
         end
         cycles = machine:read_mcycle()
         -- deal with halt
@@ -1634,14 +1762,10 @@ else
                     assert(reason == cartesi.machine.HTIF_YIELD_REASON_RX_ACCEPTED, "invalid manual yield reason")
                 end
                 stderr("\nEpoch %d before input %d\n", rollup_advance.epoch_index, rollup_advance.next_input_index)
-                if rollup_advance.hashes then
-                    print_root_hash(machine)
-                end
+                if rollup_advance.hashes then print_root_hash(machine) end
                 machine:snapshot()
                 load_rollup_input_and_metadata(machine, config.rollup, rollup_advance)
-                if rollup_advance.hashes then
-                    print_root_hash(machine)
-                end
+                if rollup_advance.hashes then print_root_hash(machine) end
                 machine:reset_iflags_Y()
                 machine:write_htif_fromhost_data(0) -- tell machine it is an rollup_advance state, but this is default
                 rollup_advance.voucher_index = 0
@@ -1680,7 +1804,7 @@ else
                     rollup_advance.report_index = rollup_advance.report_index + 1
                 end
                 -- ignore other reasons
-            -- we have feed the inspect state query
+                -- we have feed the inspect state query
             elseif rollup_inspect and not rollup_inspect.query then
                 if reason == cartesi.machine.HTIF_YIELD_REASON_TX_REPORT then
                     save_rollup_inspect_state_report(machine, config.rollup.tx_buffer, rollup_inspect)
@@ -1690,9 +1814,7 @@ else
             end
             -- otherwise ignore
         end
-        if machine:read_iflags_Y() then
-            break
-        end
+        if machine:read_iflags_Y() then break end
         if cycles == next_hash_mcycle then
             print_root_hash(machine)
             next_hash_mcycle = next_hash_mcycle + periodic_hashes_period
@@ -1705,45 +1827,36 @@ else
         if machine:run_uarch(max_uarch_cycle) == cartesi.UARCH_BREAK_REASON_UARCH_HALTED then
             -- Microarchitecture  halted. This means that one "macro" instruction was totally executed
             -- The mcycle counter was incremented, unless the machine was already halted
-            if machine:read_iflags_H()  and not previously_halted then
-                stderr("Halted\n")
-            end
+            if machine:read_iflags_H() and not previously_halted then stderr("Halted\n") end
             stderr("Cycles: %u\n", machine:read_mcycle())
-            if auto_reset_uarch_state  then
+            if auto_reset_uarch_state then
                 machine:reset_uarch_state()
             else
                 stderr("uCycles: %u\n", machine:read_uarch_cycle())
             end
         end
     end
-    if gdb_stub then
-        gdb_stub:close()
-    end
+    if gdb_stub then gdb_stub:close() end
     if step_uarch then
         assert(not config.htif.console_getchar, "micro step proof is meaningless in interactive mode")
         stderr("Gathering micro step log: please wait\n")
-        util.dump_log(machine:step_uarch{ proofs = true, annotations = true }, io.stderr)
+        util.dump_log(machine:step_uarch({ proofs = true, annotations = true }), io.stderr)
     end
-    if dump_pmas then
-        machine:dump_pmas()
-    end
+    if dump_pmas then machine:dump_pmas() end
     if final_hash then
         assert(not config.htif.console_getchar, "hashes are meaningless in interactive mode")
         print_root_hash(machine, stderr_unsilenceable)
     end
     dump_value_proofs(machine, final_proof, config.htif.console_getchar)
-    if store_dir then
-        store_machine(machine, config, store_dir)
-    end
+    if store_dir then store_machine(machine, config, store_dir) end
     if assert_rolling_template then
         local cmd, reason = get_yield(machine)
-        if not (cmd == cartesi.machine.HTIF_YIELD_MANUAL and
-                reason == cartesi.machine.HTIF_YIELD_REASON_RX_ACCEPTED) then
+        if
+            not (cmd == cartesi.machine.HTIF_YIELD_MANUAL and reason == cartesi.machine.HTIF_YIELD_REASON_RX_ACCEPTED)
+        then
             exit_code = 2
         end
     end
-    if not remote or remote_destroy then
-        machine:destroy()
-    end
+    if not remote or remote_destroy then machine:destroy() end
     os.exit(exit_code, true)
 end

--- a/src/cartesi/gdbstub.lua
+++ b/src/cartesi/gdbstub.lua
@@ -17,10 +17,10 @@
 local GDBSTUB_DEBUG_PROTOCOL = false
 
 local signals = {
-  SIGINT = 2,   -- signal sent to GDB when reaching a fixed number of cycle steps
-  SIGQUIT = 3,  -- signal sent to GDB when max cycle is reached
-  SIGTRAP = 5,  -- signal sent to GDB when a breakpoint is reached
-  SIGTERM = 15, -- signal sent to GDB when the machine halts
+    SIGINT = 2, -- signal sent to GDB when reaching a fixed number of cycle steps
+    SIGQUIT = 3, -- signal sent to GDB when max cycle is reached
+    SIGTRAP = 5, -- signal sent to GDB when a breakpoint is reached
+    SIGTERM = 15, -- signal sent to GDB when the machine halts
 }
 
 local GDBStub = {}
@@ -28,542 +28,494 @@ GDBStub.__index = GDBStub
 
 -- Returns x with the order of the bytes reversed.
 -- Used to convert 64 bit integers between little-endian and big-endian.
-local function bswap64(x)
-  return ('<I8'):unpack(('>I8'):pack(x))
-end
+local function bswap64(x) return ("<I8"):unpack((">I8"):pack(x)) end
 
-local function reg2hex(x)
-  return ('%016x'):format(bswap64(x))
-end
+local function reg2hex(x) return ("%016x"):format(bswap64(x)) end
 
-local function byte2hex(x)
-  return ('%02x'):format(x)
-end
+local function byte2hex(x) return ("%02x"):format(x) end
 
-local function chr2hex(c)
-  return ('%02x'):format(c:byte())
-end
+local function chr2hex(c) return ("%02x"):format(c:byte()) end
 
-local function str2hex(s)
-  return s:gsub('.', chr2hex)
-end
+local function str2hex(s) return s:gsub(".", chr2hex) end
 
-local function hex2int(x)
-  return tonumber(x, 16)
-end
+local function hex2int(x) return tonumber(x, 16) end
 
-local function hex2reg(x)
-  return bswap64(hex2int(x))
-end
+local function hex2reg(x) return bswap64(hex2int(x)) end
 
-local function hex2chr(x)
-  return string.char(tonumber(x, 16))
-end
+local function hex2chr(x) return string.char(tonumber(x, 16)) end
 
-local function hex2str(s)
-  return s:gsub('%x%x', hex2chr)
-end
+local function hex2str(s) return s:gsub("%x%x", hex2chr) end
 
-local function xorchr(c)
-  return string.char(c:byte() ~ 0x20)
-end
+local function xorchr(c) return string.char(c:byte() ~ 0x20) end
 
 local function stderr(fmt, ...)
-  io.stderr:write(string.format(fmt, ...), '\n')
-  io.stderr:flush()
+    io.stderr:write(string.format(fmt, ...), "\n")
+    io.stderr:flush()
 end
 
 -- Creates a new GDBStub.
 function GDBStub.new(machine)
-  return setmetatable({
-    machine=machine,
-    breakpoints={}
-  }, GDBStub)
+    return setmetatable({
+        machine = machine,
+        breakpoints = {},
+    }, GDBStub)
 end
 
 -- Listens at address:port and waits GDB to connect.
 function GDBStub:listen_and_wait_gdb(address, port)
-  address = address or '127.0.0.1'
-  port = port or 1234
-  -- listens and wair for GDB connection
-  local socket = require("socket")
-  local server = assert(socket.bind(address, port))
-  stderr('Waiting GDB to connect at %s:%d...', address, port)
-  local conn = assert(server:accept())
-  -- GDB connected, we can close the server
-  assert(server:close())
-  -- the first received byte should be '+'
-  local c = assert(conn:receive(1))
-  assert(c == '+', 'expected acknowledge character on connection start')
-  stderr('GDB connected!')
-  -- enable TCP nodelay, necessary to have fast interactive session
-  assert(conn:setoption('tcp-nodelay', true))
-  self.conn = conn
+    address = address or "127.0.0.1"
+    port = port or 1234
+    -- listens and wair for GDB connection
+    local socket = require("socket")
+    local server = assert(socket.bind(address, port))
+    stderr("Waiting GDB to connect at %s:%d...", address, port)
+    local conn = assert(server:accept())
+    -- GDB connected, we can close the server
+    assert(server:close())
+    -- the first received byte should be '+'
+    local c = assert(conn:receive(1))
+    assert(c == "+", "expected acknowledge character on connection start")
+    stderr("GDB connected!")
+    -- enable TCP nodelay, necessary to have fast interactive session
+    assert(conn:setoption("tcp-nodelay", true))
+    self.conn = conn
 end
 
 -- Receive a packet from GDB.
 function GDBStub:_recv()
-  -- receive packet data
-  local escaped_data, sum = {}, 0
-  while true do
-    local c = assert(self.conn:receive(1))
-    if c == '#' then break end
-    sum = sum + c:byte()
-    escaped_data[#escaped_data+1] = c
-  end
-  escaped_data = table.concat(escaped_data)
-  -- validate checksum
-  local checksum = assert(self.conn:receive(2))
-  if sum % 256 ~= hex2int(checksum) then
-    assert(self.conn:send('-')) -- request retransmission
-    stderr('Received a packet with invalid checksum from GDB')
-    return nil
-  end
-  -- send packet acknowledge
-  if not self.noack then
-    assert(self.conn:send('+')) -- send acknowledge packet
-  end
-  -- escape packet data
-  local data = escaped_data:gsub('}(.)', xorchr)
-  if GDBSTUB_DEBUG_PROTOCOL then
-    stderr('Packet recv: %s', data)
-  end
-  return data
+    -- receive packet data
+    local escaped_data, sum = {}, 0
+    while true do
+        local c = assert(self.conn:receive(1))
+        if c == "#" then break end
+        sum = sum + c:byte()
+        escaped_data[#escaped_data + 1] = c
+    end
+    escaped_data = table.concat(escaped_data)
+    -- validate checksum
+    local checksum = assert(self.conn:receive(2))
+    if sum % 256 ~= hex2int(checksum) then
+        assert(self.conn:send("-")) -- request retransmission
+        stderr("Received a packet with invalid checksum from GDB")
+        return nil
+    end
+    -- send packet acknowledge
+    if not self.noack then
+        assert(self.conn:send("+")) -- send acknowledge packet
+    end
+    -- escape packet data
+    local data = escaped_data:gsub("}(.)", xorchr)
+    if GDBSTUB_DEBUG_PROTOCOL then stderr("Packet recv: %s", data) end
+    return data
 end
 
 -- Send a packet to GDB.
 function GDBStub:_send(data)
-  -- escape packet data
-  local escape_set = {['#']=true, ['$']=true, ['}']=true, ['*']=true}
-  local escaped_data = data:gsub('.', function(c)
-    return escape_set[c] and '}'..xorchr(c) or c
-  end)
-  -- compute checksum
-  local sum = 0
-  for c in escaped_data:gmatch('.') do
-    sum = sum + c:byte()
-  end
-  local checksum = byte2hex(sum % 256)
-  -- send packet
-  local packet_data = '$'..escaped_data..'#'..checksum
-  assert(self.conn:send(packet_data))
-  if GDBSTUB_DEBUG_PROTOCOL then
-    stderr('Packet sent: %s', data)
-  end
-  -- wait for packet acknowledge
-  if not self.noack then
-    local c = assert(self.conn:receive(1))
-    assert(c == '+', 'GDB did not acknowledged last packet')
-  end
-  return true
+    -- escape packet data
+    local escape_set = { ["#"] = true, ["$"] = true, ["}"] = true, ["*"] = true }
+    local escaped_data = data:gsub(".", function(c) return escape_set[c] and "}" .. xorchr(c) or c end)
+    -- compute checksum
+    local sum = 0
+    for c in escaped_data:gmatch(".") do
+        sum = sum + c:byte()
+    end
+    local checksum = byte2hex(sum % 256)
+    -- send packet
+    local packet_data = "$" .. escaped_data .. "#" .. checksum
+    assert(self.conn:send(packet_data))
+    if GDBSTUB_DEBUG_PROTOCOL then stderr("Packet sent: %s", data) end
+    -- wait for packet acknowledge
+    if not self.noack then
+        local c = assert(self.conn:receive(1))
+        assert(c == "+", "GDB did not acknowledged last packet")
+    end
+    return true
 end
 
 -- Sent to GDB when a packet is handled with success.
-function GDBStub:_send_ok()
-  return self:_send('OK')
-end
+function GDBStub:_send_ok() return self:_send("OK") end
 
 -- Sent to GDB when a packet is not handled, due some error.
-function GDBStub:_send_error()
-  return self:_send('E01')
-end
+function GDBStub:_send_error() return self:_send("E01") end
 
 -- Sent to GDB when a packet is not supported.
-function GDBStub:_send_unsupported()
-  return self:_send('')
-end
+function GDBStub:_send_unsupported() return self:_send("") end
 
 -- Sent to GDB when stopping the machine, using `signal` as the reason for stopping.
-function GDBStub:_send_signal(signal)
-  return self:_send('S'..byte2hex(signal))
-end
+function GDBStub:_send_signal(signal) return self:_send("S" .. byte2hex(signal)) end
 
 -- Sent to GDB when replying custom command packets.
-function GDBStub:_send_rcmd_reply(res)
-  return self:_send('O'..str2hex(tostring(res)))
-end
+function GDBStub:_send_rcmd_reply(res) return self:_send("O" .. str2hex(tostring(res))) end
 
 -- GDB is asking for a reason why the target halted.
-function GDBStub:_handle_target_halt()
-  return self:_send_signal(signals.SIGTRAP)
-end
+function GDBStub:_handle_target_halt() return self:_send_signal(signals.SIGTRAP) end
 
 -- GDB is asking to execute "v" commands.
 function GDBStub:_handle_v_command(_, command)
-  if command == 'vMustReplyEmpty' then -- GDB is testing if our protocol responds with unknown packets
-    return self:_send('') -- Must reply with an empty packet
-  elseif command == 'vCont?' then -- GDB is checking if we support vCont actions.
-    return self:_send_unsupported()
-  elseif command:find('^vKill') then -- GDB is killing the machine
-    return self:_handle_kill()
-  end
+    if command == "vMustReplyEmpty" then -- GDB is testing if our protocol responds with unknown packets
+        return self:_send("") -- Must reply with an empty packet
+    elseif command == "vCont?" then -- GDB is checking if we support vCont actions.
+        return self:_send_unsupported()
+    elseif command:find("^vKill") then -- GDB is killing the machine
+        return self:_handle_kill()
+    end
 end
 
 -- GDB is querying machine or protocol information.
 function GDBStub:_handle_query(_, query)
-  if query:find('^qSupported:') then -- GDB is checking for supported features.
-    local supported_features = {
-      ["hwbreak"] = true, -- we only support hardware breakpoints
-    }
-    local res = {
-      'QStartNoAckMode+' -- we want to disable acknowledge packets, since its redundant with TCP
-    }
-    for feature in query:gmatch('([A-Za-z-]+)%+;?') do
-      if supported_features[feature] then
-        table.insert(res, feature..'+')
-      end
-    end
-    -- reply with features we support
-    res = table.concat(res, ';')
-    return self:_send(res)
-  elseif query == 'qTStatus' then -- GDB is asking whether a trace experiment is currently running
-    return self:_send_unsupported()
-  elseif query == 'qfThreadInfo' or query == 'qC' or query:find('^qL') then -- GDB is asking thread info
-    return self:_send_unsupported()
-  elseif query == 'qAttached' then -- GDB is asking if we are attached to an existing process
-    return self:_send('1') -- reply with '1', indicating that our remote server is attached
-  elseif query == 'qSymbol::' then -- GDB is prepared to serve symbol lookup requests
-    return self:_send_ok()
-  elseif query == 'qOffsets' then-- GDB is requesting section offsets that the target used when relocating the image
-    -- let GDB decide the text offset based in the binary file being debugged
-    return self:_send_unsupported()
-  elseif query:find('^qRcmd,') then -- custom command
-    local payload = hex2str(query:sub(7))
-    if payload:find('^stepc %d+$') then -- step a fixed number of cycles
-      self.mcycle_limit = self.machine:read_mcycle() + tonumber(payload:match('^stepc (%d+)$'))
-      return self:_send_ok()
-    elseif payload:find('^stepu %d+$') then -- step until a cycle number
-      self.mcycle_limit = math.max(self.machine:read_mcycle(), tonumber(payload:match('^stepu (%d+)$')))
-      return self:_send_ok()
-    elseif payload == 'stepc_clear' then -- remove stepping breakpoint
-      self.mcycle_limit = nil
-      return self:_send_ok()
-    elseif payload == 'cycles' then -- print current cycle
-      self:_send_rcmd_reply(string.format('%u\n', self.machine:read_mcycle()))
-      return self:_send_ok()
-    elseif payload:find('^csr [%w_]+$') then -- read machine CSRs
-      local csr_name = payload:match('^csr ([%w_]+)$')
-      local read_method_name = 'read_'..csr_name
-      local read_method = self.machine[read_method_name]
-      if not read_method then return self:_send_unsupported() end
-      local ok, res = pcall(read_method, self.machine)
-      if not ok or res == nil then return self:_send_unsupported() end
-      if math.type(res) == 'integer' then
-        self:_send_rcmd_reply(string.format('0x%x (%d)\n', res, res))
-      else
-        self:_send_rcmd_reply(tostring(res)..'\n')
-      end
-      return self:_send_ok()
-    elseif payload:find('^csr [%w_]+%=.*$') then -- write machine CSRs
-      local csr_name, val = payload:match('^csr ([%w_]+)%=(.*)$')
-      local write_method_name = 'write_'..csr_name
-      local read_method_name = 'read_'..csr_name
-      local write_method = self.machine[write_method_name]
-      local read_method = self.machine[read_method_name]
-      if not write_method or not read_method then return self:_send_unsupported() end
-      val = tonumber(val)
-      if not val or math.type(val) ~= 'integer' then
-        self:_send_rcmd_reply('ERROR: malformed CSR integer\n')
+    if query:find("^qSupported:") then -- GDB is checking for supported features.
+        local supported_features = {
+            ["hwbreak"] = true, -- we only support hardware breakpoints
+        }
+        local res = {
+            "QStartNoAckMode+", -- we want to disable acknowledge packets, since its redundant with TCP
+        }
+        for feature in query:gmatch("([A-Za-z-]+)%+;?") do
+            if supported_features[feature] then table.insert(res, feature .. "+") end
+        end
+        -- reply with features we support
+        res = table.concat(res, ";")
+        return self:_send(res)
+    elseif query == "qTStatus" then -- GDB is asking whether a trace experiment is currently running
+        return self:_send_unsupported()
+    elseif query == "qfThreadInfo" or query == "qC" or query:find("^qL") then -- GDB is asking thread info
+        return self:_send_unsupported()
+    elseif query == "qAttached" then -- GDB is asking if we are attached to an existing process
+        return self:_send("1") -- reply with '1', indicating that our remote server is attached
+    elseif query == "qSymbol::" then -- GDB is prepared to serve symbol lookup requests
         return self:_send_ok()
-      end
-      local write_ok = pcall(write_method, self.machine, val)
-      if not write_ok then return self:_send_unsupported() end
-      -- print the new CSR value
-      local ok, res = pcall(read_method, self.machine)
-      if ok and res ~= nil then
-        if math.type(res) == 'integer' then
-          self:_send_rcmd_reply(string.format('%s = 0x%x (%d)\n', csr_name, res, res))
-        else
-          self:_send_rcmd_reply(tostring(res)..'\n')
+    elseif query == "qOffsets" then -- GDB is requesting section offsets that the target used when relocating the image
+        -- let GDB decide the text offset based in the binary file being debugged
+        return self:_send_unsupported()
+    elseif query:find("^qRcmd,") then -- custom command
+        local payload = hex2str(query:sub(7))
+        if payload:find("^stepc %d+$") then -- step a fixed number of cycles
+            self.mcycle_limit = self.machine:read_mcycle() + tonumber(payload:match("^stepc (%d+)$"))
+            return self:_send_ok()
+        elseif payload:find("^stepu %d+$") then -- step until a cycle number
+            self.mcycle_limit = math.max(self.machine:read_mcycle(), tonumber(payload:match("^stepu (%d+)$")))
+            return self:_send_ok()
+        elseif payload == "stepc_clear" then -- remove stepping breakpoint
+            self.mcycle_limit = nil
+            return self:_send_ok()
+        elseif payload == "cycles" then -- print current cycle
+            self:_send_rcmd_reply(string.format("%u\n", self.machine:read_mcycle()))
+            return self:_send_ok()
+        elseif payload:find("^csr [%w_]+$") then -- read machine CSRs
+            local csr_name = payload:match("^csr ([%w_]+)$")
+            local read_method_name = "read_" .. csr_name
+            local read_method = self.machine[read_method_name]
+            if not read_method then return self:_send_unsupported() end
+            local ok, res = pcall(read_method, self.machine)
+            if not ok or res == nil then return self:_send_unsupported() end
+            if math.type(res) == "integer" then
+                self:_send_rcmd_reply(string.format("0x%x (%d)\n", res, res))
+            else
+                self:_send_rcmd_reply(tostring(res) .. "\n")
+            end
+            return self:_send_ok()
+        elseif payload:find("^csr [%w_]+%=.*$") then -- write machine CSRs
+            local csr_name, val = payload:match("^csr ([%w_]+)%=(.*)$")
+            local write_method_name = "write_" .. csr_name
+            local read_method_name = "read_" .. csr_name
+            local write_method = self.machine[write_method_name]
+            local read_method = self.machine[read_method_name]
+            if not write_method or not read_method then return self:_send_unsupported() end
+            val = tonumber(val)
+            if not val or math.type(val) ~= "integer" then
+                self:_send_rcmd_reply("ERROR: malformed CSR integer\n")
+                return self:_send_ok()
+            end
+            local write_ok = pcall(write_method, self.machine, val)
+            if not write_ok then return self:_send_unsupported() end
+            -- print the new CSR value
+            local ok, res = pcall(read_method, self.machine)
+            if ok and res ~= nil then
+                if math.type(res) == "integer" then
+                    self:_send_rcmd_reply(string.format("%s = 0x%x (%d)\n", csr_name, res, res))
+                else
+                    self:_send_rcmd_reply(tostring(res) .. "\n")
+                end
+            end
+            return self:_send_ok()
+        elseif payload == "hash" then -- print machine state hash
+            if not self.performed_first_hash then
+                self:_send_rcmd_reply("GDB may complain about packet errors due to command timeout, ignore them.\n")
+                self:_send_rcmd_reply("Performing first hash, this may take a while...\n")
+                self.performed_first_hash = true
+            end
+            local hash = self.machine:get_root_hash()
+            self:_send_rcmd_reply(string.format("%u: %s\n", self.machine:read_mcycle(), str2hex(hash)))
+            return self:_send_ok()
+        elseif payload:find("^store .*$") then -- store the machine state
+            local store_dir = payload:match("^store (.*)$")
+            self:_send_rcmd_reply("GDB may complain about packet errors due to command timeout, ignore them.\n")
+            self:_send_rcmd_reply("Storing the machine, this may take a while...\n")
+            local ok, res = pcall(self.machine.store, self.machine, store_dir)
+            if not ok then
+                self:_send_rcmd_reply(string.format("ERROR: machine store failed: %s\n", res))
+            else
+                self:_send_rcmd_reply(string.format('machine stated saved to "%s"\n', store_dir))
+            end
+            return self:_send_ok()
+        elseif payload:find([[^lua ["'].*["']$]]) then -- execute arbitrary lua code
+            local source = payload:match([[^lua ["'](.*)["']$]])
+            local env = { machine = self.machine }
+            setmetatable(env, { __index = _ENV })
+            local func, err = load(source, "@gdb_command_chunk", "t", env)
+            if not func then
+                self:_send_rcmd_reply(string.format("ERROR: %s\n", err))
+            else
+                local ok, ret = pcall(func)
+                if not ok then
+                    self:_send_rcmd_reply(string.format("ERROR: %s\n", ret))
+                elseif ret ~= nil then
+                    self:_send_rcmd_reply(tostring(ret) .. "\n")
+                end
+            end
+            return self:_send_ok()
+        elseif payload:find("^breakpc [xXa-fA-F0-9]+$") then
+            local pcstr = payload:match("^breakpc ([xXa-fA-F0-9]+)$")
+            local pc = tonumber(pcstr)
+            if pc then
+                if self.breakpoints[pc] then
+                    self.breakpoints[pc] = nil
+                    self:_send_rcmd_reply(string.format("disabled PC breakpoint at 0x%x\n", pc))
+                else
+                    self:_send_rcmd_reply(string.format("enabled PC breakpoint at 0x%x\n", pc))
+                    self.breakpoints[pc] = true
+                end
+            else
+                self:_send_rcmd_reply(string.format("ERROR: malformed PC address '%s'\n", pcstr))
+            end
+            return self:_send_ok()
+        else -- invalid command
+            return self:_send_unsupported()
         end
-      end
-      return self:_send_ok()
-    elseif payload == 'hash' then -- print machine state hash
-      if not self.performed_first_hash then
-        self:_send_rcmd_reply('GDB may complain about packet errors due to command timeout, ignore them.\n')
-        self:_send_rcmd_reply('Performing first hash, this may take a while...\n')
-        self.performed_first_hash = true
-      end
-      local hash = self.machine:get_root_hash()
-      self:_send_rcmd_reply(string.format("%u: %s\n", self.machine:read_mcycle(), str2hex(hash)))
-      return self:_send_ok()
-    elseif payload:find('^store .*$') then -- store the machine state
-      local store_dir = payload:match('^store (.*)$')
-      self:_send_rcmd_reply('GDB may complain about packet errors due to command timeout, ignore them.\n')
-      self:_send_rcmd_reply('Storing the machine, this may take a while...\n')
-      local ok, res = pcall(self.machine.store, self.machine, store_dir)
-      if not ok then
-        self:_send_rcmd_reply(string.format('ERROR: machine store failed: %s\n', res))
-      else
-        self:_send_rcmd_reply(string.format('machine stated saved to "%s"\n', store_dir))
-      end
-      return self:_send_ok()
-    elseif payload:find([[^lua ["'].*["']$]]) then -- execute arbitrary lua code
-      local source = payload:match([[^lua ["'](.*)["']$]])
-      local env = {machine=self.machine}
-      setmetatable(env, {__index = _ENV})
-      local func, err = load(source, "@gdb_command_chunk", "t", env)
-      if not func then
-        self:_send_rcmd_reply(string.format('ERROR: %s\n', err))
-      else
-        local ok, ret = pcall(func)
-        if not ok then
-          self:_send_rcmd_reply(string.format('ERROR: %s\n', ret))
-        elseif ret ~= nil then
-          self:_send_rcmd_reply(tostring(ret)..'\n')
-        end
-      end
-      return self:_send_ok()
-    elseif payload:find('^breakpc [xXa-fA-F0-9]+$') then
-      local pcstr = payload:match('^breakpc ([xXa-fA-F0-9]+)$')
-      local pc = tonumber(pcstr)
-      if pc then
-        if self.breakpoints[pc] then
-          self.breakpoints[pc] = nil
-          self:_send_rcmd_reply(string.format("disabled PC breakpoint at 0x%x\n", pc))
-        else
-          self:_send_rcmd_reply(string.format("enabled PC breakpoint at 0x%x\n", pc))
-          self.breakpoints[pc] = true
-        end
-      else
-        self:_send_rcmd_reply(string.format("ERROR: malformed PC address '%s'\n", pcstr))
-      end
-      return self:_send_ok()
-    else -- invalid command
-      return self:_send_unsupported()
     end
-  end
 end
 
 -- GDB is setting a query feature.
 function GDBStub:_handle_query_set(_, query)
-  if query == 'QStartNoAckMode' then
-    if self:_send_ok() then
-      self.noack = true
-      return true
+    if query == "QStartNoAckMode" then
+        if self:_send_ok() then
+            self.noack = true
+            return true
+        end
     end
-  end
 end
 
 -- GDB is setting the thread for the next resume commands.
 function GDBStub:_handle_set_thread(payload)
-  local c, thread_id = payload:match('^(.)(.*)$')
-  assert(c and thread_id, 'unexpected set thread payload '..payload)
-  -- a thread-id can also be a literal '-1' to indicate all threads, or '0' to pick any thread.
-  if thread_id == '0' or thread_id == '-1' then
-    -- indicates that all following c commands refer to the given thread id
-    return self:_send_ok()
-  else
-    return self:_send_error()
-  end
+    local c, thread_id = payload:match("^(.)(.*)$")
+    assert(c and thread_id, "unexpected set thread payload " .. payload)
+    -- a thread-id can also be a literal '-1' to indicate all threads, or '0' to pick any thread.
+    if thread_id == "0" or thread_id == "-1" then
+        -- indicates that all following c commands refer to the given thread id
+        return self:_send_ok()
+    else
+        return self:_send_error()
+    end
 end
 
 -- GDB is writing a machine register.
 function GDBStub:_handle_write_reg(payload)
-  local reg, val = payload:match('^(%x+)=(%x+)$')
-  if not (reg and val) then return end
-  reg, val = hex2int(reg), hex2reg(val)
-  if reg > 0 and reg < 32 then -- machine registers
-    self.machine:write_x(reg, val)
-    return self:_send_ok()
-  elseif reg == 32 then -- machine program counter
-    self.machine:write_pc(val)
-    return self:_send_ok()
-  end
+    local reg, val = payload:match("^(%x+)=(%x+)$")
+    if not (reg and val) then return end
+    reg, val = hex2int(reg), hex2reg(val)
+    if reg > 0 and reg < 32 then -- machine registers
+        self.machine:write_x(reg, val)
+        return self:_send_ok()
+    elseif reg == 32 then -- machine program counter
+        self.machine:write_pc(val)
+        return self:_send_ok()
+    end
 end
 
 -- GDB is asking for all machine registers.
 function GDBStub:_handle_read_all_regs()
-  local res = {}
-  -- read general purposes registers
-  for i=0,31 do
-    table.insert(res, reg2hex(self.machine:read_x(i)))
-  end
-  -- read program counter
-  table.insert(res, reg2hex(self.machine:read_pc()))
-  res = table.concat(res)
-  return self:_send(res)
+    local res = {}
+    -- read general purposes registers
+    for i = 0, 31 do
+        table.insert(res, reg2hex(self.machine:read_x(i)))
+    end
+    -- read program counter
+    table.insert(res, reg2hex(self.machine:read_pc()))
+    res = table.concat(res)
+    return self:_send(res)
 end
 
 -- GDB is writing all machine registers.
 function GDBStub:_handle_write_all_regs(payload)
-  -- parse registers
-  local n = 0
-  local regs = {}
-  for val in payload:gmatch('%x%x%x%x%x%x%x%x%x%x%x%x%x%x%x%x') do
-    regs[n] = hex2reg(val)
-    n = n + 1
-  end
-  if n ~= 33 then
-    stderr('GDB sent an unexpected number of registers (%d)', n)
-    return
-  end
-  -- write general purposes registers
-  for i=1,31 do
-    self.machine:write_x(i, regs[i])
-  end
-  -- write program counter
-  self.machine:write_pc(regs[32])
-  return self:_send_ok()
+    -- parse registers
+    local n = 0
+    local regs = {}
+    for val in payload:gmatch("%x%x%x%x%x%x%x%x%x%x%x%x%x%x%x%x") do
+        regs[n] = hex2reg(val)
+        n = n + 1
+    end
+    if n ~= 33 then
+        stderr("GDB sent an unexpected number of registers (%d)", n)
+        return
+    end
+    -- write general purposes registers
+    for i = 1, 31 do
+        self.machine:write_x(i, regs[i])
+    end
+    -- write program counter
+    self.machine:write_pc(regs[32])
+    return self:_send_ok()
 end
 
 -- GDB wants to read machine memory.
 function GDBStub:_handle_read_mem(payload)
-  local address, length = payload:match('^(%x+),(%x+)$')
-  if not (address and length) then return end
-  address, length = hex2int(address), hex2int(length)
-  -- GDB may want to access invalid address ranges when debugging
-  local ok, mem = pcall(function()
-    return self.machine:read_virtual_memory(address, length)
-  end)
-  if not ok then return self:_send_error() end
-  local hexmem = str2hex(mem)
-  return self:_send(hexmem)
+    local address, length = payload:match("^(%x+),(%x+)$")
+    if not (address and length) then return end
+    address, length = hex2int(address), hex2int(length)
+    -- GDB may want to access invalid address ranges when debugging
+    local ok, mem = pcall(function() return self.machine:read_virtual_memory(address, length) end)
+    if not ok then return self:_send_error() end
+    local hexmem = str2hex(mem)
+    return self:_send(hexmem)
 end
 
 -- GDB wants to write machine memory.
 function GDBStub:_handle_write_mem(payload)
-  local address, length, hexmem = payload:match('^(%x+),(%x+):(%x+)$')
-  if not (address and length) then return end
-  address, length = hex2int(address), hex2int(length)
-  local mem = hex2str(hexmem)
-  assert(#mem == length)
-  -- GDB may want to access invalid address ranges when debugging
-  local ok = pcall(function()
-    self.machine:write_virtual_memory(address, mem)
-  end)
-  if ok then return self:_send_error() end
-  return self:_send_ok()
+    local address, length, hexmem = payload:match("^(%x+),(%x+):(%x+)$")
+    if not (address and length) then return end
+    address, length = hex2int(address), hex2int(length)
+    local mem = hex2str(hexmem)
+    assert(#mem == length)
+    -- GDB may want to access invalid address ranges when debugging
+    local ok = pcall(function() self.machine:write_virtual_memory(address, mem) end)
+    if ok then return self:_send_error() end
+    return self:_send_ok()
 end
 
 -- GDB is asking to let the machine continue.
 function GDBStub:_handle_continue()
-  local machine = self.machine
-  local mcycle = machine:read_mcycle()
-  local mcycle_end = self.max_mcycle
-  local ult = math.ult -- localized to speed up Lua loop
-  if self.mcycle_limit and ult(self.mcycle_limit, self.max_mcycle) then
-    -- we want to advance just a fixed number of cycles
-    mcycle_end = self.mcycle_limit
-  end
-  if next(self.breakpoints) then -- at least one breakpoint is set
-    local breakpoints = self.breakpoints -- localized to speed up Lua loop
-    -- need to run cycle by cycle, while checking breakpoints
-    while ult(mcycle, mcycle_end) do
-      machine:run(mcycle+1)
-      if breakpoints[machine:read_pc()] then -- breakpoint reached
-        return self:_send_signal(signals.SIGTRAP)
-      elseif machine:read_iflags_H() then -- machined halted
+    local machine = self.machine
+    local mcycle = machine:read_mcycle()
+    local mcycle_end = self.max_mcycle
+    local ult = math.ult -- localized to speed up Lua loop
+    if self.mcycle_limit and ult(self.mcycle_limit, self.max_mcycle) then
+        -- we want to advance just a fixed number of cycles
+        mcycle_end = self.mcycle_limit
+    end
+    if next(self.breakpoints) then -- at least one breakpoint is set
+        local breakpoints = self.breakpoints -- localized to speed up Lua loop
+        -- need to run cycle by cycle, while checking breakpoints
+        while ult(mcycle, mcycle_end) do
+            machine:run(mcycle + 1)
+            if breakpoints[machine:read_pc()] then -- breakpoint reached
+                return self:_send_signal(signals.SIGTRAP)
+            elseif machine:read_iflags_H() then -- machined halted
+                return self:_send_signal(signals.SIGTERM)
+            elseif machine:read_iflags_Y() or machine:read_iflags_X() then -- machine yielded
+                self.yielded = true
+                return true -- a reply will be sent to GDB in the next run loop
+            end
+            mcycle = machine:read_mcycle()
+        end
+    else -- no breakpoint set, we can run through the fast path
+        machine:run(mcycle_end)
+    end
+    if machine:read_iflags_H() then -- machine halted
         return self:_send_signal(signals.SIGTERM)
-      elseif machine:read_iflags_Y() or machine:read_iflags_X() then -- machine yielded
+    elseif machine:read_mcycle() == self.max_mcycle then -- reached max cycles
+        return self:_send_signal(signals.SIGQUIT)
+    elseif machine:read_iflags_Y() or machine:read_iflags_X() then -- machine yielded
         self.yielded = true
         return true -- a reply will be sent to GDB in the next run loop
-      end
-      mcycle = machine:read_mcycle()
+    else -- reached step cycles limit
+        return self:_send_signal(signals.SIGINT)
     end
-  else -- no breakpoint set, we can run through the fast path
-    machine:run(mcycle_end)
-  end
-  if machine:read_iflags_H() then -- machine halted
-    return self:_send_signal(signals.SIGTERM)
-  elseif machine:read_mcycle() == self.max_mcycle then -- reached max cycles
-    return self:_send_signal(signals.SIGQUIT)
-  elseif machine:read_iflags_Y() or machine:read_iflags_X() then -- machine yielded
-    self.yielded = true
-    return true -- a reply will be sent to GDB in the next run loop
-  else -- reached step cycles limit
-    return self:_send_signal(signals.SIGINT)
-  end
 end
 
 -- GDB is requesting to continue past halting signal.
 function GDBStub:_handle_continue_signal(payload)
-  local signum = payload:match('^(%x+)$')
-  if not signum then return end
-  return self:_handle_continue()
+    local signum = payload:match("^(%x+)$")
+    if not signum then return end
+    return self:_handle_continue()
 end
 
 local function parse_breakpoint_address(payload)
-  local type, address, kind = payload:match('^(%d+),(%x+),(%x+)$')
-  if address and type == '0' or (kind == '4' or kind == '2') then
-    return hex2int(address)
-  end
+    local type, address, kind = payload:match("^(%d+),(%x+),(%x+)$")
+    if address and type == "0" or (kind == "4" or kind == "2") then return hex2int(address) end
 end
 
 -- GDB is adding a breakpoint.
 function GDBStub:_handle_insert_breakpoint(payload)
-  local address = parse_breakpoint_address(payload)
-  if not address then return end
-  self.breakpoints[address] = true
-  return self:_send_ok()
+    local address = parse_breakpoint_address(payload)
+    if not address then return end
+    self.breakpoints[address] = true
+    return self:_send_ok()
 end
 
 -- GDB is removing a breakpoint.
 function GDBStub:_handle_remove_breakpoint(payload)
-  local address = parse_breakpoint_address(payload)
-  if not address then return end
-  self.breakpoints[address] = nil
-  return self:_send_ok()
+    local address = parse_breakpoint_address(payload)
+    if not address then return end
+    self.breakpoints[address] = nil
+    return self:_send_ok()
 end
 
 -- GDB is requesting to kill the machine.
 function GDBStub:_handle_kill()
-  stderr('GDB killed!')
-  self:_send_ok()
-  self:close()
-  os.exit(0) -- exit immediately
-  return true
+    stderr("GDB killed!")
+    self:_send_ok()
+    self:close()
+    os.exit(0) -- exit immediately
+    return true
 end
 
 -- GDB is detaching (debug session ended).
 function GDBStub:_handle_detach()
-  self:_send_ok()
-  self:close()
-  return true
+    self:_send_ok()
+    self:close()
+    return true
 end
 
 -- GDB is asking if extended debugging is supported.
-function GDBStub:_handle_extended_debugging()
-  return self:_send_ok()
-end
+function GDBStub:_handle_extended_debugging() return self:_send_ok() end
 
 -- Packet handler for the GDB protocol.
 local gdbstub_handlers = {
-  ['!'] = GDBStub._handle_extended_debugging,
-  ['k'] = GDBStub._handle_kill,
-  ['?'] = GDBStub._handle_target_halt,
-  ['c'] = GDBStub._handle_continue,
-  ['C'] = GDBStub._handle_continue_signal,
-  ['D'] = GDBStub._handle_detach,
-  ['m'] = GDBStub._handle_read_mem,
-  ['M'] = GDBStub._handle_write_mem,
-  -- ['p'] = GDBStub._handle_read_reg,
-  ['P'] = GDBStub._handle_write_reg,
-  ['g'] = GDBStub._handle_read_all_regs,
-  ['G'] = GDBStub._handle_write_all_regs,
-  ['Z'] = GDBStub._handle_insert_breakpoint,
-  ['z'] = GDBStub._handle_remove_breakpoint,
-  ['v'] = GDBStub._handle_v_command,
-  ['q'] = GDBStub._handle_query,
-  ['Q'] = GDBStub._handle_query_set,
-  ['H'] = GDBStub._handle_set_thread,
-  -- explicitly unsupported, but GDB may send packets
-  ['X'] = false, -- write data to memory, where the data is transmitted in binary
+    ["!"] = GDBStub._handle_extended_debugging,
+    ["k"] = GDBStub._handle_kill,
+    ["?"] = GDBStub._handle_target_halt,
+    ["c"] = GDBStub._handle_continue,
+    ["C"] = GDBStub._handle_continue_signal,
+    ["D"] = GDBStub._handle_detach,
+    ["m"] = GDBStub._handle_read_mem,
+    ["M"] = GDBStub._handle_write_mem,
+    -- ['p'] = GDBStub._handle_read_reg,
+    ["P"] = GDBStub._handle_write_reg,
+    ["g"] = GDBStub._handle_read_all_regs,
+    ["G"] = GDBStub._handle_write_all_regs,
+    ["Z"] = GDBStub._handle_insert_breakpoint,
+    ["z"] = GDBStub._handle_remove_breakpoint,
+    ["v"] = GDBStub._handle_v_command,
+    ["q"] = GDBStub._handle_query,
+    ["Q"] = GDBStub._handle_query_set,
+    ["H"] = GDBStub._handle_set_thread,
+    -- explicitly unsupported, but GDB may send packets
+    ["X"] = false, -- write data to memory, where the data is transmitted in binary
 }
 
 -- Handle every packet received from GDB.
 function GDBStub:_handle_packet(data)
-  local c, payload = data:sub(1,1), data:sub(2)
-  local handler = gdbstub_handlers[data] or gdbstub_handlers[c]
-  if handler == false then -- explicitly unsupported
-    self:_send_unsupported()
-  elseif handler then -- packet handler found
-    local ok = handler(self, payload, data)
-    if not ok then -- the handler could not process the packet
-      stderr('Received an unexpected packet from GDB: %s', data)
-      self:_send_unsupported()
+    local c, payload = data:sub(1, 1), data:sub(2)
+    local handler = gdbstub_handlers[data] or gdbstub_handlers[c]
+    if handler == false then -- explicitly unsupported
+        self:_send_unsupported()
+    elseif handler then -- packet handler found
+        local ok = handler(self, payload, data)
+        if not ok then -- the handler could not process the packet
+            stderr("Received an unexpected packet from GDB: %s", data)
+            self:_send_unsupported()
+        end
     end
-  end
 end
 
 -- Runs the machine until GDB detaches.
@@ -573,44 +525,40 @@ end
 -- Returns false if GDB session ended (GDB detached),
 -- otherwise true if GDB session is still going on (when yielding).
 function GDBStub:run(max_mcycle)
-  if not self.conn then return false end
-  -- set max mcycle for continue operations
-  self.max_mcycle = max_mcycle or math.maxinteger
-  -- when resuming from a yield, we have a pending GDB continue packet to reply
-  if self.yielded then
-    self.yielded = nil
-    self:_handle_continue() -- resume handling last continue packet
-  end
-  -- run while GDB is connected and the machine has not yielded
-  while self.conn and not self.yielded do
-    local c = assert(self.conn:receive(1))
-    if c == '$' then -- incoming packet
-      local data = self:_recv()
-      if data then -- acknowledged packet
-        self:_handle_packet(data)
-      end
-    elseif c == '-' then -- GDB requested packet requested retransmission
-      -- GDB usually asks for retransmission for long running commands (or broken protocol)
-      if GDBSTUB_DEBUG_PROTOCOL then
-        stderr('GDB requested packet retransmission\n')
-      end
-    else
-      error('Received unexpected protocol character from GDB: '..c)
+    if not self.conn then return false end
+    -- set max mcycle for continue operations
+    self.max_mcycle = max_mcycle or math.maxinteger
+    -- when resuming from a yield, we have a pending GDB continue packet to reply
+    if self.yielded then
+        self.yielded = nil
+        self:_handle_continue() -- resume handling last continue packet
     end
-  end
-  return self.yielded
+    -- run while GDB is connected and the machine has not yielded
+    while self.conn and not self.yielded do
+        local c = assert(self.conn:receive(1))
+        if c == "$" then -- incoming packet
+            local data = self:_recv()
+            if data then -- acknowledged packet
+                self:_handle_packet(data)
+            end
+        elseif c == "-" then -- GDB requested packet requested retransmission
+            -- GDB usually asks for retransmission for long running commands (or broken protocol)
+            if GDBSTUB_DEBUG_PROTOCOL then stderr("GDB requested packet retransmission\n") end
+        else
+            error("Received unexpected protocol character from GDB: " .. c)
+        end
+    end
+    return self.yielded
 end
 
 -- Returns true if GDB is connected.
-function GDBStub:is_connected()
-  return self.conn ~= nil
-end
+function GDBStub:is_connected() return self.conn ~= nil end
 
 -- Closes the GDB connection.
 function GDBStub:close()
-  if not self.conn then return end
-  assert(self.conn:close())
-  self.conn = nil
+    if not self.conn then return end
+    assert(self.conn:close())
+    self.conn = nil
 end
 
 return GDBStub

--- a/src/cartesi/proof.lua
+++ b/src/cartesi/proof.lua
@@ -1,13 +1,13 @@
-local cartesi = require"cartesi"
+local cartesi = require("cartesi")
 
 local _M = {}
 
 function _M.roll_hash_up_tree(proof, target_hash)
     local hash = target_hash
-    for log2_size = proof.log2_target_size, proof.log2_root_size-1 do
+    for log2_size = proof.log2_target_size, proof.log2_root_size - 1 do
         local bit = (proof.target_address & (1 << log2_size)) ~= 0
         local first, second
-        local i = proof.log2_root_size-log2_size
+        local i = proof.log2_root_size - log2_size
         if bit then
             first, second = proof.sibling_hashes[i], hash
         else
@@ -20,28 +20,24 @@ end
 
 function _M.slice_assert(root_hash, proof)
     assert(root_hash == proof.root_hash, "proof root_hash mismatch")
-    assert(_M.roll_hash_up_tree(proof, proof.target_hash) == root_hash,
-        "node not in tree")
+    assert(_M.roll_hash_up_tree(proof, proof.target_hash) == root_hash, "node not in tree")
 end
 
 function _M.word_slice_assert(root_hash, proof, word)
     assert(proof.log2_target_size == 3, "not a word proof")
     assert(root_hash == proof.root_hash, "proof root_hash mismatch")
     assert(cartesi.keccak(word) == proof.target_hash, "proof target_hash mismatch")
-    assert(_M.roll_hash_up_tree(proof, proof.target_hash) == root_hash,
-        "node not in tree")
+    assert(_M.roll_hash_up_tree(proof, proof.target_hash) == root_hash, "node not in tree")
 end
 
 function _M.splice_assert(root_hash, proof, new_target_hash, new_root_hash)
     _M.slice_assert(root_hash, proof)
-    assert(_M.roll_hash_up_tree(proof, new_target_hash) == new_root_hash,
-        "new root hash mismatch")
+    assert(_M.roll_hash_up_tree(proof, new_target_hash) == new_root_hash, "new root hash mismatch")
 end
 
 function _M.word_splice_assert(root_hash, proof, old_word, new_word, new_root_hash)
     _M.word_slice_assert(root_hash, proof, old_word)
-    assert(_M.roll_hash_up_tree(proof, cartesi.keccak(new_word)) == new_root_hash,
-        "new root hash mismatch")
+    assert(_M.roll_hash_up_tree(proof, cartesi.keccak(new_word)) == new_root_hash, "new root hash mismatch")
 end
 
 return _M

--- a/src/cartesi/util.lua
+++ b/src/cartesi/util.lua
@@ -16,16 +16,12 @@
 
 local _M = {}
 
-local function indentout(f, indent, fmt, ...)
-    f:write(string.rep("  ", indent), string.format(fmt, ...))
-end
+local function indentout(f, indent, fmt, ...) f:write(string.rep("  ", indent), string.format(fmt, ...)) end
 
 _M.indentout = indentout
 
 local function hexstring(hash)
-    return (string.gsub(hash, ".", function(c)
-        return string.format("%02x", string.byte(c))
-    end))
+    return (string.gsub(hash, ".", function(c) return string.format("%02x", string.byte(c)) end))
 end
 
 local hexhash = hexstring
@@ -35,8 +31,11 @@ _M.hexhash = hexstring
 local function dump_json_sibling_hashes(sibling_hashes, out, indent)
     for i, h in ipairs(sibling_hashes) do
         indentout(out, indent, '"%s"', hexhash(h))
-        if sibling_hashes[i+1] then out:write(',\n')
-        else out:write('\n') end
+        if sibling_hashes[i + 1] then
+            out:write(",\n")
+        else
+            out:write("\n")
+        end
     end
 end
 
@@ -46,8 +45,8 @@ local function dump_json_proof(proof, out, indent)
     indentout(out, indent, '"log2_root_size": %u,\n', proof.log2_root_size)
     indentout(out, indent, '"target_hash": "%s",\n', hexhash(proof.target_hash))
     indentout(out, indent, '"sibling_hashes": [\n')
-    dump_json_sibling_hashes(proof.sibling_hashes, out, indent+1)
-    indentout(out, indent, '],\n')
+    dump_json_sibling_hashes(proof.sibling_hashes, out, indent + 1)
+    indentout(out, indent, "],\n")
     indentout(out, indent, '"root_hash": "%s"\n', hexhash(proof.root_hash))
 end
 
@@ -57,75 +56,84 @@ local function dump_json_log_notes(notes, out, indent)
     local n = #notes
     for i, note in ipairs(notes) do
         indentout(out, indent, '"%s"', note)
-        if i < n then out:write(',\n')
-        else out:write("\n") end
+        if i < n then
+            out:write(",\n")
+        else
+            out:write("\n")
+        end
     end
 end
 
 local function dump_json_log_brackets(brackets, out, indent)
     local n = #brackets
     for i, bracket in ipairs(brackets) do
-        indentout(out, indent, '{\n')
-        indentout(out, indent+1, '"type": "%s",\n', bracket.type)
-        indentout(out, indent+1, '"where": %u,\n', bracket.where)
-        indentout(out, indent+1, '"text": "%s"\n', bracket.text)
-        indentout(out, indent, '}')
-        if i < n then out:write(',\n')
-        else out:write("\n") end
+        indentout(out, indent, "{\n")
+        indentout(out, indent + 1, '"type": "%s",\n', bracket.type)
+        indentout(out, indent + 1, '"where": %u,\n', bracket.where)
+        indentout(out, indent + 1, '"text": "%s"\n', bracket.text)
+        indentout(out, indent, "}")
+        if i < n then
+            out:write(",\n")
+        else
+            out:write("\n")
+        end
     end
 end
 
 local function dump_json_log_access(access, out, indent)
-    indentout(out, indent, '{\n')
-    indentout(out, indent+1, '"type": "%s",\n', access.type)
-    indentout(out, indent+1, '"address": %u,\n', access.address)
-    indentout(out, indent+1, '"read": "%s"', hexstring(access.read))
+    indentout(out, indent, "{\n")
+    indentout(out, indent + 1, '"type": "%s",\n', access.type)
+    indentout(out, indent + 1, '"address": %u,\n', access.address)
+    indentout(out, indent + 1, '"read": "%s"', hexstring(access.read))
     if access.type == "write" then
         out:write(",\n")
-        indentout(out, indent+1, '"written": "%s"', hexstring(access.written))
+        indentout(out, indent + 1, '"written": "%s"', hexstring(access.written))
     end
     if access.proof then
         out:write(",\n")
-        indentout(out, indent+1, '"proof": {\n')
-        dump_json_proof(access.proof, out, indent+2)
-        indentout(out, indent+1, '}\n')
+        indentout(out, indent + 1, '"proof": {\n')
+        dump_json_proof(access.proof, out, indent + 2)
+        indentout(out, indent + 1, "}\n")
     else
         out:write("\n")
     end
-    indentout(out, indent, '}')
+    indentout(out, indent, "}")
 end
 
 local function dump_json_log_accesses(accesses, out, indent)
     local n = #accesses
     for i, access in ipairs(accesses) do
         dump_json_log_access(access, out, indent)
-        if i < n then out:write(',\n')
-        else out:write('\n') end
+        if i < n then
+            out:write(",\n")
+        else
+            out:write("\n")
+        end
     end
 end
 
-function _M.dump_json_log(log, init_mcycle, init_uarch_cycle, final_mcycle,final_uarch_cycle, out, indent)
+function _M.dump_json_log(log, init_mcycle, init_uarch_cycle, final_mcycle, final_uarch_cycle, out, indent)
     indent = indent or 0
-    indentout(out, indent, '{\n')
-    indentout(out, indent+1, '"init_mcycle": %u,\n', init_mcycle)
-    indentout(out, indent+1, '"init_uarch_cycle": %u,\n', init_uarch_cycle)
-    indentout(out, indent+1, '"final_mcycle": %u,\n', final_mcycle)
-    indentout(out, indent+1, '"final_uarch_cycle": %u,\n', final_uarch_cycle)
-    indentout(out, indent+1, '"accesses": [\n')
-    dump_json_log_accesses(log.accesses, out, indent+2)
-    indentout(out, indent+1, "]");
+    indentout(out, indent, "{\n")
+    indentout(out, indent + 1, '"init_mcycle": %u,\n', init_mcycle)
+    indentout(out, indent + 1, '"init_uarch_cycle": %u,\n', init_uarch_cycle)
+    indentout(out, indent + 1, '"final_mcycle": %u,\n', final_mcycle)
+    indentout(out, indent + 1, '"final_uarch_cycle": %u,\n', final_uarch_cycle)
+    indentout(out, indent + 1, '"accesses": [\n')
+    dump_json_log_accesses(log.accesses, out, indent + 2)
+    indentout(out, indent + 1, "]")
     if log.log_type.annotations then
         out:write(",\n")
-        indentout(out, indent+1, '"notes": [\n')
-        dump_json_log_notes(log.notes, out, indent+2)
-        indentout(out, indent+1, '],\n')
-        indentout(out, indent+1, '"brackets": [\n')
-        dump_json_log_brackets(log.brackets, out, indent+2)
-        indentout(out, indent+1, ']\n')
+        indentout(out, indent + 1, '"notes": [\n')
+        dump_json_log_notes(log.notes, out, indent + 2)
+        indentout(out, indent + 1, "],\n")
+        indentout(out, indent + 1, '"brackets": [\n')
+        dump_json_log_brackets(log.brackets, out, indent + 2)
+        indentout(out, indent + 1, "]\n")
     else
         out:write("\n")
     end
-    indentout(out, indent, '}')
+    indentout(out, indent, "}")
 end
 
 function _M.parse_number(n)
@@ -136,10 +144,15 @@ function _M.parse_number(n)
     end
     base = tonumber(base)
     if not base then return nil end
-    if rest == "Ki" then return base << 10
-    elseif rest == "Mi" then return base << 20
-    elseif rest == "Gi" then return base << 30
-    elseif rest == "" then return base end
+    if rest == "Ki" then
+        return base << 10
+    elseif rest == "Mi" then
+        return base << 20
+    elseif rest == "Gi" then
+        return base << 30
+    elseif rest == "" then
+        return base
+    end
     local shift = string.match(rest, "^%s*%<%<%s*(%d+)$")
     if shift then
         shift = tonumber(shift)
@@ -177,18 +190,19 @@ function _M.parse_options(s, keys)
     return options
 end
 
-local function hexhash8(hash)
-    return string.sub(hexhash(hash), 1, 8)
-end
+local function hexhash8(hash) return string.sub(hexhash(hash), 1, 8) end
 
 local function accessdatastring(data, log2_size)
     if log2_size == 3 then
         data = string.unpack("<I8", data)
         return string.format("0x%x(%u)", data, data)
     else
-        return string.format("%s...%s(2^%d bytes)",
+        return string.format(
+            "%s...%s(2^%d bytes)",
             hexstring(string.sub(data, 1, 3)),
-            hexstring(string.sub(data, -3, -1)), log2_size)
+            hexstring(string.sub(data, -3, -1)),
+            log2_size
+        )
     end
 end
 
@@ -216,19 +230,24 @@ function _M.dump_log(log, out)
             j = j + 1
         -- Otherwise, output access
         elseif ai then
-            if ai.proof then
-                indentout(out, indent, "hash %s\n",
-                    hexhash8(ai.proof.root_hash))
-            end
+            if ai.proof then indentout(out, indent, "hash %s\n", hexhash8(ai.proof.root_hash)) end
             local read = accessdatastring(ai.read, ai.log2_size)
             if ai.type == "read" then
-                indentout(out, indent, "%d: read %s@0x%x(%u): %s\n", i,
-                    notes[i] or "", ai.address, ai.address, read)
+                indentout(out, indent, "%d: read %s@0x%x(%u): %s\n", i, notes[i] or "", ai.address, ai.address, read)
             else
                 assert(ai.type == "write", "unknown access type")
                 local written = accessdatastring(ai.written, ai.log2_size)
-                indentout(out, indent, "%d: write %s@0x%x(%u): %s -> %s\n", i,
-                    notes[i] or "", ai.address, ai.address, read, written)
+                indentout(
+                    out,
+                    indent,
+                    "%d: write %s@0x%x(%u): %s -> %s\n",
+                    i,
+                    notes[i] or "",
+                    ai.address,
+                    ai.address,
+                    read,
+                    written
+                )
             end
             i = i + 1
         end

--- a/src/rollup-memory-range.lua
+++ b/src/rollup-memory-range.lua
@@ -100,7 +100,7 @@ local function unhex(hex)
         return string.char(n)
     end)
     if invalid then
-        return nil, format("'%q' not valid hex", c)
+        return nil, string.format("'%q' not valid hex", invalid)
     else
         return data
     end
@@ -173,7 +173,7 @@ local function errorf(...)
 end
 
 local function read_json()
-    local j, p, e = json.decode(io.read("*a"))
+    local j, _, e = json.decode(io.read("*a"))
     if not j then error(e) end
     return j
 end
@@ -207,7 +207,7 @@ local function check_number(number, name)
 end
 
 
-local function encode_input_metadata(arg)
+local function encode_input_metadata()
     local j = read_json()
     j.msg_sender = unhexhash(j.msg_sender, "msg_sender")
     j.block_number = check_number(j.block_number, "block_number")
@@ -222,15 +222,7 @@ local function encode_input_metadata(arg)
     write_be256(j.input_index)
 end
 
-local function encode_string(arg)
-    local j = read_json()
-    local payload = assert(j.payload, "missing payload")
-    write_be256(32) -- offset
-    write_be256(#payload)
-    io.stdout:write(payload)
-end
-
-local function encode_voucher(arg)
+local function encode_voucher()
     local j = read_json()
     local payload = assert(j.payload, "missing payload")
     local destination = unhexhash(j.destination, "destination")
@@ -254,7 +246,7 @@ local function read_be256()
     return string.unpack(">I8", string.sub(io.stdin:read(32), 25))
 end
 
-local function decode_input_metadata(arg)
+local function decode_input_metadata()
     local msg_sender = read_address()
     local block_number = read_be256()
     local time_stamp = read_be256()
@@ -278,14 +270,14 @@ local function decode_input_metadata(arg)
     }), "\n")
 end
 
-local function decode_string(arg)
+local function decode_string()
     assert(read_be256() == 32) -- skip offset
     local length = read_be256()
     local payload = length == 0 and '' or assert(io.stdin:read(length))
     io.stdout:write(json.encode({ payload = payload }, { indent = true }), "\n")
 end
 
-local function encode_string(arg)
+local function encode_string()
     local j = read_json()
     assert(j.payload, "missing payload")
     write_be256(32)
@@ -293,7 +285,7 @@ local function encode_string(arg)
     io.stdout:write(j.payload)
 end
 
-local function decode_voucher(arg)
+local function decode_voucher()
     local destination = hexhash(read_address())
     local offset = read_be256()
     assert(offset == 64, "expected offset 64, got " .. offset) -- skip offset
@@ -311,7 +303,7 @@ local function decode_voucher(arg)
     }), "\n")
 end
 
-local function decode_hashes(arg)
+local function decode_hashes()
     local t = {}
     while 1 do
         local hash = read_hash()

--- a/src/tests/htif-console.lua
+++ b/src/tests/htif-console.lua
@@ -1,34 +1,30 @@
 #!/usr/bin/env lua5.4
 
-local cartesi = require"cartesi"
-local test_util = require "tests.util"
+local cartesi = require("cartesi")
+local test_util = require("tests.util")
 
-local config_base =  {
-  processor = {
-    mvendorid = -1,
-    mimpid = -1,
-    marchid = -1,
-  },
-  ram = {
-    image_filename = test_util.tests_path .. "htif_console.bin",
-    length = 0x4000000,
-  },
-  rom = {
-    image_filename = test_util.tests_path .. "bootstrap.bin"
-  },
+local config_base = {
+    processor = {
+        mvendorid = -1,
+        mimpid = -1,
+        marchid = -1,
+    },
+    ram = {
+        image_filename = test_util.tests_path .. "htif_console.bin",
+        length = 0x4000000,
+    },
+    rom = {
+        image_filename = test_util.tests_path .. "bootstrap.bin",
+    },
 }
 
-local function stderr(...)
-    io.stderr:write(string.format(...))
-end
+local function stderr(...) io.stderr:write(string.format(...)) end
 
 local final_mcycle = 2141
 local exit_payload = 42
 
 local function test(config, console_getchar_enable)
-    stderr("  testing console_getchar:%s\n",
-        console_getchar_enable and "on" or "off"
-    )
+    stderr("  testing console_getchar:%s\n", console_getchar_enable and "on" or "off")
     config.htif = {
         console_getchar = console_getchar_enable,
     }
@@ -39,17 +35,20 @@ local function test(config, console_getchar_enable)
     assert(machine:read_iflags_H(), "expected iflags_H set")
 
     -- with the expected payload
-    assert((machine:read_htif_tohost_data() >> 1) == exit_payload,
-        string.format("exit payload: expected %u, got %u\n", exit_payload,
-            machine:read_htif_tohost_data() >> 1))
+    assert(
+        (machine:read_htif_tohost_data() >> 1) == exit_payload,
+        string.format("exit payload: expected %u, got %u\n", exit_payload, machine:read_htif_tohost_data() >> 1)
+    )
 
     -- at the expected mcycle
-    assert(machine:read_mcycle() == final_mcycle, string.format("mcycle: expected, %u got %u",
-        final_mcycle, machine:read_mcycle()))
+    assert(
+        machine:read_mcycle() == final_mcycle,
+        string.format("mcycle: expected, %u got %u", final_mcycle, machine:read_mcycle())
+    )
 
     stderr("    passed\n")
 end
 
-for _, getchar in ipairs{true, false} do
+for _, getchar in ipairs({ true, false }) do
     test(config_base, getchar)
 end

--- a/src/tests/htif-console.lua
+++ b/src/tests/htif-console.lua
@@ -3,7 +3,7 @@
 local cartesi = require"cartesi"
 local test_util = require "tests.util"
 
-local config =  {
+local config_base =  {
   processor = {
     mvendorid = -1,
     mimpid = -1,
@@ -25,7 +25,7 @@ end
 local final_mcycle = 2141
 local exit_payload = 42
 
-function test(config, console_getchar_enable)
+local function test(config, console_getchar_enable)
     stderr("  testing console_getchar:%s\n",
         console_getchar_enable and "on" or "off"
     )
@@ -51,5 +51,5 @@ function test(config, console_getchar_enable)
 end
 
 for _, getchar in ipairs{true, false} do
-    test(config, getchar)
+    test(config_base, getchar)
 end

--- a/src/tests/htif-rollup.lua
+++ b/src/tests/htif-rollup.lua
@@ -16,10 +16,10 @@
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 --
 
-local cartesi = require"cartesi"
-local test_util = require "tests.util"
+local cartesi = require("cartesi")
+local test_util = require("tests.util")
 
-local config_base =  {
+local config_base = {
     processor = {
         mvendorid = -1,
         mimpid = -1,
@@ -34,39 +34,47 @@ local config_base =  {
         length = 0x4000000,
     },
     rom = {
-        image_filename = test_util.tests_path .. "bootstrap.bin"
+        image_filename = test_util.tests_path .. "bootstrap.bin",
     },
     htif = {
         yield_automatic = true,
     },
     rollup = {
         rx_buffer = {
-            start = 0x60000000, length = 0x1000, shared = false,
+            start = 0x60000000,
+            length = 0x1000,
+            shared = false,
         },
         tx_buffer = {
-            start = 0x60001000, length = 0x1000, shared = false,
+            start = 0x60001000,
+            length = 0x1000,
+            shared = false,
         },
         input_metadata = {
-            start = 0x60002000, length = 0x1000, shared = false,
+            start = 0x60002000,
+            length = 0x1000,
+            shared = false,
         },
         voucher_hashes = {
-            start = 0x60003000, length = 0x1000, shared = false,
+            start = 0x60003000,
+            length = 0x1000,
+            shared = false,
         },
         notice_hashes = {
-            start = 0x60004000, length = 0x1000, shared = false,
+            start = 0x60004000,
+            length = 0x1000,
+            shared = false,
         },
-    }
+    },
 }
 
-local function stderr(...)
-    io.stderr:write(string.format(...))
-end
+local function stderr(...) io.stderr:write(string.format(...)) end
 
 local final_mcycle = 8981
 local exit_payload = 0
 
 local function check_buffer(machine, pattern, buffer)
-    local mem = string.rep(pattern, buffer.length/8)
+    local mem = string.rep(pattern, buffer.length / 8)
     assert(mem == machine:read_memory(buffer.start, buffer.length))
 end
 
@@ -75,12 +83,12 @@ local function test(config)
     local machine = cartesi.machine(config)
 
     -- fill input with `pattern`
-    local rx = config.rollup.rx_buffer;
-    machine:write_memory(rx.start, string.rep(pattern, rx.length/8), rx.length);
+    local rx = config.rollup.rx_buffer
+    machine:write_memory(rx.start, string.rep(pattern, rx.length / 8), rx.length)
 
     -- fill input_metadata with `pattern`
-    local im = config.rollup.input_metadata;
-    machine:write_memory(im.start, string.rep(pattern, im.length/8), im.length);
+    local im = config.rollup.input_metadata
+    machine:write_memory(im.start, string.rep(pattern, im.length / 8), im.length)
     machine:run(math.maxinteger)
 
     -- check that buffers got filled in with `pattern`

--- a/src/tests/htif-rollup.lua
+++ b/src/tests/htif-rollup.lua
@@ -19,7 +19,7 @@
 local cartesi = require"cartesi"
 local test_util = require "tests.util"
 
-local config =  {
+local config_base =  {
     processor = {
         mvendorid = -1,
         mimpid = -1,
@@ -65,12 +65,12 @@ end
 local final_mcycle = 8981
 local exit_payload = 0
 
-function check_buffer(machine, pattern, buffer)
+local function check_buffer(machine, pattern, buffer)
     local mem = string.rep(pattern, buffer.length/8)
     assert(mem == machine:read_memory(buffer.start, buffer.length))
 end
 
-function test(config)
+local function test(config)
     local pattern = "\xef\xcd\xab\x89\x67\x45\x23\x01"
     local machine = cartesi.machine(config)
 
@@ -100,4 +100,4 @@ function test(config)
 end
 
 stderr("testing rollup\n")
-test(config)
+test(config_base)

--- a/src/tests/htif-yield.lua
+++ b/src/tests/htif-yield.lua
@@ -1,11 +1,12 @@
 #!/usr/bin/env lua5.4
 
-local cartesi = require"cartesi"
-local test_util = require "tests.util"
-local util = require"cartesi.util"
+local cartesi = require("cartesi")
+local test_util = require("tests.util")
+local util = require("cartesi.util")
 
 local function help()
-    io.stderr:write(string.format([=[
+    io.stderr:write(string.format(
+        [=[
 Usage:
 
   %s [options]
@@ -21,7 +22,9 @@ where options are:
   --uarch-ram-length=<number>
     set microarchitecture RAM length.
 
-]=], arg[0]))
+]=],
+        arg[0]
+    ))
     os.exit()
 end
 
@@ -37,95 +40,106 @@ local uarch_ram_image_filename = nil
 --     if callback returns true, the option is accepted.
 --     if callback returns false, the option is rejected.
 local options = {
-    { "^%-%-help$", function(all)
-        if not all then return false end
-        help()
-    end },
-    { "^%-%-uarch$", function(all)
-        if not all then return false end
-        uarch = true
-        return true
-    end },
-    { "^%-%-uarch%-ram%-image%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        uarch_ram_image_filename = o
-        return true
-    end },
-    { "^%-%-uarch%-ram%-length%=(.+)$", function(n)
-        if not n then return false end
-        uarch_ram_length = assert(util.parse_number(n), "invalid microarchitecture RAM length " .. n)
-        return true
-    end },
-    { ".*", function(all)
-        error("unrecognized option " .. all .. ". Use --help to obtain a list of supported options.")
-    end }
+    {
+        "^%-%-help$",
+        function(all)
+            if not all then return false end
+            help()
+        end,
+    },
+    {
+        "^%-%-uarch$",
+        function(all)
+            if not all then return false end
+            uarch = true
+            return true
+        end,
+    },
+    {
+        "^%-%-uarch%-ram%-image%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            uarch_ram_image_filename = o
+            return true
+        end,
+    },
+    {
+        "^%-%-uarch%-ram%-length%=(.+)$",
+        function(n)
+            if not n then return false end
+            uarch_ram_length = assert(util.parse_number(n), "invalid microarchitecture RAM length " .. n)
+            return true
+        end,
+    },
+    {
+        ".*",
+        function(all) error("unrecognized option " .. all .. ". Use --help to obtain a list of supported options.") end,
+    },
 }
 
 -- Process command line options
-for i, argument in ipairs({...}) do
-    if argument:sub(1,1) == "-" then
-        for j, option in ipairs(options) do
-            if option[2](argument:match(option[1])) then
-                break
-            end
+for _, argument in ipairs({ ... }) do
+    if argument:sub(1, 1) == "-" then
+        for _, option in ipairs(options) do
+            if option[2](argument:match(option[1])) then break end
         end
     end
 end
 
 -- Config yields 5 times with progress
-local config_base =  {
-  processor = {
-    mvendorid = -1,
-    mimpid = -1,
-    marchid = -1,
-  },
-  ram = {
-    image_filename = test_util.tests_path .. "htif_yield.bin",
-    length = 0x4000000,
-  },
-  rom = {
-    image_filename = test_util.tests_path .. "bootstrap.bin"
-  }
+local config_base = {
+    processor = {
+        mvendorid = -1,
+        mimpid = -1,
+        marchid = -1,
+    },
+    ram = {
+        image_filename = test_util.tests_path .. "htif_yield.bin",
+        length = 0x4000000,
+    },
+    rom = {
+        image_filename = test_util.tests_path .. "bootstrap.bin",
+    },
 }
 
 if uarch then
     assert(uarch_ram_length, "--uarch-ram-length was not specified")
     assert(uarch_ram_image_filename, "--uarch-ram-image was not specified")
-    config.uarch = {
-        ram = { length = uarch_ram_length, image_filename = uarch_ram_image_filename }
+    config_base.uarch = {
+        ram = { length = uarch_ram_length, image_filename = uarch_ram_image_filename },
     }
 end
 
 local YIELD_MANUAL = cartesi.machine.HTIF_YIELD_MANUAL
 local YIELD_AUTOMATIC = cartesi.machine.HTIF_YIELD_AUTOMATIC
 
-local REASON_PROGRESS    = cartesi.machine.HTIF_YIELD_REASON_PROGRESS
+local REASON_PROGRESS = cartesi.machine.HTIF_YIELD_REASON_PROGRESS
 local REASON_RX_ACCEPTED = cartesi.machine.HTIF_YIELD_REASON_RX_ACCEPTED
 local REASON_RX_REJECTED = cartesi.machine.HTIF_YIELD_REASON_RX_REJECTED
-local REASON_TX_VOUCHER   = cartesi.machine.HTIF_YIELD_REASON_TX_VOUCHER
-local REASON_TX_NOTICE  = cartesi.machine.HTIF_YIELD_REASON_TX_NOTICE
-local REASON_TX_REPORT   = cartesi.machine.HTIF_YIELD_REASON_TX_REPORT
-local REASON_TX_EXCEPTION   = cartesi.machine.HTIF_YIELD_REASON_TX_EXCEPTION
+local REASON_TX_VOUCHER = cartesi.machine.HTIF_YIELD_REASON_TX_VOUCHER
+local REASON_TX_NOTICE = cartesi.machine.HTIF_YIELD_REASON_TX_NOTICE
+local REASON_TX_REPORT = cartesi.machine.HTIF_YIELD_REASON_TX_REPORT
+local REASON_TX_EXCEPTION = cartesi.machine.HTIF_YIELD_REASON_TX_EXCEPTION
 
 local yields = {
-    { mcycle =  13, data = 10, cmd = YIELD_MANUAL, reason = REASON_PROGRESS},
-    { mcycle =  44, data = 11, cmd = YIELD_MANUAL, reason = REASON_PROGRESS},
-    { mcycle =  75, data = 12, cmd = YIELD_MANUAL, reason = REASON_PROGRESS},
-    { mcycle =  107, data = 13, cmd = YIELD_MANUAL, reason = REASON_RX_ACCEPTED},
-    { mcycle =  139, data = 14, cmd = YIELD_MANUAL, reason = REASON_RX_REJECTED},
-    { mcycle =  171, data = 15, cmd = YIELD_MANUAL, reason = REASON_TX_VOUCHER},
-    { mcycle =  203, data = 16, cmd = YIELD_MANUAL, reason = REASON_TX_NOTICE},
-    { mcycle = 235, data = 17, cmd = YIELD_MANUAL, reason = REASON_TX_REPORT},
-    { mcycle = 267, data = 18, cmd = YIELD_MANUAL, reason = REASON_TX_EXCEPTION},
+    { mcycle = 13, data = 10, cmd = YIELD_MANUAL, reason = REASON_PROGRESS },
+    { mcycle = 44, data = 11, cmd = YIELD_MANUAL, reason = REASON_PROGRESS },
+    { mcycle = 75, data = 12, cmd = YIELD_MANUAL, reason = REASON_PROGRESS },
+    { mcycle = 107, data = 13, cmd = YIELD_MANUAL, reason = REASON_RX_ACCEPTED },
+    { mcycle = 139, data = 14, cmd = YIELD_MANUAL, reason = REASON_RX_REJECTED },
+    { mcycle = 171, data = 15, cmd = YIELD_MANUAL, reason = REASON_TX_VOUCHER },
+    { mcycle = 203, data = 16, cmd = YIELD_MANUAL, reason = REASON_TX_NOTICE },
+    { mcycle = 235, data = 17, cmd = YIELD_MANUAL, reason = REASON_TX_REPORT },
+    { mcycle = 267, data = 18, cmd = YIELD_MANUAL, reason = REASON_TX_EXCEPTION },
 
-    { mcycle = 298, data = 20, cmd = YIELD_AUTOMATIC, reason = REASON_PROGRESS},
-    { mcycle = 329, data = 21, cmd = YIELD_AUTOMATIC, reason = REASON_PROGRESS},
-    { mcycle = 360, data = 22, cmd = YIELD_AUTOMATIC, reason = REASON_PROGRESS},
-    { mcycle = 392, data = 23, cmd = YIELD_AUTOMATIC, reason = REASON_RX_ACCEPTED},
-    { mcycle = 424, data = 24, cmd = YIELD_AUTOMATIC, reason = REASON_RX_REJECTED},
-    { mcycle = 456, data = 25, cmd = YIELD_AUTOMATIC, reason = REASON_TX_VOUCHER},
-    { mcycle = 488, data = 26, cmd = YIELD_AUTOMATIC, reason = REASON_TX_NOTICE},
-    { mcycle = 520, data = 27, cmd = YIELD_AUTOMATIC, reason = REASON_TX_REPORT},
+    { mcycle = 298, data = 20, cmd = YIELD_AUTOMATIC, reason = REASON_PROGRESS },
+    { mcycle = 329, data = 21, cmd = YIELD_AUTOMATIC, reason = REASON_PROGRESS },
+    { mcycle = 360, data = 22, cmd = YIELD_AUTOMATIC, reason = REASON_PROGRESS },
+    { mcycle = 392, data = 23, cmd = YIELD_AUTOMATIC, reason = REASON_RX_ACCEPTED },
+    { mcycle = 424, data = 24, cmd = YIELD_AUTOMATIC, reason = REASON_RX_REJECTED },
+    { mcycle = 456, data = 25, cmd = YIELD_AUTOMATIC, reason = REASON_TX_VOUCHER },
+    { mcycle = 488, data = 26, cmd = YIELD_AUTOMATIC, reason = REASON_TX_NOTICE },
+    { mcycle = 520, data = 27, cmd = YIELD_AUTOMATIC, reason = REASON_TX_REPORT },
 }
 
 local function run_machine_with_uarch(machine)
@@ -133,11 +147,11 @@ local function run_machine_with_uarch(machine)
     while true do
         local ubr = machine:run_uarch()
         if ubr == cartesi.UARCH_BREAK_REASON_HALTED then
-            -- iflags.H was already set when uarch started 
+            -- iflags.H was already set when uarch started
             return cartesi.BREAK_REASON_HALTED
         end
         if ubr == cartesi.UARCH_BREAK_REASON_YIELDED_MANUALLY then
-            -- iflags.Y was already set when uarch started 
+            -- iflags.Y was already set when uarch started
             return cartesi.BREAK_REASON_YIELDED_MANUALLY
         end
         if ubr == cartesi.UARCH_BREAK_REASON_UARCH_HALTED then
@@ -159,22 +173,19 @@ local function run_machine_with_uarch(machine)
 end
 
 local function run_machine(machine)
-    if uarch then
-        return run_machine_with_uarch(machine)
-    end
+    if uarch then return run_machine_with_uarch(machine) end
     return machine:run()
 end
 
-local function stderr(...)
-    io.stderr:write(string.format(...))
-end
+local function stderr(...) io.stderr:write(string.format(...)) end
 
 local final_mcycle = 561
 local exit_payload = 42
 local progress_enable = false
 
 local function test(config, yield_automatic_enable, yield_manual_enable)
-    stderr("  testing yield_automatic:%s yield_manual:%s\n",
+    stderr(
+        "  testing yield_automatic:%s yield_manual:%s\n",
         yield_automatic_enable and "on" or "off",
         yield_manual_enable and "on" or "off"
     )
@@ -185,24 +196,24 @@ local function test(config, yield_automatic_enable, yield_manual_enable)
     local machine = cartesi.machine(config)
     local break_reason
     for _, v in ipairs(yields) do
-        if (v.reason == REASON_PROGRESS and progress_enable) or
-           (v.cmd    == YIELD_MANUAL and yield_manual_enable) or
-           (v.cmd    == YIELD_AUTOMATIC and yield_automatic_enable)
+        if
+            (v.reason == REASON_PROGRESS and progress_enable)
+            or (v.cmd == YIELD_MANUAL and yield_manual_enable)
+            or (v.cmd == YIELD_AUTOMATIC and yield_automatic_enable)
         then
-            while not machine:read_iflags_Y() and
-                  not machine:read_iflags_X() and
-                  not machine:read_iflags_H() do
+            while not machine:read_iflags_Y() and not machine:read_iflags_X() and not machine:read_iflags_H() do
                 break_reason = run_machine(machine)
             end
 
             -- mcycle should be as expected
             local mcycle = machine:read_mcycle()
-            assert(mcycle == v.mcycle,
-                string.format("mcycle: expected %d, got %d", v.mcycle, mcycle))
+            assert(mcycle == v.mcycle, string.format("mcycle: expected %d, got %d", v.mcycle, mcycle))
 
             if yield_automatic_enable and v.cmd == YIELD_AUTOMATIC then
-                assert(break_reason == cartesi.BREAK_REASON_YIELDED_AUTOMATICALLY,
-                    "expected break reason yielded automatically")
+                assert(
+                    break_reason == cartesi.BREAK_REASON_YIELDED_AUTOMATICALLY,
+                    "expected break reason yielded automatically"
+                )
                 assert(machine:read_iflags_X(), "expected iflags_X set")
                 assert(not machine:read_iflags_Y(), "expected iflags_Y not set")
             elseif yield_manual_enable and v.cmd == YIELD_MANUAL then
@@ -217,8 +228,7 @@ local function test(config, yield_automatic_enable, yield_manual_enable)
             local data = machine:read_htif_tohost_data()
             local reason = data >> 32
             data = data << 32 >> 32
-            assert(data == v.data,
-                string.format("data: expected %d, got %d", v.data, data))
+            assert(data == v.data, string.format("data: expected %d, got %d", v.data, data))
             assert(reason == v.reason)
             -- cmd should be as expected
             assert(machine:read_htif_tohost_cmd() == v.cmd)
@@ -241,19 +251,22 @@ local function test(config, yield_automatic_enable, yield_manual_enable)
     assert(break_reason == cartesi.BREAK_REASON_HALTED)
     assert(machine:read_iflags_H(), "expected iflags_H set")
     -- at the expected mcycle
-    assert(machine:read_mcycle() == final_mcycle, string.format("mcycle: expected, %u got %u",
-        final_mcycle, machine:read_mcycle()))
+    assert(
+        machine:read_mcycle() == final_mcycle,
+        string.format("mcycle: expected, %u got %u", final_mcycle, machine:read_mcycle())
+    )
     -- with the expected payload
-    assert((machine:read_htif_tohost_data() >> 1) == exit_payload,
-        string.format("exit payload: expected %u, got %u\n", exit_payload,
-            machine:read_htif_tohost_data() >> 1))
+    assert(
+        (machine:read_htif_tohost_data() >> 1) == exit_payload,
+        string.format("exit payload: expected %u, got %u\n", exit_payload, machine:read_htif_tohost_data() >> 1)
+    )
     stderr("    passed\n")
 end
 
 stderr("testing yield sink\n")
 
-for _, auto in ipairs{true, false} do
-    for _, manual in ipairs{true, false} do
+for _, auto in ipairs({ true, false }) do
+    for _, manual in ipairs({ true, false }) do
         test(config_base, auto, manual)
     end
 end

--- a/src/tests/htif-yield.lua
+++ b/src/tests/htif-yield.lua
@@ -73,7 +73,7 @@ for i, argument in ipairs({...}) do
 end
 
 -- Config yields 5 times with progress
-local config =  {
+local config_base =  {
   processor = {
     mvendorid = -1,
     mimpid = -1,
@@ -171,6 +171,7 @@ end
 
 local final_mcycle = 561
 local exit_payload = 42
+local progress_enable = false
 
 local function test(config, yield_automatic_enable, yield_manual_enable)
     stderr("  testing yield_automatic:%s yield_manual:%s\n",
@@ -183,7 +184,7 @@ local function test(config, yield_automatic_enable, yield_manual_enable)
     }
     local machine = cartesi.machine(config)
     local break_reason
-    for i, v in ipairs(yields) do
+    for _, v in ipairs(yields) do
         if (v.reason == REASON_PROGRESS and progress_enable) or
            (v.cmd    == YIELD_MANUAL and yield_manual_enable) or
            (v.cmd    == YIELD_AUTOMATIC and yield_automatic_enable)
@@ -200,7 +201,8 @@ local function test(config, yield_automatic_enable, yield_manual_enable)
                 string.format("mcycle: expected %d, got %d", v.mcycle, mcycle))
 
             if yield_automatic_enable and v.cmd == YIELD_AUTOMATIC then
-                assert(break_reason == cartesi.BREAK_REASON_YIELDED_AUTOMATICALLY, "expected break reason yielded automatically")
+                assert(break_reason == cartesi.BREAK_REASON_YIELDED_AUTOMATICALLY,
+                    "expected break reason yielded automatically")
                 assert(machine:read_iflags_X(), "expected iflags_X set")
                 assert(not machine:read_iflags_Y(), "expected iflags_Y not set")
             elseif yield_manual_enable and v.cmd == YIELD_MANUAL then
@@ -252,6 +254,6 @@ stderr("testing yield sink\n")
 
 for _, auto in ipairs{true, false} do
     for _, manual in ipairs{true, false} do
-        test(config, auto, manual)
+        test(config_base, auto, manual)
     end
 end

--- a/src/tests/log-with-mtime-transition.lua
+++ b/src/tests/log-with-mtime-transition.lua
@@ -5,7 +5,8 @@ local cartesi = require"cartesi"
 
 local rom_filename = os.tmpname()
 io.open(rom_filename, 'w'):close()
-local deleter = setmetatable({}, { __gc = function() os.remove(rom_filename) end } )
+local rom_deleter = {}
+setmetatable(rom_deleter, { __gc = function() os.remove(rom_filename) end } )
 
 local config = {
     processor = {
@@ -20,7 +21,7 @@ local config = {
     rom = {
         image_filename = rom_filename
     },
-    uarch = { 
+    uarch = {
         ram = { length = 1 << 20, image_filename = test_util.create_test_uarch_program() }
     }
 }

--- a/src/tests/log-with-mtime-transition.lua
+++ b/src/tests/log-with-mtime-transition.lua
@@ -1,29 +1,29 @@
 #!/usr/bin/env lua5.4
 
-local test_util = require "tests.util"
-local cartesi = require"cartesi"
+local test_util = require("tests.util")
+local cartesi = require("cartesi")
 
 local rom_filename = os.tmpname()
-io.open(rom_filename, 'w'):close()
+io.open(rom_filename, "w"):close()
 local rom_deleter = {}
-setmetatable(rom_deleter, { __gc = function() os.remove(rom_filename) end } )
+setmetatable(rom_deleter, { __gc = function() os.remove(rom_filename) end })
 
 local config = {
     processor = {
         marchid = -1,
         mimplid = -1,
         mvendorid = -1,
-        mcycle = 99
+        mcycle = 99,
     },
     ram = {
-        length = 1<<12
+        length = 1 << 12,
     },
     rom = {
-        image_filename = rom_filename
+        image_filename = rom_filename,
     },
     uarch = {
-        ram = { length = 1 << 20, image_filename = test_util.create_test_uarch_program() }
-    }
+        ram = { length = 1 << 20, image_filename = test_util.create_test_uarch_program() },
+    },
 }
 local machine = cartesi.machine(config)
 os.remove(config.uarch.ram.image_filename)

--- a/src/tests/machine-bind.lua
+++ b/src/tests/machine-bind.lua
@@ -21,8 +21,8 @@
 -- Note: for jsongrpc machine test to work, jsonrpc-remote-cartesi-machine must run on
 -- same computer and jsonrpc-remote-cartesi-machine execution path must be provided
 
-local cartesi = require "cartesi"
-local test_util = require "tests.util"
+local cartesi = require("cartesi")
+local test_util = require("tests.util")
 
 local remote_address
 local checkin_address
@@ -37,7 +37,8 @@ local MAX_UARCH_CYCLE = -1
 
 -- Print help and exit
 local function help()
-    io.stderr:write(string.format([=[
+    io.stderr:write(string.format(
+        [=[
 Usage:
 
   %s <machine_type> [options]
@@ -61,67 +62,77 @@ where options are:
    unix:<path>
 
 <host> can be a host name, IPv4 or IPv6 address.
-]=], arg[0]))
+]=],
+        arg[0]
+    ))
     os.exit()
 end
 
-
 local options = {
-    { "^%-%-h$", function(all)
-        if not all then return false end
-        help()
-    end },
-    { "^%-%-help$", function(all)
-        if not all then return false end
-        help()
-    end },
-    { "^%-%-remote%-address%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        remote_address = o
-        return true
-    end },
-    { "^%-%-checkin%-address%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        checkin_address = o
-        return true
-    end },
-    { "^%-%-test%-path%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        test_path = o
-        if string.sub(test_path, -1, -1) ~= "/" then
-            error("test-path must end in '/'")
-        end
-        return true
-    end },
-    { ".*", function(all)
-        error("unrecognized option " .. all)
-    end }
+    {
+        "^%-%-h$",
+        function(all)
+            if not all then return false end
+            help()
+        end,
+    },
+    {
+        "^%-%-help$",
+        function(all)
+            if not all then return false end
+            help()
+        end,
+    },
+    {
+        "^%-%-remote%-address%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            remote_address = o
+            return true
+        end,
+    },
+    {
+        "^%-%-checkin%-address%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            checkin_address = o
+            return true
+        end,
+    },
+    {
+        "^%-%-test%-path%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            test_path = o
+            if string.sub(test_path, -1, -1) ~= "/" then error("test-path must end in '/'") end
+            return true
+        end,
+    },
+    { ".*", function(all) error("unrecognized option " .. all) end },
 }
 
 -- Process command line options
 local arguments = {}
-for _, argument in ipairs({...}) do
-    if argument:sub(1,1) == "-" then
+for _, argument in ipairs({ ... }) do
+    if argument:sub(1, 1) == "-" then
         for _, option in ipairs(options) do
-            if option[2](argument:match(option[1])) then
-                break
-            end
+            if option[2](argument:match(option[1])) then break end
         end
     else
-        arguments[#arguments+1] = argument
+        arguments[#arguments + 1] = argument
     end
 end
 
 local SHADOW_BASE = 0x0
 
 local cpu_x_addr = {}
-for i=0,31 do
+for i = 0, 31 do
     cpu_x_addr[i] = i * 8
 end
 
 local function get_cpu_xreg_test_values()
     local values = {}
-    for i=0,31 do
+    for i = 0, 31 do
         values[i] = i * 8
     end
     return values
@@ -129,7 +140,7 @@ end
 
 local function get_cpu_uarch_xreg_test_values()
     local values = {}
-    for i=0,31 do
+    for i = 0, 31 do
         values[i] = 0x10000 + (i * 8)
     end
     return values
@@ -209,16 +220,18 @@ local function get_cpu_csr_test_values()
 end
 
 local machine_type = assert(arguments[1], "missing machine type")
-assert(machine_type == "local" or machine_type == "grpc" or machine_type == "jsonrpc",
-    "unknown machine type, should be 'local', 'grpc', or 'jsonrpc'")
+assert(
+    machine_type == "local" or machine_type == "grpc" or machine_type == "jsonrpc",
+    "unknown machine type, should be 'local', 'grpc', or 'jsonrpc'"
+)
 local protocol
-if (machine_type == "grpc") then
+if machine_type == "grpc" then
     assert(remote_address ~= nil, "remote cartesi machine address is missing")
     assert(checkin_address, "missing checkin address")
     assert(test_path ~= nil, "test path must be provided and must be working directory of remote cartesi machine")
     protocol = require("cartesi.grpc")
 end
-if (machine_type == "jsonrpc") then
+if machine_type == "jsonrpc" then
     assert(remote_address ~= nil, "remote cartesi machine address is missing")
     assert(test_path ~= nil, "test path must be provided and must be working directory of remote cartesi machine")
     protocol = require("cartesi.jsonrpc")
@@ -226,10 +239,9 @@ end
 
 local function connect()
     local remote = protocol.stub(remote_address, checkin_address)
-    local version = assert(remote.get_version(),
-        "could not connect to remote cartesi machine at " .. remote_address)
+    local version = assert(remote.get_version(), "could not connect to remote cartesi machine at " .. remote_address)
     local shutdown = function() remote.shutdown() end
-    local mt = { __gc = function() pcall(shutdown) end}
+    local mt = { __gc = function() pcall(shutdown) end }
     setmetatable(cleanup, mt)
     return remote, version
 end
@@ -242,9 +254,9 @@ local pmas_file_names = {
     "0000000002000000--00000000000c0000.bin", -- clint
     "0000000040008000--0000000000001000.bin", -- htif
     "0000000080000000--0000000000100000.bin", -- ram
-    "0000000070000000--0000000000010000.bin"  -- uarch ram
+    "0000000070000000--0000000000010000.bin", -- uarch ram
 }
-local pmas_sizes = { 4096, 61440, 4096, 24576, 786432, 4096, 1048576, 65536, 65536}
+local pmas_sizes = { 4096, 61440, 4096, 24576, 786432, 4096, 1048576, 65536, 65536 }
 
 local remote
 local function build_machine(type)
@@ -256,23 +268,23 @@ local function build_machine(type)
     initial_csr_values.x = initial_xreg_values
     local config = {
         processor = initial_csr_values,
-        rom = {image_filename = test_util.images_path .. "rom.bin"},
-        ram = {length = 1 << 20},
+        rom = { image_filename = test_util.images_path .. "rom.bin" },
+        ram = { length = 1 << 20 },
         uarch = {
             processor = {
-                x = initial_uarch_xreg_values
+                x = initial_uarch_xreg_values,
             },
             ram = { length = 1 << 16, image_filename = test_util.create_test_uarch_program() },
-        }
+        },
     }
     local runtime = {
         concurrency = {
-            update_merkle_tree = concurrency_update_merkle_tree
-        }
+            update_merkle_tree = concurrency_update_merkle_tree,
+        },
     }
 
     local new_machine
-    if (type ~= "local") then
+    if type ~= "local" then
         if not remote then remote = connect() end
         new_machine = assert(remote.machine(config, runtime))
     else
@@ -291,131 +303,119 @@ local do_test = test_util.make_do_test(build_machine, machine_type)
 print("Testing machine bindings for type " .. machine_type)
 
 print("\n\ntesting machine initial flags")
-do_test("machine should not have halt and yield initial flags set",
-    function(machine)
-        -- Check machine is not halted
-        assert(not machine:read_iflags_H(), "machine shouldn't be halted")
-        -- Check machine is not yielded
-        assert(not machine:read_iflags_Y(), "machine shouldn't be yielded")
-    end
-)
+do_test("machine should not have halt and yield initial flags set", function(machine)
+    -- Check machine is not halted
+    assert(not machine:read_iflags_H(), "machine shouldn't be halted")
+    -- Check machine is not yielded
+    assert(not machine:read_iflags_Y(), "machine shouldn't be yielded")
+end)
 
 print("\n\ntesting machine register initial flag values ")
-do_test("machine should have default config shadow register values",
-    function(machine)
-        local initial_csr_values = get_cpu_csr_test_values()
-        local initial_xreg_values = get_cpu_xreg_test_values()
-        initial_csr_values.x = nil
-        initial_csr_values.mvendorid = nil
-        initial_csr_values.marchid = nil
-        initial_csr_values.mimpid = nil
-        -- Check initialization and shadow reads
-        for k, v in pairs(initial_csr_values) do
-            local r = machine:read_word(cpu_csr_addr[k])
-            assert(v == r)
-        end
-        for k, v in pairs(initial_xreg_values) do
-            local r = machine:read_word(cpu_x_addr[k])
-            assert(v == r)
-        end
+do_test("machine should have default config shadow register values", function(machine)
+    local initial_csr_values = get_cpu_csr_test_values()
+    local initial_xreg_values = get_cpu_xreg_test_values()
+    initial_csr_values.x = nil
+    initial_csr_values.mvendorid = nil
+    initial_csr_values.marchid = nil
+    initial_csr_values.mimpid = nil
+    -- Check initialization and shadow reads
+    for k, v in pairs(initial_csr_values) do
+        local r = machine:read_word(cpu_csr_addr[k])
+        assert(v == r)
     end
-)
+    for k, v in pairs(initial_xreg_values) do
+        local r = machine:read_word(cpu_x_addr[k])
+        assert(v == r)
+    end
+end)
 
 print("\n\ntesting merkle tree get_proof for values for registers")
-do_test("should provide proof for values in registers",
-    function(machine)
-        local initial_csr_values = get_cpu_csr_test_values()
-        local initial_xreg_values = get_cpu_xreg_test_values()
-        initial_csr_values.x = nil
-        initial_csr_values.mvendorid = nil
-        initial_csr_values.marchid = nil
-        initial_csr_values.mimpid = nil
+do_test("should provide proof for values in registers", function(machine)
+    local initial_csr_values = get_cpu_csr_test_values()
+    local initial_xreg_values = get_cpu_xreg_test_values()
+    initial_csr_values.x = nil
+    initial_csr_values.mvendorid = nil
+    initial_csr_values.marchid = nil
+    initial_csr_values.mimpid = nil
 
-        -- Check proofs
-        for _, v in pairs(initial_csr_values) do
-            for el = 3, 63 do
-                local a = test_util.align(v, el)
-                assert(test_util.check_proof(assert(machine:get_proof(a, el)),
-                                            "no proof"), "proof failed")
-            end
-        end
-
-        for _, v in pairs(initial_xreg_values) do
-            for el = 3, 63 do
-                local a = test_util.align(v, el)
-                assert(test_util.check_proof(
-                        assert(machine:get_proof(a, el), "no proof")),
-                    "proof failed")
-            end
+    -- Check proofs
+    for _, v in pairs(initial_csr_values) do
+        for el = 3, 63 do
+            local a = test_util.align(v, el)
+            assert(test_util.check_proof(assert(machine:get_proof(a, el)), "no proof"), "proof failed")
         end
     end
-)
+
+    for _, v in pairs(initial_xreg_values) do
+        for el = 3, 63 do
+            local a = test_util.align(v, el)
+            assert(test_util.check_proof(assert(machine:get_proof(a, el), "no proof")), "proof failed")
+        end
+    end
+end)
 
 print("\n\ntesting get_csr_address function binding")
-do_test("should return address value for csr register",
-    function()
-        local module = cartesi
-        if (machine_type ~= "local") then
-            if not remote then remote = connect() end
-            module = remote
-        end
-        -- Check CSR address
-        for k, v in pairs(cpu_csr_addr) do
-            local u = module.machine.get_csr_address(k)
-            assert(u == v, "invalid return for " .. v)
-        end
+do_test("should return address value for csr register", function()
+    local module = cartesi
+    if machine_type ~= "local" then
+        if not remote then remote = connect() end
+        module = remote
     end
-)
+    -- Check CSR address
+    for k, v in pairs(cpu_csr_addr) do
+        local u = module.machine.get_csr_address(k)
+        assert(u == v, "invalid return for " .. v)
+    end
+end)
 
 print("\n\ntesting get_x_address function binding")
-do_test("should return address value for x registers",
-    function()
-        local module = cartesi
-        if (machine_type ~= "local") then
-            if not remote then remote = connect() end
-            module = remote
-        end
-        -- Check x address
-        for i = 0,31 do
-            assert(module.machine.get_x_address(i) == SHADOW_BASE+i*8, "invalid return for x"..i)
-        end
+do_test("should return address value for x registers", function()
+    local module = cartesi
+    if machine_type ~= "local" then
+        if not remote then remote = connect() end
+        module = remote
     end
-)
+    -- Check x address
+    for i = 0, 31 do
+        assert(module.machine.get_x_address(i) == SHADOW_BASE + i * 8, "invalid return for x" .. i)
+    end
+end)
 
 print("\n\ntesting get_x_uarch_address function binding")
-    do_test("should return address value for uarch x registers",
-        function()
-            local SHADOW_UARCH_XBASE = 0x340
-            local module = cartesi
-            if (machine_type == "grpc") then
-                if not remote then remote = connect() end
-                module = remote
-            end
-            -- Check x address
-            for i = 0,31 do
-                assert(module.machine.get_uarch_x_address(i) == SHADOW_UARCH_XBASE+i*8, "invalid return for uarch x"..i)
-            end
-        end
-    )
+do_test("should return address value for uarch x registers", function()
+    local SHADOW_UARCH_XBASE = 0x340
+    local module = cartesi
+    if machine_type == "grpc" then
+        if not remote then remote = connect() end
+        module = remote
+    end
+    -- Check x address
+    for i = 0, 31 do
+        assert(module.machine.get_uarch_x_address(i) == SHADOW_UARCH_XBASE + i * 8, "invalid return for uarch x" .. i)
+    end
+end)
 
 local function test_config_memory_range(range, name)
-    assert(type(range.length) == "number", "invalid "..name..".length")
-    assert(type(range.start) == "number", "invalid "..name..".start")
-    assert(range.shared == nil or type(range.shared) == "boolean", "invalid "..name..".shared")
-    assert(range.image_filename == nil or type(range.image_filename) == "string", "invalid "..name..".image_filename")
+    assert(type(range.length) == "number", "invalid " .. name .. ".length")
+    assert(type(range.start) == "number", "invalid " .. name .. ".start")
+    assert(range.shared == nil or type(range.shared) == "boolean", "invalid " .. name .. ".shared")
+    assert(
+        range.image_filename == nil or type(range.image_filename) == "string",
+        "invalid " .. name .. ".image_filename"
+    )
 end
 
 local function test_config(config)
     assert(type(config) == "table", "config not a table")
-    for _, field in ipairs{"processor", "htif", "clint", "flash_drive", "ram", "rom"} do
-        assert(config[field] and type(config[field]) == 'table', "invalid field " .. field)
+    for _, field in ipairs({ "processor", "htif", "clint", "flash_drive", "ram", "rom" }) do
+        assert(config[field] and type(config[field]) == "table", "invalid field " .. field)
     end
     for i = 1, 31 do
-        assert(type(config.processor.x[i]) == "number", "x"..i.." is not a number")
+        assert(type(config.processor.x[i]) == "number", "x" .. i .. " is not a number")
     end
     local htif = config.htif
-    for _, field in ipairs{"console_getchar", "yield_manual", "yield_automatic"} do
-        assert(htif[field] == nil or type(htif[field]) == "boolean", "invalid htif."..field)
+    for _, field in ipairs({ "console_getchar", "yield_manual", "yield_automatic" }) do
+        assert(htif[field] == nil or type(htif[field]) == "boolean", "invalid htif." .. field)
     end
     assert(type(htif.tohost) == "number", "invalid htif.tohost")
     assert(type(htif.fromhost) == "number", "invalid htif.fromhost")
@@ -443,281 +443,238 @@ local function test_config(config)
 end
 
 print("\n\ntesting get_default_config function binding")
-do_test("should return default machine config",
-    function()
-        local module = cartesi
-        if (machine_type ~= "local") then
-            if not remote then remote = connect() end
-            module = remote
-        end
-        test_config(module.machine.get_default_config())
+do_test("should return default machine config", function()
+    local module = cartesi
+    if machine_type ~= "local" then
+        if not remote then remote = connect() end
+        module = remote
     end
-)
+    test_config(module.machine.get_default_config())
+end)
 
 print("\n\n test verifying integrity of the merkle tree")
-do_test("verify_merkle_tree should return true",
-    function(machine)
-        -- Verify starting merkle tree
-        assert(machine:verify_merkle_tree(), "error, non consistent merkle tree")
-    end
-)
+do_test("verify_merkle_tree should return true", function(machine)
+    -- Verify starting merkle tree
+    assert(machine:verify_merkle_tree(), "error, non consistent merkle tree")
+end)
 
 print("\n\n test calculation of initial root hash")
-do_test("should return expected value",
-    function(machine)
-        -- Get starting root hash
-        local root_hash = machine:get_root_hash()
-        print("Root hash: ", test_util.tohex(root_hash))
+do_test("should return expected value", function(machine)
+    -- Get starting root hash
+    local root_hash = machine:get_root_hash()
+    print("Root hash: ", test_util.tohex(root_hash))
 
-        machine:dump_pmas()
-        local calculated_root_hash = test_util.calculate_emulator_hash(test_path,
-                                                pmas_file_names, machine)
-        for _, file_name in pairs(pmas_file_names) do
-            os.remove(test_path .. file_name)
-        end
-
-        assert(test_util.tohex(root_hash) == test_util.tohex(calculated_root_hash),
-            "initial root hash does not match")
+    machine:dump_pmas()
+    local calculated_root_hash = test_util.calculate_emulator_hash(test_path, pmas_file_names, machine)
+    for _, file_name in pairs(pmas_file_names) do
+        os.remove(test_path .. file_name)
     end
-)
+
+    assert(test_util.tohex(root_hash) == test_util.tohex(calculated_root_hash), "initial root hash does not match")
+end)
 
 print("\n\n test get_initial_config")
-do_test("should have expected values",
-    function(machine)
-        -- Check initial config
-        local initial_config = machine:get_initial_config()
-        test_config(initial_config)
-        assert(initial_config.processor.pc == 0x200,
-            "wrong pc reg initial config value")
-        assert(initial_config.processor.ilrsc == 0x2e0,
-            "wrong ilrsc reg initial config value")
-        assert(initial_config.processor.mstatus == 0x230,
-            "wrong mstatus reg initial config value")
-        assert(initial_config.clint.mtimecmp == 0,
-            "wrong clint mtimecmp initial config value")
-        assert(initial_config.htif.fromhost == 0,
-            "wrong htif fromhost initial config value")
-        assert(initial_config.htif.tohost == 0,
-            "wrong htif tohost initial config value")
-        assert(initial_config.htif.yield_automatic == false,
-            "wrong htif yield automatic initial config value")
-        assert(initial_config.htif.yield_manual == false,
-            "wrong htif yield manual initial config value")
-        assert(initial_config.rom.image_filename == test_util.images_path .. "rom.bin",
-            "wrong initial config image path name")
-    end
-)
+do_test("should have expected values", function(machine)
+    -- Check initial config
+    local initial_config = machine:get_initial_config()
+    test_config(initial_config)
+    assert(initial_config.processor.pc == 0x200, "wrong pc reg initial config value")
+    assert(initial_config.processor.ilrsc == 0x2e0, "wrong ilrsc reg initial config value")
+    assert(initial_config.processor.mstatus == 0x230, "wrong mstatus reg initial config value")
+    assert(initial_config.clint.mtimecmp == 0, "wrong clint mtimecmp initial config value")
+    assert(initial_config.htif.fromhost == 0, "wrong htif fromhost initial config value")
+    assert(initial_config.htif.tohost == 0, "wrong htif tohost initial config value")
+    assert(initial_config.htif.yield_automatic == false, "wrong htif yield automatic initial config value")
+    assert(initial_config.htif.yield_manual == false, "wrong htif yield manual initial config value")
+    assert(
+        initial_config.rom.image_filename == test_util.images_path .. "rom.bin",
+        "wrong initial config image path name"
+    )
+end)
 
 print("\n\n test read_csr")
-do_test("should return expected values",
-    function(machine)
-        local initial_csr_values = get_cpu_csr_test_values()
-        initial_csr_values.mvendorid = cartesi.MVENDORID
-        initial_csr_values.marchid = cartesi.MARCHID
-        initial_csr_values.mimpid = cartesi.MIMPID
-        initial_csr_values.htif_tohost = 0x0
-        initial_csr_values.htif_fromhost = 0x0
-        initial_csr_values.htif_ihalt = 0x0
-        initial_csr_values.htif_iconsole = 0x0
-        initial_csr_values.htif_iyield = 0x0
+do_test("should return expected values", function(machine)
+    local initial_csr_values = get_cpu_csr_test_values()
+    initial_csr_values.mvendorid = cartesi.MVENDORID
+    initial_csr_values.marchid = cartesi.MARCHID
+    initial_csr_values.mimpid = cartesi.MIMPID
+    initial_csr_values.htif_tohost = 0x0
+    initial_csr_values.htif_fromhost = 0x0
+    initial_csr_values.htif_ihalt = 0x0
+    initial_csr_values.htif_iconsole = 0x0
+    initial_csr_values.htif_iyield = 0x0
 
-        -- Check csr register read
-        local to_ignore = {
-            iflags = true,
-            clint_mtimecmp = true,
-            htif_ihalt = true,
-            htif_iconsole = true,
-        }
-        for k in pairs(cpu_csr_addr) do
-            if not to_ignore[k] then
-                local method_name = "read_" .. k
-                assert(machine[method_name](machine) == initial_csr_values[k],
-                    "wrong " .. k .. " value")
-            end
+    -- Check csr register read
+    local to_ignore = {
+        iflags = true,
+        clint_mtimecmp = true,
+        htif_ihalt = true,
+        htif_iconsole = true,
+    }
+    for k in pairs(cpu_csr_addr) do
+        if not to_ignore[k] then
+            local method_name = "read_" .. k
+            assert(machine[method_name](machine) == initial_csr_values[k], "wrong " .. k .. " value")
         end
     end
-)
+end)
 
 print("\n\n dump pmas to files")
-do_test("there should exist dumped files of expected size",
-    function(machine)
-        -- Dump pmas to files
-        machine:dump_pmas()
+do_test("there should exist dumped files of expected size", function(machine)
+    -- Dump pmas to files
+    machine:dump_pmas()
 
-        for i = 1, #pmas_file_names do
-            local dumped_file = test_path .. pmas_file_names[i]
-            local fd = assert(io.open(dumped_file, "rb"))
-            local real_file_size = fd:seek("end")
-            fd:close(dumped_file)
+    for i = 1, #pmas_file_names do
+        local dumped_file = test_path .. pmas_file_names[i]
+        local fd = assert(io.open(dumped_file, "rb"))
+        local real_file_size = fd:seek("end")
+        fd:close(dumped_file)
 
-            assert(real_file_size == pmas_sizes[i],
-                "unexpected pmas file size " .. dumped_file)
+        assert(real_file_size == pmas_sizes[i], "unexpected pmas file size " .. dumped_file)
 
-            assert(test_util.file_exists(dumped_file),
-                "dumping pmas to file failed " .. dumped_file)
+        assert(test_util.file_exists(dumped_file), "dumping pmas to file failed " .. dumped_file)
 
-            os.remove(dumped_file)
-        end
+        os.remove(dumped_file)
     end
-)
-
+end)
 
 print("\n\n read and write x registers")
-do_test("writen and expected register values should match",
-    function(machine)
-        local initial_xreg_values = get_cpu_xreg_test_values()
-        -- Write/Read X registers
-        local x1_initial_value = machine:read_x(1)
-        assert(x1_initial_value == initial_xreg_values[1], "error reading x1 register")
-        machine:write_x(1, 0x1122)
-        assert(machine:read_x(1) == 0x1122, "error with writing to x1 register")
-        machine:write_x(1, x1_initial_value)
-        assert(machine:read_x(1) == x1_initial_value)
-        -- Read unexsisting register
-        local status_invalid_reg = pcall(machine.read_x, machine, 1000)
-        assert(status_invalid_reg == false, "no error reading invalid x register")
-    end
-)
+do_test("writen and expected register values should match", function(machine)
+    local initial_xreg_values = get_cpu_xreg_test_values()
+    -- Write/Read X registers
+    local x1_initial_value = machine:read_x(1)
+    assert(x1_initial_value == initial_xreg_values[1], "error reading x1 register")
+    machine:write_x(1, 0x1122)
+    assert(machine:read_x(1) == 0x1122, "error with writing to x1 register")
+    machine:write_x(1, x1_initial_value)
+    assert(machine:read_x(1) == x1_initial_value)
+    -- Read unexsisting register
+    local status_invalid_reg = pcall(machine.read_x, machine, 1000)
+    assert(status_invalid_reg == false, "no error reading invalid x register")
+end)
 
 print("\n\n read and write uarch x registers")
-do_test("writen and expected register values should match",
-    function(machine)
-        local initial_xreg_values = get_cpu_uarch_xreg_test_values()
-        -- Write/Read uarch X registers
-        local x1_initial_value = machine:read_uarch_x(1)
-        assert(x1_initial_value == initial_xreg_values[1], "error reading uarch x1 register")
-        machine:write_uarch_x(1, 0x1122)
-        assert(machine:read_uarch_x(1) == 0x1122, "error with writing to uarch x1 register")
-        machine:write_uarch_x(1, x1_initial_value)
-        assert(machine:read_uarch_x(1) == x1_initial_value)
-        -- Read unexsisting uarch register
-        local status_invalid_reg = pcall(machine.read_uarch_x, machine, 1000)
-        assert(status_invalid_reg == false, "no error reading invalid uarch x register")
-    end
-)
+do_test("writen and expected register values should match", function(machine)
+    local initial_xreg_values = get_cpu_uarch_xreg_test_values()
+    -- Write/Read uarch X registers
+    local x1_initial_value = machine:read_uarch_x(1)
+    assert(x1_initial_value == initial_xreg_values[1], "error reading uarch x1 register")
+    machine:write_uarch_x(1, 0x1122)
+    assert(machine:read_uarch_x(1) == 0x1122, "error with writing to uarch x1 register")
+    machine:write_uarch_x(1, x1_initial_value)
+    assert(machine:read_uarch_x(1) == x1_initial_value)
+    -- Read unexsisting uarch register
+    local status_invalid_reg = pcall(machine.read_uarch_x, machine, 1000)
+    assert(status_invalid_reg == false, "no error reading invalid uarch x register")
+end)
 
 print("\n\n read and write csr registers")
-do_test("writen and expected register values should match",
-    function(machine)
-        -- Check csr register write
-        local sscratch_initial_value = machine:read_csr('sscratch')
-        assert(machine:read_sscratch() == sscratch_initial_value,
-            "error reading csr sscratch")
-        machine:write_csr('sscratch', 0x1122)
-        assert(machine:read_csr('sscratch') == 0x1122)
-        machine:write_csr('sscratch', sscratch_initial_value)
+do_test("writen and expected register values should match", function(machine)
+    -- Check csr register write
+    local sscratch_initial_value = machine:read_csr("sscratch")
+    assert(machine:read_sscratch() == sscratch_initial_value, "error reading csr sscratch")
+    machine:write_csr("sscratch", 0x1122)
+    assert(machine:read_csr("sscratch") == 0x1122)
+    machine:write_csr("sscratch", sscratch_initial_value)
 
-        -- Read unexsisting register
-        local status_invalid_reg = pcall(machine.read_csr, machine, "invalidreg")
-        assert(status_invalid_reg == false, "no error reading invalid csr register")
-    end
-)
+    -- Read unexsisting register
+    local status_invalid_reg = pcall(machine.read_csr, machine, "invalidreg")
+    assert(status_invalid_reg == false, "no error reading invalid csr register")
+end)
 
 print("\n\n perform step and check mcycle register")
-do_test("mcycle value should match",
-    function(machine)
-        local log_type = {}
-        local uarch_cycle_initial_value = machine:read_csr('uarch_cycle')
+do_test("mcycle value should match", function(machine)
+    local log_type = {}
+    local uarch_cycle_initial_value = machine:read_csr("uarch_cycle")
 
-        machine:step_uarch(log_type)
+    machine:step_uarch(log_type)
 
-        -- Check mcycle increment
-        local uarch_cycle_current_value = machine:read_csr('uarch_cycle')
-        assert(uarch_cycle_current_value == uarch_cycle_initial_value + 1,
-            "wrong uarch_cycle value")
-    end
-)
+    -- Check mcycle increment
+    local uarch_cycle_current_value = machine:read_csr("uarch_cycle")
+    assert(uarch_cycle_current_value == uarch_cycle_initial_value + 1, "wrong uarch_cycle value")
+end)
 
-do_test("should error if target mcycle is smaller than current mcycle",
-    function(machine)
-        machine:write_mcycle(MAX_MCYCLE)
-        assert(machine:read_mcycle() == MAX_MCYCLE)
-        success, err = pcall(function() machine:run(MAX_MCYCLE - 1) end)
-        assert(success == false)
-        assert(err:match("mcycle is past"))
-        assert(machine:read_mcycle() == MAX_MCYCLE)
-    end
-)
+do_test("should error if target mcycle is smaller than current mcycle", function(machine)
+    machine:write_mcycle(MAX_MCYCLE)
+    assert(machine:read_mcycle() == MAX_MCYCLE)
+    local success, err = pcall(function() machine:run(MAX_MCYCLE - 1) end)
+    assert(success == false)
+    assert(err:match("mcycle is past"))
+    assert(machine:read_mcycle() == MAX_MCYCLE)
+end)
 
-do_test("should error if target uarch_cycle is smaller than current uarch_cycle",
-    function(machine)
-        machine:write_uarch_cycle(MAX_UARCH_CYCLE)
-        assert(machine:read_uarch_cycle() == MAX_UARCH_CYCLE)
-        local success, err = pcall(function() machine:run_uarch(MAX_UARCH_CYCLE - 1) end)
-        assert(success == false)
-        assert(err:match("uarch_cycle is past"))
-        assert(machine:read_uarch_cycle() == MAX_UARCH_CYCLE)
-    end
-)
+do_test("should error if target uarch_cycle is smaller than current uarch_cycle", function(machine)
+    machine:write_uarch_cycle(MAX_UARCH_CYCLE)
+    assert(machine:read_uarch_cycle() == MAX_UARCH_CYCLE)
+    local success, err = pcall(function() machine:run_uarch(MAX_UARCH_CYCLE - 1) end)
+    assert(success == false)
+    assert(err:match("uarch_cycle is past"))
+    assert(machine:read_uarch_cycle() == MAX_UARCH_CYCLE)
+end)
 
 print("\n\n run_uarch tests")
-do_test("advance one micro cycle without halting",
-    function(machine)
-        assert(machine:read_uarch_cycle() == 0, "uarch cycle should be 0")
-        assert(machine:read_uarch_halt_flag() == false, "uarch halt flag should be cleared")
-        assert(machine:read_iflags_Y() == false, "iflags.Y should be cleared")
-        assert(machine:read_iflags_H() == false, "iflags.H should be cleared")
-        local status = machine:run_uarch(1)
-        assert(status == cartesi.UARCH_BREAK_REASON_REACHED_TARGET_CYCLE)
-        assert(machine:read_uarch_cycle() == 1, "uarch cycle should be 1")
-        assert(machine:read_uarch_halt_flag() == false, "uarch should not be halted")
-    end
-)
 
-do_test("do not advance micro cycle if uarch is halted",
-    function(machine)
-        machine:set_uarch_halt_flag()
-        assert(machine:read_uarch_cycle() == 0, "uarch cycle should be 0")
-        assert(machine:read_uarch_halt_flag() == true, "uarch halt flag should be set")
-        assert(machine:read_iflags_Y() == false, "iflags.Y should be cleared")
-        assert(machine:read_iflags_H() == false, "iflags.H should be cleared")
-        local status = machine:run_uarch(1)
-        assert(status == cartesi.UARCH_BREAK_REASON_UARCH_HALTED, "run_uarch should return UARCH_BREAK_REASON_UARCH_HALTED")
-        assert(machine:read_uarch_cycle() == 0, "uarch cycle should still be 0")
-    end
-)
+do_test("advance one micro cycle without halting", function(machine)
+    assert(machine:read_uarch_cycle() == 0, "uarch cycle should be 0")
+    assert(machine:read_uarch_halt_flag() == false, "uarch halt flag should be cleared")
+    assert(machine:read_iflags_Y() == false, "iflags.Y should be cleared")
+    assert(machine:read_iflags_H() == false, "iflags.H should be cleared")
+    local status = machine:run_uarch(1)
+    assert(status == cartesi.UARCH_BREAK_REASON_REACHED_TARGET_CYCLE)
+    assert(machine:read_uarch_cycle() == 1, "uarch cycle should be 1")
+    assert(machine:read_uarch_halt_flag() == false, "uarch should not be halted")
+end)
 
-do_test("do not advance micro cycle if iflags.H is set",
-    function(machine)
-        machine:set_iflags_H()
-        assert(machine:read_uarch_cycle() == 0, "uarch cycle should be 0")
-        assert(machine:read_uarch_halt_flag() == false, "uarch halt flag should be cleared")
-        assert(machine:read_iflags_Y() == false, "iflags.Y should be cleared")
-        assert(machine:read_iflags_H() == true, "iflags.H should be set")
-        local status = machine:run_uarch(1)
-        assert(status == cartesi.UARCH_BREAK_REASON_HALTED, "run_uarch should return UARCH_BREAK_REASON_HALTED")
-        assert(machine:read_uarch_cycle() == 0, "uarch cycle should still be 0")
-    end
-)
+do_test("do not advance micro cycle if uarch is halted", function(machine)
+    machine:set_uarch_halt_flag()
+    assert(machine:read_uarch_cycle() == 0, "uarch cycle should be 0")
+    assert(machine:read_uarch_halt_flag() == true, "uarch halt flag should be set")
+    assert(machine:read_iflags_Y() == false, "iflags.Y should be cleared")
+    assert(machine:read_iflags_H() == false, "iflags.H should be cleared")
+    local status = machine:run_uarch(1)
+    assert(status == cartesi.UARCH_BREAK_REASON_UARCH_HALTED, "run_uarch should return UARCH_BREAK_REASON_UARCH_HALTED")
+    assert(machine:read_uarch_cycle() == 0, "uarch cycle should still be 0")
+end)
 
-do_test("do not advance micro cycle if iflags.Y is set",
-    function(machine)
-        machine:set_iflags_Y()
-        assert(machine:read_uarch_cycle() == 0, "uarch cycle should be 0")
-        assert(machine:read_uarch_halt_flag() == false, "uarch should not be halted")
-        assert(machine:read_iflags_Y() == true, "machine iflags.Y should be set")
-        assert(machine:read_iflags_H() == false, "machine iflags.H should be cleared")
-        local status = machine:run_uarch(1)
-        assert(status == cartesi.UARCH_BREAK_REASON_YIELDED_MANUALLY, "run_uarch should return UARCH_BREAK_REASON_YIELDED_MANUALLY")
-        assert(machine:read_uarch_cycle() == 0, "uarch cycle should still be 0")
-    end
-)
+do_test("do not advance micro cycle if iflags.H is set", function(machine)
+    machine:set_iflags_H()
+    assert(machine:read_uarch_cycle() == 0, "uarch cycle should be 0")
+    assert(machine:read_uarch_halt_flag() == false, "uarch halt flag should be cleared")
+    assert(machine:read_iflags_Y() == false, "iflags.Y should be cleared")
+    assert(machine:read_iflags_H() == true, "iflags.H should be set")
+    local status = machine:run_uarch(1)
+    assert(status == cartesi.UARCH_BREAK_REASON_HALTED, "run_uarch should return UARCH_BREAK_REASON_HALTED")
+    assert(machine:read_uarch_cycle() == 0, "uarch cycle should still be 0")
+end)
 
-do_test("return UARCH_BREAK_REASON_UARCH_HALTED if uarch halt, iflags.H and iflags.Y are set",
-    function(machine)
-        machine:set_uarch_halt_flag()
-        machine:set_iflags_Y()
-        machine:set_iflags_H()
-        assert(machine:read_uarch_halt_flag() == true, "uarch halt should be set")
-        assert(machine:read_iflags_Y() == true, "iflags.Y should be set")
-        assert(machine:read_iflags_H() == true, "iflags.H should be set")
-        io.write("ANTES com io")
-        local status = machine:run_uarch(1)
-        assert(status == cartesi.UARCH_BREAK_REASON_UARCH_HALTED, "run_uarch should return UARCH_BREAK_REASON_UARCH_HALTED ")
-    end
-)
+do_test("do not advance micro cycle if iflags.Y is set", function(machine)
+    machine:set_iflags_Y()
+    assert(machine:read_uarch_cycle() == 0, "uarch cycle should be 0")
+    assert(machine:read_uarch_halt_flag() == false, "uarch should not be halted")
+    assert(machine:read_iflags_Y() == true, "machine iflags.Y should be set")
+    assert(machine:read_iflags_H() == false, "machine iflags.H should be cleared")
+    local status = machine:run_uarch(1)
+    assert(
+        status == cartesi.UARCH_BREAK_REASON_YIELDED_MANUALLY,
+        "run_uarch should return UARCH_BREAK_REASON_YIELDED_MANUALLY"
+    )
+    assert(machine:read_uarch_cycle() == 0, "uarch cycle should still be 0")
+end)
 
-do_test("return UARCH_BREAK_REASON_HALTED if uarch halt is not set,  iflags.H is set and iflags.Y is set",
+do_test("return UARCH_BREAK_REASON_UARCH_HALTED if uarch halt, iflags.H and iflags.Y are set", function(machine)
+    machine:set_uarch_halt_flag()
+    machine:set_iflags_Y()
+    machine:set_iflags_H()
+    assert(machine:read_uarch_halt_flag() == true, "uarch halt should be set")
+    assert(machine:read_iflags_Y() == true, "iflags.Y should be set")
+    assert(machine:read_iflags_H() == true, "iflags.H should be set")
+    io.write("ANTES com io")
+    local status = machine:run_uarch(1)
+    assert(status == cartesi.UARCH_BREAK_REASON_UARCH_HALTED, "run_uarch should return UARCH_BREAK_REASON_UARCH_HALTED")
+end)
+
+do_test(
+    "return UARCH_BREAK_REASON_HALTED if uarch halt is not set,  iflags.H is set and iflags.Y is set",
     function(machine)
         machine:set_iflags_Y()
         machine:set_iflags_H()
@@ -729,69 +686,58 @@ do_test("return UARCH_BREAK_REASON_HALTED if uarch halt is not set,  iflags.H is
     end
 )
 
-do_test("advance micro cycles until halt",
-    function(machine)
-        assert(machine:read_uarch_cycle() == 0, "uarch cycle should be 0")
-        assert(machine:read_uarch_halt_flag() == false, "machine should not be halted")
-        local status = machine:run_uarch()
-        assert(status == cartesi.UARCH_BREAK_REASON_UARCH_HALTED)
-        assert(machine:read_uarch_cycle() == 4, "uarch cycle should be 4")
-        assert(machine:read_uarch_halt_flag() == true, "uarch should be halted")
-    end
-)
+do_test("advance micro cycles until halt", function(machine)
+    assert(machine:read_uarch_cycle() == 0, "uarch cycle should be 0")
+    assert(machine:read_uarch_halt_flag() == false, "machine should not be halted")
+    local status = machine:run_uarch()
+    assert(status == cartesi.UARCH_BREAK_REASON_UARCH_HALTED)
+    assert(machine:read_uarch_cycle() == 4, "uarch cycle should be 4")
+    assert(machine:read_uarch_halt_flag() == true, "uarch should be halted")
+end)
 
 print("\n\n run machine to 1000 mcycle")
-do_test("mcycle value should be 1000 after execution",
-    function(machine)
-        -- Run machine
-        machine:write_csr('mcycle', 0)
-        assert(machine:read_csr('mcycle') == 0)
+do_test("mcycle value should be 1000 after execution", function(machine)
+    -- Run machine
+    machine:write_csr("mcycle", 0)
+    assert(machine:read_csr("mcycle") == 0)
 
-        local test = machine:read_mcycle()
-        while test < 1000 do
-            machine:run(1000)
-            test = machine:read_mcycle()
-        end
-        assert(machine:read_csr('mcycle') == 1000)
+    local test = machine:read_mcycle()
+    while test < 1000 do
+        machine:run(1000)
+        test = machine:read_mcycle()
     end
-)
+    assert(machine:read_csr("mcycle") == 1000)
+end)
 
 print("\n\n check reading and writing htif registers")
-do_test("htif register values should match",
-    function(machine)
-        -- Check HTIF interface bindings
-        assert(machine:read_htif_tohost(), "error reading htif tohost")
-        assert(machine:read_htif_tohost_dev(), "error reading htif tohost dev")
-        assert(machine:read_htif_tohost_cmd(), "error reading htif tohost cmd")
-        assert(machine:read_htif_tohost_data(), "error reading htif tohost data")
-        assert(machine:read_htif_fromhost(), "error reading htif fromhost")
-        machine:write_htif_tohost(0x123456)
-        assert(machine:read_htif_tohost() == 0x123456, "error writing htif tohost")
-        machine:write_htif_fromhost(0x12345678)
-        assert(machine:read_htif_fromhost() == 0x12345678,
-            "error writing htif fromhost")
-        machine:write_htif_fromhost_data(0x123456789A)
-        assert(machine:read_htif_ihalt(), "error reading htif ihalt")
-        assert(machine:read_htif_iyield(), "error reading htif yield")
-    end
-)
+do_test("htif register values should match", function(machine)
+    -- Check HTIF interface bindings
+    assert(machine:read_htif_tohost(), "error reading htif tohost")
+    assert(machine:read_htif_tohost_dev(), "error reading htif tohost dev")
+    assert(machine:read_htif_tohost_cmd(), "error reading htif tohost cmd")
+    assert(machine:read_htif_tohost_data(), "error reading htif tohost data")
+    assert(machine:read_htif_fromhost(), "error reading htif fromhost")
+    machine:write_htif_tohost(0x123456)
+    assert(machine:read_htif_tohost() == 0x123456, "error writing htif tohost")
+    machine:write_htif_fromhost(0x12345678)
+    assert(machine:read_htif_fromhost() == 0x12345678, "error writing htif fromhost")
+    machine:write_htif_fromhost_data(0x123456789A)
+    assert(machine:read_htif_ihalt(), "error reading htif ihalt")
+    assert(machine:read_htif_iyield(), "error reading htif yield")
+end)
 
 print("\n\n check memory reading/writing")
-do_test("written and read values should match",
-    function(machine)
-        -- Check mem write and mem read
-        machine:write_memory(0x800000FF, "mydataol12345678", 0x10)
-        local memory_read = machine:read_memory(0x800000FF, 0x10)
-        assert(memory_read == "mydataol12345678")
-
-    end
-)
+do_test("written and read values should match", function(machine)
+    -- Check mem write and mem read
+    machine:write_memory(0x800000FF, "mydataol12345678", 0x10)
+    local memory_read = machine:read_memory(0x800000FF, 0x10)
+    assert(memory_read == "mydataol12345678")
+end)
 
 print("\n\n dump log  to console")
-do_test("dumped log content should match",
-    function()
-        -- Dump log and check values
-        local lua_code = [[ "
+do_test("dumped log content should match", function()
+    -- Dump log and check values
+    local lua_code = [[ "
                                  local cartesi = require 'cartesi'
                                  test_util = require 'tests.util'
                                  cartesi_util = require 'cartesi.util'
@@ -811,67 +757,61 @@ do_test("dumped log content should match",
                                  local log = machine:step_uarch(log_type)
                                  cartesi_util.dump_log(log, io.stdout)
                                  " 2>&1]]
-        local p = io.popen(lua_cmd .. lua_code)
-        local output = p:read(2000)
-        p:close()
-        local expected_output =
-            "begin step\n" ..
-            "  1: read uarch.cycle@0x320(800): 0x0(0)\n" ..
-            "  2: read uarch.halt_flag@0x328(808): 0x0(0)\n" ..
-            "  3: read iflags@0x2e8(744): 0x18(24)\n" ..
-            "  4: read uarch.pc@0x330(816): 0x70000000(1879048192)\n" ..
-            "  5: read memory@0x70000000(1879048192): 0x3280029307b00513(3638911329427784979)\n" ..
-            "  begin addi\n" ..
-            "    6: read uarch.x@0x340(832): 0x0(0)\n" ..
-            "    7: write uarch.x@0x390(912): 0x0(0) -> 0x7b(123)\n" ..
-            "    8: write uarch.pc@0x330(816): 0x70000000(1879048192) -> 0x70000004(1879048196)\n" ..
-            "  end addi\n" ..
-            "  9: write uarch.cycle@0x320(800): 0x0(0) -> 0x1(1)\n" ..
-            "  10: read iflags@0x2e8(744): 0x18(24)\n" ..
-            "end step\n"
 
-        print("Output of dump log:")
-        print("--------------------------")
-        print(output)
-        print("--------------------------")
-        assert(output == expected_output, "Output does not match expected output:\n"..expected_output)
-    end
-)
+    local p = io.popen(lua_cmd .. lua_code)
+    local output = p:read(2000)
+    p:close()
+    local expected_output = "begin step\n"
+        .. "  1: read uarch.cycle@0x320(800): 0x0(0)\n"
+        .. "  2: read uarch.halt_flag@0x328(808): 0x0(0)\n"
+        .. "  3: read iflags@0x2e8(744): 0x18(24)\n"
+        .. "  4: read uarch.pc@0x330(816): 0x70000000(1879048192)\n"
+        .. "  5: read memory@0x70000000(1879048192): 0x3280029307b00513(3638911329427784979)\n"
+        .. "  begin addi\n"
+        .. "    6: read uarch.x@0x340(832): 0x0(0)\n"
+        .. "    7: write uarch.x@0x390(912): 0x0(0) -> 0x7b(123)\n"
+        .. "    8: write uarch.pc@0x330(816): 0x70000000(1879048192) -> 0x70000004(1879048196)\n"
+        .. "  end addi\n"
+        .. "  9: write uarch.cycle@0x320(800): 0x0(0) -> 0x1(1)\n"
+        .. "  10: read iflags@0x2e8(744): 0x18(24)\n"
+        .. "end step\n"
+
+    print("Output of dump log:")
+    print("--------------------------")
+    print(output)
+    print("--------------------------")
+    assert(output == expected_output, "Output does not match expected output:\n" .. expected_output)
+end)
 
 print("\n\ntesting step and verification")
-do_test("machine step should pass verifications",
-    function(machine)
-        local module = cartesi
-        if (machine_type ~= "local") then
-            if not remote then remote = connect() end
-            module = remote
-        end
-        local initial_hash = machine:get_root_hash()
-        local log = machine:step_uarch({proofs = true, annotations = true})
-        local final_hash = machine:get_root_hash()
-        module.machine.verify_state_transition(initial_hash, log, final_hash, {})
-        module.machine.verify_access_log(log, {})
+do_test("machine step should pass verifications", function(machine)
+    local module = cartesi
+    if machine_type ~= "local" then
+        if not remote then remote = connect() end
+        module = remote
     end
-)
+    local initial_hash = machine:get_root_hash()
+    local log = machine:step_uarch({ proofs = true, annotations = true })
+    local final_hash = machine:get_root_hash()
+    module.machine.verify_state_transition(initial_hash, log, final_hash, {})
+    module.machine.verify_access_log(log, {})
+end)
 
-do_test("step when uarch cycle is max",
-    function(machine)
-        local module = cartesi
-        if (machine_type ~= "local") then
-            if not remote then remote = connect() end
-            module = remote
-        end
-        local MAX_UARCH_CYCLE = -1
-        machine:write_uarch_cycle(MAX_UARCH_CYCLE)
-        assert(machine:read_uarch_cycle() == MAX_UARCH_CYCLE)
-        local initial_hash = machine:get_root_hash()
-        local log = machine:step_uarch({proofs = true, annotations = true})
-        assert(machine:read_uarch_cycle() == MAX_UARCH_CYCLE)
-        local final_hash = machine:get_root_hash()
-        assert(final_hash == initial_hash)
-        module.machine.verify_state_transition(initial_hash, log, final_hash, {})
-        module.machine.verify_access_log(log, {})
+do_test("step when uarch cycle is max", function(machine)
+    local module = cartesi
+    if machine_type ~= "local" then
+        if not remote then remote = connect() end
+        module = remote
     end
-)
+    machine:write_uarch_cycle(MAX_UARCH_CYCLE)
+    assert(machine:read_uarch_cycle() == MAX_UARCH_CYCLE)
+    local initial_hash = machine:get_root_hash()
+    local log = machine:step_uarch({ proofs = true, annotations = true })
+    assert(machine:read_uarch_cycle() == MAX_UARCH_CYCLE)
+    local final_hash = machine:get_root_hash()
+    assert(final_hash == initial_hash)
+    module.machine.verify_state_transition(initial_hash, log, final_hash, {})
+    module.machine.verify_access_log(log, {})
+end)
 
 print("\n\nAll machine binding tests for type " .. machine_type .. " passed")

--- a/src/tests/machine-bind.lua
+++ b/src/tests/machine-bind.lua
@@ -22,11 +22,10 @@
 -- same computer and jsonrpc-remote-cartesi-machine execution path must be provided
 
 local cartesi = require "cartesi"
-local cartesi_util = require "cartesi.util"
 local test_util = require "tests.util"
 
-local remote_address = nil
-local checkin_address = nil
+local remote_address
+local checkin_address
 local test_path = "./"
 local cleanup = {}
 
@@ -101,9 +100,9 @@ local options = {
 
 -- Process command line options
 local arguments = {}
-for i, argument in ipairs({...}) do
+for _, argument in ipairs({...}) do
     if argument:sub(1,1) == "-" then
-        for j, option in ipairs(options) do
+        for _, option in ipairs(options) do
             if option[2](argument:match(option[1])) then
                 break
             end
@@ -116,10 +115,8 @@ end
 local SHADOW_BASE = 0x0
 
 local cpu_x_addr = {}
-local cpu_f_addr = {}
 for i=0,31 do
     cpu_x_addr[i] = i * 8
-    cpu_f_addr[i] = 0x100 + i * 8
 end
 
 local function get_cpu_xreg_test_values()
@@ -249,6 +246,7 @@ local pmas_file_names = {
 }
 local pmas_sizes = { 4096, 61440, 4096, 24576, 786432, 4096, 1048576, 65536, 65536}
 
+local remote
 local function build_machine(type)
     -- Create new machine
     local concurrency_update_merkle_tree = 0
@@ -260,7 +258,7 @@ local function build_machine(type)
         processor = initial_csr_values,
         rom = {image_filename = test_util.images_path .. "rom.bin"},
         ram = {length = 1 << 20},
-        uarch = { 
+        uarch = {
             processor = {
                 x = initial_uarch_xreg_values
             },
@@ -273,7 +271,7 @@ local function build_machine(type)
         }
     }
 
-    local new_machine = nil
+    local new_machine
     if (type ~= "local") then
         if not remote then remote = connect() end
         new_machine = assert(remote.machine(config, runtime))
@@ -355,7 +353,7 @@ do_test("should provide proof for values in registers",
 
 print("\n\ntesting get_csr_address function binding")
 do_test("should return address value for csr register",
-    function(machine)
+    function()
         local module = cartesi
         if (machine_type ~= "local") then
             if not remote then remote = connect() end
@@ -371,7 +369,7 @@ do_test("should return address value for csr register",
 
 print("\n\ntesting get_x_address function binding")
 do_test("should return address value for x registers",
-    function(machine)
+    function()
         local module = cartesi
         if (machine_type ~= "local") then
             if not remote then remote = connect() end
@@ -386,7 +384,7 @@ do_test("should return address value for x registers",
 
 print("\n\ntesting get_x_uarch_address function binding")
     do_test("should return address value for uarch x registers",
-        function(machine)
+        function()
             local SHADOW_UARCH_XBASE = 0x340
             local module = cartesi
             if (machine_type == "grpc") then
@@ -412,7 +410,6 @@ local function test_config(config)
     for _, field in ipairs{"processor", "htif", "clint", "flash_drive", "ram", "rom"} do
         assert(config[field] and type(config[field]) == 'table', "invalid field " .. field)
     end
-    local processor = config.processor
     for i = 1, 31 do
         assert(type(config.processor.x[i]) == "number", "x"..i.." is not a number")
     end
@@ -432,7 +429,7 @@ local function test_config(config)
     assert(rom.bootargs == nil or type(rom.bootargs) == "string", "invalid rom.bootargs")
     local tlb = config.tlb
     assert(tlb.image_filename == nil or type(tlb.image_filename) == "string", "invalid tlb.image_filename")
-    for i, f in ipairs(config.flash_drive) do
+    for _, f in ipairs(config.flash_drive) do
         test_config_memory_range(f)
     end
     local rollup = config.rollup
@@ -447,7 +444,7 @@ end
 
 print("\n\ntesting get_default_config function binding")
 do_test("should return default machine config",
-    function(machine)
+    function()
         local module = cartesi
         if (machine_type ~= "local") then
             if not remote then remote = connect() end
@@ -577,7 +574,7 @@ do_test("writen and expected register values should match",
         machine:write_x(1, x1_initial_value)
         assert(machine:read_x(1) == x1_initial_value)
         -- Read unexsisting register
-        local status_invalid_reg, retval = pcall(machine.read_x, machine, 1000)
+        local status_invalid_reg = pcall(machine.read_x, machine, 1000)
         assert(status_invalid_reg == false, "no error reading invalid x register")
     end
 )
@@ -594,7 +591,7 @@ do_test("writen and expected register values should match",
         machine:write_uarch_x(1, x1_initial_value)
         assert(machine:read_uarch_x(1) == x1_initial_value)
         -- Read unexsisting uarch register
-        local status_invalid_reg, retval = pcall(machine.read_uarch_x, machine, 1000)
+        local status_invalid_reg = pcall(machine.read_uarch_x, machine, 1000)
         assert(status_invalid_reg == false, "no error reading invalid uarch x register")
     end
 )
@@ -611,7 +608,7 @@ do_test("writen and expected register values should match",
         machine:write_csr('sscratch', sscratch_initial_value)
 
         -- Read unexsisting register
-        local status_invalid_reg, retval = pcall(machine.read_csr, machine, "invalidreg")
+        local status_invalid_reg = pcall(machine.read_csr, machine, "invalidreg")
         assert(status_invalid_reg == false, "no error reading invalid csr register")
     end
 )
@@ -783,9 +780,8 @@ print("\n\n check memory reading/writing")
 do_test("written and read values should match",
     function(machine)
         -- Check mem write and mem read
-        local memory_read = machine:read_memory(0x80000000, 0x8)
         machine:write_memory(0x800000FF, "mydataol12345678", 0x10)
-        memory_read = machine:read_memory(0x800000FF, 0x10)
+        local memory_read = machine:read_memory(0x800000FF, 0x10)
         assert(memory_read == "mydataol12345678")
 
     end
@@ -793,7 +789,7 @@ do_test("written and read values should match",
 
 print("\n\n dump log  to console")
 do_test("dumped log content should match",
-    function(machine)
+    function()
         -- Dump log and check values
         local lua_code = [[ "
                                  local cartesi = require 'cartesi'
@@ -806,7 +802,7 @@ do_test("dumped log content should match",
                                  processor = initial_csr_values,
                                  ram = {length = 1 << 20},
                                  rom = {image_filename = test_util.images_path .. 'rom.bin'},
-                                 uarch = { 
+                                 uarch = {
                                     ram = { length = 1 << 16, image_filename = uarch_ram_path }
                                  }
                                  }

--- a/src/tests/machine-test.lua
+++ b/src/tests/machine-test.lua
@@ -15,9 +15,9 @@
 -- You should have received a copy of the GNU Lesser General Public License
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 
-local cartesi = require "cartesi"
-local test_util = require "tests.util"
-local md5 = require "md5"
+local cartesi = require("cartesi")
+local test_util = require("tests.util")
+local md5 = require("md5")
 
 -- Note: for grpc machine test to work, remote-cartesi-machine must run on
 -- same computer and remote-cartesi-machine execution path must be provided
@@ -35,7 +35,7 @@ local cleanup = {}
 local function get_file_length(filename)
     local file = io.open(filename, "rb")
     if not file then return nil end
-    local size = file:seek("end")    -- get file size
+    local size = file:seek("end") -- get file size
     file:close()
     return size
 end
@@ -47,7 +47,8 @@ local rootfs_length = get_file_length(rootfs_image)
 
 -- Print help and exit
 local function help()
-    io.stderr:write(string.format([=[
+    io.stderr:write(string.format(
+        [=[
 Usage:
 
   %s <machine_type> [options]
@@ -71,68 +72,80 @@ where options are:
    unix:<path>
 
 <host> can be a host name, IPv4 or IPv6 address.
-]=], arg[0]))
+]=],
+        arg[0]
+    ))
     os.exit()
 end
 
-
 local options = {
-    { "^%-%-h$", function(all)
-        if not all then return false end
-        help()
-    end },
-    { "^%-%-help$", function(all)
-        if not all then return false end
-        help()
-    end },
-    { "^%-%-remote%-address%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        remote_address = o
-        return true
-    end },
-    { "^%-%-checkin%-address%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        checkin_address = o
-        return true
-    end },
-    { "^%-%-test%-path%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        test_path = o
-        if string.sub(test_path, -1, -1) ~= "/" then
-            error("test-path must end in '/'")
-        end
-        return true
-    end },
-    { ".*", function(all)
-        error("unrecognized option " .. all)
-    end }
+    {
+        "^%-%-h$",
+        function(all)
+            if not all then return false end
+            help()
+        end,
+    },
+    {
+        "^%-%-help$",
+        function(all)
+            if not all then return false end
+            help()
+        end,
+    },
+    {
+        "^%-%-remote%-address%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            remote_address = o
+            return true
+        end,
+    },
+    {
+        "^%-%-checkin%-address%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            checkin_address = o
+            return true
+        end,
+    },
+    {
+        "^%-%-test%-path%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            test_path = o
+            if string.sub(test_path, -1, -1) ~= "/" then error("test-path must end in '/'") end
+            return true
+        end,
+    },
+    { ".*", function(all) error("unrecognized option " .. all) end },
 }
 
 -- Process command line options
 local arguments = {}
-for _, argument in ipairs({...}) do
-    if argument:sub(1,1) == "-" then
+for _, argument in ipairs({ ... }) do
+    if argument:sub(1, 1) == "-" then
         for _, option in ipairs(options) do
-            if option[2](argument:match(option[1])) then
-                break
-            end
+            if option[2](argument:match(option[1])) then break end
         end
     else
-        arguments[#arguments+1] = argument
+        arguments[#arguments + 1] = argument
     end
 end
 
 local machine_type = assert(arguments[1], "missing machine type")
-assert(machine_type == "local" or machine_type == "grpc" or machine_type == "jsonrpc",
-    "unknown machine type, should be 'local', 'grpc', or 'jsonrpc'")
+assert(
+    machine_type == "local" or machine_type == "grpc" or machine_type == "jsonrpc",
+    "unknown machine type, should be 'local', 'grpc', or 'jsonrpc'"
+)
 local protocol
-if (machine_type == "grpc") then
+if machine_type == "grpc" then
     assert(remote_address ~= nil, "remote cartesi machine address is missing")
     assert(checkin_address, "missing checkin address")
     assert(test_path ~= nil, "test path must be provided and must be working directory of remote cartesi machine")
     protocol = require("cartesi.grpc")
 end
-if (machine_type == "jsonrpc") then
+if machine_type == "jsonrpc" then
     assert(remote_address ~= nil, "remote cartesi machine address is missing")
     assert(test_path ~= nil, "test path must be provided and must be working directory of remote cartesi machine")
     protocol = require("cartesi.jsonrpc")
@@ -140,10 +153,9 @@ end
 
 local function connect()
     local remote = protocol.stub(remote_address, checkin_address)
-    local version = assert(remote.get_version(),
-        "could not connect to remote cartesi machine at " .. remote_address)
+    local version = assert(remote.get_version(), "could not connect to remote cartesi machine at " .. remote_address)
     local shutdown = function() remote.shutdown() end
-    local mt = { __gc = function() pcall(shutdown) end}
+    local mt = { __gc = function() pcall(shutdown) end }
     setmetatable(cleanup, mt)
     return remote, version
 end
@@ -155,7 +167,7 @@ local pmas_file_names = {
     "0000000000020000--0000000000006000.bin", -- shadow tlb
     "0000000002000000--00000000000c0000.bin", -- clint
     "0000000040008000--0000000000001000.bin", -- htif
-    "0000000080000000--0000000000100000.bin",  -- ram
+    "0000000080000000--0000000000100000.bin", -- ram
 }
 
 local pmas_file_names_with_uarch = {
@@ -165,8 +177,8 @@ local pmas_file_names_with_uarch = {
     "0000000000020000--0000000000006000.bin", -- shadow tlb
     "0000000002000000--00000000000c0000.bin", -- clint
     "0000000040008000--0000000000001000.bin", -- htif
-    "0000000080000000--0000000000100000.bin",  -- ram
-    "0000000070000000--0000000000100000.bin" -- uarch ram
+    "0000000080000000--0000000000100000.bin", -- ram
+    "0000000070000000--0000000000100000.bin", -- uarch ram
 }
 
 local remote
@@ -174,18 +186,19 @@ local function build_machine(type, config)
     -- Create new machine
     -- Use default config to be max reproducible
     local concurrency_update_merkle_tree = 0
-    config = config or {
-        processor = {},
-        ram = {length = 1 << 20},
-        rom = {image_filename = rom_image}
-    }
+    config = config
+        or {
+            processor = {},
+            ram = { length = 1 << 20 },
+            rom = { image_filename = rom_image },
+        }
     local runtime = {
         concurrency = {
-            update_merkle_tree = concurrency_update_merkle_tree
-        }
+            update_merkle_tree = concurrency_update_merkle_tree,
+        },
     }
     local new_machine
-    if (type ~= "local") then
+    if type ~= "local" then
         if not remote then remote = connect() end
         new_machine = assert(remote.machine(config, runtime))
     else
@@ -197,14 +210,14 @@ end
 local function build_uarch_machine(type)
     local config = {
         processor = {},
-        ram = {length = 1 << 20},
-        rom = {image_filename = rom_image},
+        ram = { length = 1 << 20 },
+        rom = { image_filename = rom_image },
         uarch = {
             ram = {
                 length = 1 << 20,
-                image_filename = test_util.create_test_uarch_program()
-            }
-        }
+                image_filename = test_util.create_test_uarch_program(),
+            },
+        },
     }
     local machine = build_machine(type, config)
     os.remove(config.uarch.ram.image_filename)
@@ -214,86 +227,72 @@ end
 local do_test = test_util.make_do_test(build_machine, machine_type)
 
 local function remove_files(file_names)
-    for _, file_name in pairs(file_names) do os.remove(test_path .. file_name) end
+    for _, file_name in pairs(file_names) do
+        os.remove(test_path .. file_name)
+    end
 end
-
 
 print("Testing machine for type " .. machine_type)
 
 print("\n\ntesting getting machine intial config and iflags")
-do_test("machine halt and yield flags and config matches",
-    function(machine)
-        -- Get machine default config  and test for known fields
-        local initial_config = machine:get_initial_config()
-        -- test_util.print_table(initial_config)
-        assert(initial_config["processor"]["marchid"] == cartesi.MARCHID,
-            "marchid value does not match")
-        assert(initial_config["processor"]["pc"] == 0x1000,
-            "pc value does not match")
-        assert(initial_config["ram"]["length"] == 1048576,
-            "ram length value does not match")
-        assert(initial_config["rom"]["image_filename"] ~= "",
-            "rom image filename not set")
-        -- Check machine is not halted
-        assert(not machine:read_iflags_H(), "machine shouldn't be halted")
-        -- Check machine is not yielded
-        assert(not machine:read_iflags_Y(), "machine shouldn't be yielded")
-    end
-)
+do_test("machine halt and yield flags and config matches", function(machine)
+    -- Get machine default config  and test for known fields
+    local initial_config = machine:get_initial_config()
+    -- test_util.print_table(initial_config)
+    assert(initial_config["processor"]["marchid"] == cartesi.MARCHID, "marchid value does not match")
+    assert(initial_config["processor"]["pc"] == 0x1000, "pc value does not match")
+    assert(initial_config["ram"]["length"] == 1048576, "ram length value does not match")
+    assert(initial_config["rom"]["image_filename"] ~= "", "rom image filename not set")
+    -- Check machine is not halted
+    assert(not machine:read_iflags_H(), "machine shouldn't be halted")
+    -- Check machine is not yielded
+    assert(not machine:read_iflags_Y(), "machine shouldn't be yielded")
+end)
 
 print("\n\ntesting memory pmas dump to files")
-do_test("dumped file hashes should match memory data hashes",
-    function(machine)
-        -- Dump memory regions to files
-        -- Calculate hash for memory regions
-        -- Check if match memory data hash
-        machine:dump_pmas()
+do_test("dumped file hashes should match memory data hashes", function(machine)
+    -- Dump memory regions to files
+    -- Calculate hash for memory regions
+    -- Check if match memory data hash
+    machine:dump_pmas()
 
-        for _, file_name in pairs(pmas_file_names) do
+    for _, file_name in pairs(pmas_file_names) do
+        print("Checking dump file " .. file_name)
 
-            print("Checking dump file " .. file_name)
+        local temp = test_util.split_string(file_name, "--.")
+        local data_region_start = tonumber(temp[1], 16)
+        local data_region_size = tonumber(temp[2], 16)
 
-            local temp = test_util.split_string(file_name, "--.")
-            local data_region_start = tonumber(temp[1], 16)
-            local data_region_size = tonumber(temp[2], 16)
+        local dump = assert(io.open(test_path .. file_name, "rb"))
+        local dump_hash = md5.sumhexa(dump:read("*all"))
+        dump:close()
 
-            local dump = assert(io.open(test_path .. file_name, 'rb'))
-            local dump_hash = md5.sumhexa(dump:read("*all"))
-            dump:close()
+        local memory_read = machine:read_memory(data_region_start, data_region_size)
+        local memory_hash = md5.sumhexa(memory_read)
 
-            local memory_read = machine:read_memory(data_region_start, data_region_size)
-            local memory_hash = md5.sumhexa(memory_read)
-
-            assert(dump_hash == memory_hash,
-                "hash does not match for dump file " .. file_name)
-        end
-        remove_files(pmas_file_names)
+        assert(dump_hash == memory_hash, "hash does not match for dump file " .. file_name)
     end
-)
+    remove_files(pmas_file_names)
+end)
 
 print("\n\ntesting if machine initial hash is correct")
-do_test("machine initial hash should match",
-    function(machine)
-        -- Get starting root hash
-        local root_hash = machine:get_root_hash()
+do_test("machine initial hash should match", function(machine)
+    -- Get starting root hash
+    local root_hash = machine:get_root_hash()
 
-        machine:dump_pmas()
-        local calculated_root_hash = test_util.calculate_emulator_hash(test_path,
-                                                pmas_file_names, machine)
+    machine:dump_pmas()
+    local calculated_root_hash = test_util.calculate_emulator_hash(test_path, pmas_file_names, machine)
 
-        print("Root hash:", test_util.tohex(root_hash), " calculated root hash:",
-            test_util.tohex(calculated_root_hash))
+    print("Root hash:", test_util.tohex(root_hash), " calculated root hash:", test_util.tohex(calculated_root_hash))
 
-        assert(
-            test_util.tohex(root_hash) == test_util.tohex(calculated_root_hash),
-            "Initial root hash does not match")
+    assert(test_util.tohex(root_hash) == test_util.tohex(calculated_root_hash), "Initial root hash does not match")
 
-        remove_files(pmas_file_names)
-    end
-)
+    remove_files(pmas_file_names)
+end)
 
 print("\n\ntesting root hash after step one")
-test_util.make_do_test(build_uarch_machine, machine_type)("machine root hash after step one should match",
+test_util.make_do_test(build_uarch_machine, machine_type)(
+    "machine root hash after step one should match",
     function(machine)
         -- Get starting root hash
         local root_hash = machine:get_root_hash()
@@ -303,9 +302,7 @@ test_util.make_do_test(build_uarch_machine, machine_type)("machine root hash aft
         local calculated_root_hash = test_util.calculate_emulator_hash(test_path, pmas_file_names_with_uarch, machine)
         remove_files(pmas_file_names)
 
-        assert(test_util.tohex(root_hash) ==
-                test_util.tohex(calculated_root_hash),
-            "Initial root hash does not match")
+        assert(test_util.tohex(root_hash) == test_util.tohex(calculated_root_hash), "Initial root hash does not match")
 
         -- Perform step, dump address space to file, calculate emulator root hash
         -- and check if maches
@@ -314,198 +311,203 @@ test_util.make_do_test(build_uarch_machine, machine_type)("machine root hash aft
         local root_hash_step1 = machine:get_root_hash()
 
         machine:dump_pmas()
-        local calculated_root_hash_step1 = test_util.calculate_emulator_hash(test_path,
-                                                    pmas_file_names_with_uarch, machine)
+        local calculated_root_hash_step1 =
+            test_util.calculate_emulator_hash(test_path, pmas_file_names_with_uarch, machine)
 
         -- Remove dumped pmas files
         remove_files(pmas_file_names)
 
-        assert(test_util.tohex(root_hash_step1) ==
-                test_util.tohex(calculated_root_hash_step1),
-            "hash after first step does not match")
+        assert(
+            test_util.tohex(root_hash_step1) == test_util.tohex(calculated_root_hash_step1),
+            "hash after first step does not match"
+        )
     end
 )
 
 print("\n\ntesting proof after step one")
-test_util.make_do_test(build_uarch_machine, machine_type)("proof check should pass",
-    function(machine)
-        local log_type = {}
-        machine:step_uarch(log_type)
+test_util.make_do_test(build_uarch_machine, machine_type)("proof check should pass", function(machine)
+    local log_type = {}
+    machine:step_uarch(log_type)
 
-        -- Dump RAM memory to file, calculate hash of file
-        -- get proof of ram using get_proof and check if
-        -- hashes match
-        machine:dump_pmas()
-        local ram_file_name = pmas_file_names[5]
-        local ram = test_util.parse_pma_file(test_path .. ram_file_name)
+    -- Dump RAM memory to file, calculate hash of file
+    -- get proof of ram using get_proof and check if
+    -- hashes match
+    machine:dump_pmas()
+    local ram_file_name = pmas_file_names[5]
+    local ram = test_util.parse_pma_file(test_path .. ram_file_name)
 
-        remove_files(pmas_file_names)
+    remove_files(pmas_file_names)
 
-        local ram_address_start = tonumber(test_util.split_string(ram_file_name,
-                                                                "--.")[1], 16)
-        local ram_data_number_of_pages = math.ceil(#ram / (1 << 12))
-        local ram_log2_data_size = math.ceil(math.log(#ram, 2))
-        local calculated_ram_hash = test_util.calculate_region_hash(ram,
-                                                                    ram_data_number_of_pages,
-                                                                    12,
-                                                                    ram_log2_data_size)
-        local ram_proof = machine:get_proof(ram_address_start, ram_log2_data_size)
-        local root_hash = machine:get_root_hash()
+    local ram_address_start = tonumber(test_util.split_string(ram_file_name, "--.")[1], 16)
+    local ram_data_number_of_pages = math.ceil(#ram / (1 << 12))
+    local ram_log2_data_size = math.ceil(math.log(#ram, 2))
+    local calculated_ram_hash = test_util.calculate_region_hash(ram, ram_data_number_of_pages, 12, ram_log2_data_size)
+    local ram_proof = machine:get_proof(ram_address_start, ram_log2_data_size)
+    local root_hash = machine:get_root_hash()
 
-        assert(test_util.tohex(root_hash) == test_util.tohex(ram_proof.root_hash),
-            "root hash in proof does not match")
-        print("target hash:", test_util.tohex(ram_proof.target_hash),
-            " calculated target hash:", test_util.tohex(calculated_ram_hash))
-        assert(test_util.tohex(calculated_ram_hash) ==
-                test_util.tohex(ram_proof.target_hash),
-            "target hash in proof does not match")
-    end
-)
+    assert(test_util.tohex(root_hash) == test_util.tohex(ram_proof.root_hash), "root hash in proof does not match")
+    print(
+        "target hash:",
+        test_util.tohex(ram_proof.target_hash),
+        " calculated target hash:",
+        test_util.tohex(calculated_ram_hash)
+    )
+    assert(
+        test_util.tohex(calculated_ram_hash) == test_util.tohex(ram_proof.target_hash),
+        "target hash in proof does not match"
+    )
+end)
 
 print("\n\nrun machine to 1000 mcycle and check for mcycle and root hash")
-do_test("mcycle and root hash should match",
-    function(machine)
-        -- Run to 1000 cycle tics
-        local current_mcycle = machine:read_mcycle()
-        while current_mcycle < 1000 do
-            machine:run(1000)
-            current_mcycle = machine:read_mcycle()
-        end
-
-        assert(machine:read_mcycle() == 1000, "machine mcycle should be 1000")
-
-        local root_hash = machine:get_root_hash()
-
-        machine:dump_pmas()
-        local calculated_root_hash_1000 = test_util.calculate_emulator_hash(test_path,
-                                                        pmas_file_names, machine)
-        -- Remove dumped pmas files
-        remove_files(pmas_file_names)
-
-        print("1000 cycle hash: ", test_util.tohex(root_hash))
-        assert(test_util.tohex(root_hash) ==
-                test_util.tohex(calculated_root_hash_1000),
-            "machine hash does not match after 1000 cycles")
+do_test("mcycle and root hash should match", function(machine)
+    -- Run to 1000 cycle tics
+    local current_mcycle = machine:read_mcycle()
+    while current_mcycle < 1000 do
+        machine:run(1000)
+        current_mcycle = machine:read_mcycle()
     end
-)
+
+    assert(machine:read_mcycle() == 1000, "machine mcycle should be 1000")
+
+    local root_hash = machine:get_root_hash()
+
+    machine:dump_pmas()
+    local calculated_root_hash_1000 = test_util.calculate_emulator_hash(test_path, pmas_file_names, machine)
+    -- Remove dumped pmas files
+    remove_files(pmas_file_names)
+
+    print("1000 cycle hash: ", test_util.tohex(root_hash))
+    assert(
+        test_util.tohex(root_hash) == test_util.tohex(calculated_root_hash_1000),
+        "machine hash does not match after 1000 cycles"
+    )
+end)
 
 print("\n\nrun machine to end mcycle and check for mcycle, hash and halt flag")
-do_test("mcycle and root hash should match",
-    function(machine)
-        machine:run(MAX_MCYCLE)
-        -- Check machine is halted
-        assert(machine:read_iflags_H(), "machine should be halted")
-        -- Check for end mcycle
-        local end_mcycle = machine:read_mcycle()
-        assert(end_mcycle > 400000, "machine mcycle should be above 400000")
+do_test("mcycle and root hash should match", function(machine)
+    machine:run(MAX_MCYCLE)
+    -- Check machine is halted
+    assert(machine:read_iflags_H(), "machine should be halted")
+    -- Check for end mcycle
+    local end_mcycle = machine:read_mcycle()
+    assert(end_mcycle > 400000, "machine mcycle should be above 400000")
 
-        local root_hash = machine:get_root_hash()
-        print("End hash: ", test_util.tohex(root_hash))
+    local root_hash = machine:get_root_hash()
+    print("End hash: ", test_util.tohex(root_hash))
 
-        machine:dump_pmas()
-        local calculated_end_hash = test_util.calculate_emulator_hash(test_path,
-                                                pmas_file_names, machine)
-        -- Remove dumped pmas files
-        remove_files(pmas_file_names)
+    machine:dump_pmas()
+    local calculated_end_hash = test_util.calculate_emulator_hash(test_path, pmas_file_names, machine)
+    -- Remove dumped pmas files
+    remove_files(pmas_file_names)
 
-        assert(test_util.tohex(root_hash) == test_util.tohex(calculated_end_hash),
-            "machine hash does not match after on end cycle")
-    end
-)
+    assert(
+        test_util.tohex(root_hash) == test_util.tohex(calculated_end_hash),
+        "machine hash does not match after on end cycle"
+    )
+end)
 
 print("\n\nwrite something to ram memory and check if hash and proof matches")
-do_test("proof  and root hash should match",
-    function(machine)
-        local ram_address_start = 0x80000000
+do_test("proof  and root hash should match", function(machine)
+    local ram_address_start = 0x80000000
 
-        -- Find proof for first KB of ram
-        local initial_ram_proof = machine:get_proof(ram_address_start, 10)
-        -- Calculate hash
-        local initial_memory_read = machine:read_memory(ram_address_start, 2 ^ 10)
-        local initial_calculated_hash = test_util.calculate_root_hash(
-                                            initial_memory_read, 10)
-        assert(test_util.tohex(initial_ram_proof.target_hash) ==
-                test_util.tohex(initial_calculated_hash),
-            "initial hash does not match")
+    -- Find proof for first KB of ram
+    local initial_ram_proof = machine:get_proof(ram_address_start, 10)
+    -- Calculate hash
+    local initial_memory_read = machine:read_memory(ram_address_start, 2 ^ 10)
+    local initial_calculated_hash = test_util.calculate_root_hash(initial_memory_read, 10)
+    assert(
+        test_util.tohex(initial_ram_proof.target_hash) == test_util.tohex(initial_calculated_hash),
+        "initial hash does not match"
+    )
 
-        print("initial target hash:",
-            test_util.tohex(initial_ram_proof.target_hash),
-            " calculated initial target hash:",
-            test_util.tohex(initial_calculated_hash))
+    print(
+        "initial target hash:",
+        test_util.tohex(initial_ram_proof.target_hash),
+        " calculated initial target hash:",
+        test_util.tohex(initial_calculated_hash)
+    )
 
-        machine:write_memory(0x8000000F, "mydataol12345678", 0x10)
+    machine:write_memory(0x8000000F, "mydataol12345678", 0x10)
 
-        local verify = machine:verify_merkle_tree()
-        assert(verify, "verify merkle tree failed")
+    local verify = machine:verify_merkle_tree()
+    assert(verify, "verify merkle tree failed")
 
-        -- Find proof for first KB of ram
-        local ram_proof = machine:get_proof(ram_address_start, 10)
-        -- Calculate hash
-        local memory_read = machine:read_memory(ram_address_start, 2 ^ 10)
-        local calculated_hash = test_util.calculate_root_hash(memory_read, 10)
+    -- Find proof for first KB of ram
+    local ram_proof = machine:get_proof(ram_address_start, 10)
+    -- Calculate hash
+    local memory_read = machine:read_memory(ram_address_start, 2 ^ 10)
+    local calculated_hash = test_util.calculate_root_hash(memory_read, 10)
 
-        print("end target hash:", test_util.tohex(ram_proof.target_hash),
-            " calculated end target hash:", test_util.tohex(calculated_hash))
+    print(
+        "end target hash:",
+        test_util.tohex(ram_proof.target_hash),
+        " calculated end target hash:",
+        test_util.tohex(calculated_hash)
+    )
 
-        assert(test_util.tohex(initial_ram_proof.target_hash) ~=
-                test_util.tohex(ram_proof.target_hash),
-            "hash is same after memory is written")
+    assert(
+        test_util.tohex(initial_ram_proof.target_hash) ~= test_util.tohex(ram_proof.target_hash),
+        "hash is same after memory is written"
+    )
 
-        assert(test_util.tohex(initial_calculated_hash) ~=
-                test_util.tohex(calculated_hash),
-            "calculated hash is same after memory is written")
+    assert(
+        test_util.tohex(initial_calculated_hash) ~= test_util.tohex(calculated_hash),
+        "calculated hash is same after memory is written"
+    )
 
-        assert(test_util.tohex(ram_proof.target_hash) ==
-                test_util.tohex(calculated_hash),
-            "hash does not match after memory is written")
-    end
-)
+    assert(
+        test_util.tohex(ram_proof.target_hash) == test_util.tohex(calculated_hash),
+        "hash does not match after memory is written"
+    )
+end)
 
 print("\n\n check dirty page maps")
-do_test("dirty page maps should be consistent",
-    function(machine)
-        -- Verify dirty page maps
-        assert(machine:verify_dirty_page_maps(), "error verifying dirty page maps")
-    end
-)
+do_test("dirty page maps should be consistent", function(machine)
+    -- Verify dirty page maps
+    assert(machine:verify_dirty_page_maps(), "error verifying dirty page maps")
+end)
 
 print("\n\n check replace flash drives")
 test_util.make_do_test(build_machine, machine_type, {
     processor = {},
-    ram = {length = 1 << 20},
-    rom = {image_filename = rom_image},
-    flash_drive = {{
-        start = 0x80000000000000,
-        length = rootfs_length,
-        shared = false,
-        image_filename = rootfs_image
-    }}
-})("should replace flash drive and read something",
-    function(machine)
-        -- Create temp flash file
-        local input_path =  test_path .. "input.raw"
-        local command  = "echo 'test data 1234567890' > " .. input_path ..
-            " && truncate -s " .. tostring(rootfs_length) .. " " .. input_path
-        local p = io.popen(command)
-        p:close()
-
-        local flash_address_start = 0x80000000000000
-        local flash_drive_config = {
-            start = flash_address_start,
+    ram = { length = 1 << 20 },
+    rom = { image_filename = rom_image },
+    flash_drive = {
+        {
+            start = 0x80000000000000,
             length = rootfs_length,
-            image_filename = input_path,
-            shared = true
-        }
+            shared = false,
+            image_filename = rootfs_image,
+        },
+    },
+})("should replace flash drive and read something", function(machine)
+    -- Create temp flash file
+    local input_path = test_path .. "input.raw"
+    local command = "echo 'test data 1234567890' > "
+        .. input_path
+        .. " && truncate -s "
+        .. tostring(rootfs_length)
+        .. " "
+        .. input_path
+    local p = io.popen(command)
+    p:close()
 
-        machine:read_memory(flash_address_start, 20)
+    local flash_address_start = 0x80000000000000
+    local flash_drive_config = {
+        start = flash_address_start,
+        length = rootfs_length,
+        image_filename = input_path,
+        shared = true,
+    }
 
-        machine:replace_memory_range(flash_drive_config)
+    machine:read_memory(flash_address_start, 20)
 
-        local flash_data = machine:read_memory(flash_address_start, 20)
-        assert(flash_data == "test data 1234567890", "data read from replaced flash failed")
-        os.remove(input_path)
-    end
-)
+    machine:replace_memory_range(flash_drive_config)
+
+    local flash_data = machine:read_memory(flash_address_start, 20)
+    assert(flash_data == "test data 1234567890", "data read from replaced flash failed")
+    os.remove(input_path)
+end)
 
 print("\n\n check reading from an input and writing to an output flash drive")
 test_util.make_do_test(build_machine, machine_type, {
@@ -516,63 +518,60 @@ test_util.make_do_test(build_machine, machine_type, {
     },
     rom = {
         image_filename = rom_image,
-        bootargs =
-            "console=hvc0 rootfstype=ext2 root=/dev/mtdblock0 rw quiet swiotlb=noforce single=yes splash=no "..
-            "mtdparts=flash.0:-(root);flash.1:-(input);flash.2:-(output) -- "..
-            "cat /mnt/input/etc/issue | dd status=none of=/dev/mtdblock2",
+        bootargs = "console=hvc0 rootfstype=ext2 root=/dev/mtdblock0 rw quiet swiotlb=noforce single=yes splash=no "
+            .. "mtdparts=flash.0:-(root);flash.1:-(input);flash.2:-(output) -- "
+            .. "cat /mnt/input/etc/issue | dd status=none of=/dev/mtdblock2",
     },
-    flash_drive = {{
-        start = 0x80000000000000,
-        length = rootfs_length,
-        image_filename = rootfs_image
-    }, {
-        start = 0x90000000000000,
-        length = rootfs_length,
-        image_filename = rootfs_image
-    }, {
-        start = 0xa0000000000000,
-        length = 4096,
-    }}
-})("should boot mount input flash drive and output to another flash drive",
-    function(machine)
-        machine:run(MAX_MCYCLE)
-        assert(machine:read_iflags_H(), "machine should be halted")
+    flash_drive = {
+        {
+            start = 0x80000000000000,
+            length = rootfs_length,
+            image_filename = rootfs_image,
+        },
+        {
+            start = 0x90000000000000,
+            length = rootfs_length,
+            image_filename = rootfs_image,
+        },
+        {
+            start = 0xa0000000000000,
+            length = 4096,
+        },
+    },
+})("should boot mount input flash drive and output to another flash drive", function(machine)
+    machine:run(MAX_MCYCLE)
+    assert(machine:read_iflags_H(), "machine should be halted")
 
-        local expected_issue = 'Welcome to Cartesi'
-        local flash_data = machine:read_memory(0xa0000000000000, #expected_issue)
-        assert(flash_data == expected_issue, 'unexpected flash drive output')
-    end
-)
+    local expected_issue = "Welcome to Cartesi"
+    local flash_data = machine:read_memory(0xa0000000000000, #expected_issue)
+    assert(flash_data == expected_issue, "unexpected flash drive output")
+end)
 
 print("\n\n check for relevant register values after step 1")
-test_util.make_do_test(build_uarch_machine, machine_type)("register values should match",
-    function(machine)
-        local uarch_pc_before = machine:read_uarch_pc()
-        local uarch_cycle_before = machine:read_uarch_cycle()
+test_util.make_do_test(build_uarch_machine, machine_type)("register values should match", function(machine)
+    local uarch_pc_before = machine:read_uarch_pc()
+    local uarch_cycle_before = machine:read_uarch_cycle()
 
-        local log_type = {}
-        machine:step_uarch(log_type)
+    local log_type = {}
+    machine:step_uarch(log_type)
 
-        local uarch_pc_after = machine:read_uarch_pc()
-        local uarch_cycle_after = machine:read_uarch_cycle()
+    local uarch_pc_after = machine:read_uarch_pc()
+    local uarch_cycle_after = machine:read_uarch_cycle()
 
-        assert(uarch_pc_before + 4 == uarch_pc_after, "wrong uarch_pc value")
-        assert(uarch_cycle_before + 1 == uarch_cycle_after, "wrong uarch_cycle value")
-    end
-)
+    assert(uarch_pc_before + 4 == uarch_pc_after, "wrong uarch_pc value")
+    assert(uarch_cycle_before + 1 == uarch_cycle_after, "wrong uarch_cycle value")
+end)
 
 if machine_type ~= "local" then
     print("\n\n check remote get_machine")
-    do_test("get_machine should get reference to working machine",
-        function(machine)
-            local machine_2 = remote.get_machine()
-            assert(machine:get_root_hash() == machine_2:get_root_hash())
-            machine_2:destroy()
-            local ret, err = pcall(function() machine:get_root_hash() end)
-            assert(ret == false)
-            assert(err:match("no machine"))
-        end
-    )
+    do_test("get_machine should get reference to working machine", function(machine)
+        local machine_2 = remote.get_machine()
+        assert(machine:get_root_hash() == machine_2:get_root_hash())
+        machine_2:destroy()
+        local ret, err = pcall(function() machine:get_root_hash() end)
+        assert(ret == false)
+        assert(err:match("no machine"))
+    end)
 end
 
 print("\n\nAll tests of machine lua API for type " .. machine_type .. "  passed")

--- a/src/tests/machine-test.lua
+++ b/src/tests/machine-test.lua
@@ -27,8 +27,8 @@ local md5 = require "md5"
 -- There is no UINT64_MAX in Lua, so we have to use the signed representation
 local MAX_MCYCLE = -1
 
-local remote_address = nil
-local checkin_address = nil
+local remote_address
+local checkin_address
 local test_path = "./"
 local cleanup = {}
 
@@ -110,9 +110,9 @@ local options = {
 
 -- Process command line options
 local arguments = {}
-for i, argument in ipairs({...}) do
+for _, argument in ipairs({...}) do
     if argument:sub(1,1) == "-" then
-        for j, option in ipairs(options) do
+        for _, option in ipairs(options) do
             if option[2](argument:match(option[1])) then
                 break
             end
@@ -169,14 +169,7 @@ local pmas_file_names_with_uarch = {
     "0000000070000000--0000000000100000.bin" -- uarch ram
 }
 
-
-local function run_loop(machine, mcycle_end)
-    while machine:read_mcycle() < mcycle_end do
-        machine:run(mcycle_end)
-        if machine:read_iflags_H() then break end
-    end
-end
-
+local remote
 local function build_machine(type, config)
     -- Create new machine
     -- Use default config to be max reproducible
@@ -191,7 +184,7 @@ local function build_machine(type, config)
             update_merkle_tree = concurrency_update_merkle_tree
         }
     }
-    local new_machine = nil
+    local new_machine
     if (type ~= "local") then
         if not remote then remote = connect() end
         new_machine = assert(remote.machine(config, runtime))
@@ -206,10 +199,10 @@ local function build_uarch_machine(type)
         processor = {},
         ram = {length = 1 << 20},
         rom = {image_filename = rom_image},
-        uarch = { 
-            ram = { 
-                length = 1 << 20, 
-                image_filename = test_util.create_test_uarch_program() 
+        uarch = {
+            ram = {
+                length = 1 << 20,
+                image_filename = test_util.create_test_uarch_program()
             }
         }
     }
@@ -423,7 +416,6 @@ do_test("mcycle and root hash should match",
 print("\n\nwrite something to ram memory and check if hash and proof matches")
 do_test("proof  and root hash should match",
     function(machine)
-        local root_hash = machine:get_root_hash()
         local ram_address_start = 0x80000000
 
         -- Find proof for first KB of ram
@@ -443,8 +435,8 @@ do_test("proof  and root hash should match",
 
         machine:write_memory(0x8000000F, "mydataol12345678", 0x10)
 
-        local root_hash_step1 = machine:get_root_hash()
         local verify = machine:verify_merkle_tree()
+        assert(verify, "verify merkle tree failed")
 
         -- Find proof for first KB of ram
         local ram_proof = machine:get_proof(ram_address_start, 10)

--- a/src/tests/mcycle-overflow.lua
+++ b/src/tests/mcycle-overflow.lua
@@ -16,23 +16,23 @@
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 --
 
-local cartesi = require"cartesi"
-local test_util = require "tests.util"
+local cartesi = require("cartesi")
+local test_util = require("tests.util")
 
 -- There is no UINT64_MAX in Lua, so we have to use the signed representation
 local MAX_MCYCLE = -1
 local MAX_UARCH_CYCLE = -1
 
 local function build_machine()
-    local config =  {
+    local config = {
         processor = {
             -- Request automatic default values for versioning CSRs
             mimpid = -1,
             marchid = -1,
-            mvendorid = -1
+            mvendorid = -1,
         },
         rom = {
-            image_filename = test_util.tests_path .. "bootstrap.bin"
+            image_filename = test_util.tests_path .. "bootstrap.bin",
         },
         ram = {
             image_filename = test_util.tests_path .. "mcycle_overflow.bin",
@@ -41,9 +41,9 @@ local function build_machine()
         uarch = {
             ram = {
                 length = 1 << 20,
-                image_filename = test_util.create_test_uarch_program()
-            }
-        }
+                image_filename = test_util.create_test_uarch_program(),
+            },
+        },
     }
     local machine = cartesi.machine(config)
     os.remove(config.uarch.ram.image_filename)
@@ -91,16 +91,15 @@ do_test("run_uarch shouldn't change state at max uarch_cycle", function(machine)
     assert(hash_before == hash_after)
 end)
 
-for _, proofs in ipairs{true, false} do
-    do_test("machine step should do nothing on max mcycle [proofs=" ..
-            tostring(proofs) .. "]", function(machine)
+for _, proofs in ipairs({ true, false }) do
+    do_test("machine step should do nothing on max mcycle [proofs=" .. tostring(proofs) .. "]", function(machine)
         machine:write_uarch_cycle(MAX_UARCH_CYCLE)
-        local log = machine:step_uarch{proofs=proofs}
+        local log = machine:step_uarch({ proofs = proofs })
         assert(machine:read_uarch_cycle() == MAX_UARCH_CYCLE)
         assert(#log.accesses == 1)
         assert(log.accesses[1].type == "read")
         assert(log.accesses[1].address == 0x320) -- address of uarch_cycle in shadow
-        assert(log.accesses[1].read == string.pack('J', MAX_UARCH_CYCLE))
+        assert(log.accesses[1].read == string.pack("J", MAX_UARCH_CYCLE))
         assert((log.accesses[1].proof ~= nil) == proofs)
     end)
 end

--- a/src/tests/mcycle-overflow.lua
+++ b/src/tests/mcycle-overflow.lua
@@ -38,10 +38,10 @@ local function build_machine()
             image_filename = test_util.tests_path .. "mcycle_overflow.bin",
             length = 32 << 20,
         },
-        uarch = { 
-            ram = { 
+        uarch = {
+            ram = {
                 length = 1 << 20,
-                image_filename = test_util.create_test_uarch_program() 
+                image_filename = test_util.create_test_uarch_program()
             }
         }
     }

--- a/src/tests/mtime-interrupt.lua
+++ b/src/tests/mtime-interrupt.lua
@@ -52,7 +52,7 @@ end
 print("testing mtime interrupt")
 
 do_test("machine:run should interrupt for mtime", function(machine)
-    for i = 1, EXPECTED_MCYCLE do
+    for _ = 1, EXPECTED_MCYCLE do
         machine:run(-1)
         if machine:read_iflags_H() then break end
     end
@@ -60,7 +60,7 @@ do_test("machine:run should interrupt for mtime", function(machine)
 end)
 
 test_util.disabled_test("machine:step_uarch should interrupt for mtime", function(machine)
-    for i = 1, EXPECTED_MCYCLE do
+    for _ = 1, EXPECTED_MCYCLE do
         machine:step_uarch{}
         if machine:read_iflags_H() then break end
     end

--- a/src/tests/mtime-interrupt.lua
+++ b/src/tests/mtime-interrupt.lua
@@ -16,13 +16,13 @@
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 --
 
-local cartesi = require"cartesi"
-local test_util = require "tests.util"
+local cartesi = require("cartesi")
+local test_util = require("tests.util")
 
 local function build_machine()
     local machine_config = {
         rom = {
-            image_filename = test_util.tests_path .. "bootstrap.bin"
+            image_filename = test_util.tests_path .. "bootstrap.bin",
         },
         ram = {
             image_filename = test_util.tests_path .. "mtime_interrupt.bin",
@@ -41,11 +41,11 @@ local function do_test(description, f)
 end
 
 local RTC_FREQ_DIV = 8192
-local EXPECTED_MCYCLE = RTC_FREQ_DIV*2 + 20
+local EXPECTED_MCYCLE = RTC_FREQ_DIV * 2 + 20
 
 local function check_state(machine)
     assert(machine:read_iflags_H(), "machine did not halt")
-    assert(machine:read_htif_tohost_data()>>1 == 0, "invalid return code")
+    assert(machine:read_htif_tohost_data() >> 1 == 0, "invalid return code")
     assert(machine:read_mcycle() == EXPECTED_MCYCLE, "invalid mcycle")
 end
 
@@ -61,7 +61,7 @@ end)
 
 test_util.disabled_test("machine:step_uarch should interrupt for mtime", function(machine)
     for _ = 1, EXPECTED_MCYCLE do
-        machine:step_uarch{}
+        machine:step_uarch({})
         if machine:read_iflags_H() then break end
     end
     check_state(machine)

--- a/src/tests/test-jsonrpc-fork.lua
+++ b/src/tests/test-jsonrpc-fork.lua
@@ -59,9 +59,9 @@ local options = {
 }
 
 -- Process command line options
-for i, argument in ipairs({...}) do
+for _, argument in ipairs({...}) do
     if argument:sub(1,1) == "-" then
-        for j, option in ipairs(options) do
+        for _, option in ipairs(options) do
             if option[2](argument:match(option[1])) then
                 break
             end
@@ -141,7 +141,7 @@ end
 local function pre_order(node, f, depth)
     depth = depth or 0
     f(node, depth)
-    for i, child in ipairs(node.children) do
+    for _, child in ipairs(node.children) do
         pre_order(child, f, depth+1)
     end
 end

--- a/src/tests/util.lua
+++ b/src/tests/util.lua
@@ -16,7 +16,7 @@
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 --
 
-local cartesi = require "cartesi"
+local cartesi = require("cartesi")
 
 local zero_keccak_hash_table = {
     "",
@@ -81,7 +81,7 @@ local zero_keccak_hash_table = {
     "6d1ab973982c7ccbe6c1fae02788e4422ae22282fa49cbdb04ba54a7a238c6fc", -- 60
     "41187451383460762c06d1c8a72b9cd718866ad4b689e10c9a8c38fe5ef045bd", -- 61
     "785b01e980fc82c7e3532ce81876b778dd9f1ceeba4478e86411fb6fdd790683", -- 62
-    "916ca832592485093644e8760cd7b4c01dba1ccc82b661bf13f0e3f34acd6b88" -- 63
+    "916ca832592485093644e8760cd7b4c01dba1ccc82b661bf13f0e3f34acd6b88", -- 63
 }
 
 local function adjust_images_path(path)
@@ -95,16 +95,16 @@ local test_util = {
         m_page_log2_size = 0,
         m_tree_log2_size = 0,
         m_page_count = 0,
-        m_max_pages = 0
+        m_max_pages = 0,
     },
-    hash = {LOG2_WORD_SIZE = 3},
-    images_path = adjust_images_path(os.getenv('CARTESI_IMAGES_PATH')),
-    tests_path = adjust_images_path(os.getenv("CARTESI_TESTS_PATH"))
+    hash = { LOG2_WORD_SIZE = 3 },
+    images_path = adjust_images_path(os.getenv("CARTESI_IMAGES_PATH")),
+    tests_path = adjust_images_path(os.getenv("CARTESI_TESTS_PATH")),
 }
 
 function test_util.create_test_uarch_program()
     local file_path = os.tmpname()
-    local f = io.open(file_path, 'wb')
+    local f = io.open(file_path, "wb")
     f:write(string.pack("I4", 0x07b00513)) --   li	a0,123
     f:write(string.pack("I4", 0x32800293)) --   li t0, UARCH_HALT_FLAG_SHADDOW_ADDR_DEF (0x328)
     f:write(string.pack("I4", 0x00100313)) --   li	t1,1           UARCH_MMIO_HALT_VALUE_DEF
@@ -123,12 +123,9 @@ function test_util.make_do_test(build_machine, type, config)
     end
 end
 
-function test_util.disabled_test(description)
-    print("Disabled test - "..description)
-end
+function test_util.disabled_test(description) print("Disabled test - " .. description) end
 
-function test_util.incremental_merkle_tree_of_pages:new(o, page_log2_size,
-                                                         tree_log2_size)
+function test_util.incremental_merkle_tree_of_pages:new(o, page_log2_size, tree_log2_size)
     o = o or {}
     setmetatable(o, self)
     self.__index = self
@@ -142,11 +139,10 @@ end
 
 function test_util.incremental_merkle_tree_of_pages:add_page(new_page_hash)
     local right = new_page_hash
-    assert(self.m_page_count < self.m_max_pages,
-           "Page count must be smaller than max pages")
+    assert(self.m_page_count < self.m_max_pages, "Page count must be smaller than max pages")
     local depth = self.m_tree_log2_size - self.m_page_log2_size
     for i = 0, depth do
-        if (self.m_page_count & (0x01 << i) ~= 0x0) then
+        if self.m_page_count & (0x01 << i) ~= 0x0 then
             local left = self.m_context[i]
             right = cartesi.keccak(left, right)
         else
@@ -158,12 +154,10 @@ function test_util.incremental_merkle_tree_of_pages:add_page(new_page_hash)
 end
 
 function test_util.incremental_merkle_tree_of_pages:get_root_hash()
-    assert(self.m_page_count <= self.m_max_pages,
-           "Page count must be smaller or equal than max pages")
+    assert(self.m_page_count <= self.m_max_pages, "Page count must be smaller or equal than max pages")
     local depth = self.m_tree_log2_size - self.m_page_log2_size
     if self.m_page_count < self.m_max_pages then
-        local root = test_util.fromhex(
-            zero_keccak_hash_table[self.m_page_log2_size])
+        local root = test_util.fromhex(zero_keccak_hash_table[self.m_page_log2_size])
         for i = 0, depth - 1 do
             if (self.m_page_count & (0x01 << i)) ~= 0 then
                 local left = self.m_context[i]
@@ -177,7 +171,6 @@ function test_util.incremental_merkle_tree_of_pages:get_root_hash()
     else
         return self.m_context[depth]
     end
-
 end
 
 function test_util.file_exists(name)
@@ -191,14 +184,11 @@ function test_util.file_exists(name)
 end
 
 function test_util.fromhex(str)
-    return
-        (str:gsub('..', function(cc) return string.char(tonumber(cc, 16)) end))
+    return (str:gsub("..", function(cc) return string.char(tonumber(cc, 16)) end))
 end
 
 function test_util.tohex(str)
-    return (str:gsub('.', function(c)
-        return string.format('%02X', string.byte(c))
-    end))
+    return (str:gsub(".", function(c) return string.format("%02X", string.byte(c)) end))
 end
 
 function test_util.split_string(inputstr, sep)
@@ -210,15 +200,15 @@ function test_util.split_string(inputstr, sep)
     return t
 end
 
-function  test_util.check_proof(proof)
+function test_util.check_proof(proof)
     local hash = proof.target_hash
-    for log2_size = proof.log2_target_size, proof.log2_root_size-1 do
+    for log2_size = proof.log2_target_size, proof.log2_root_size - 1 do
         local bit = (proof.target_address & (1 << log2_size)) ~= 0
         local first, second
         if bit then
-            first, second = proof.sibling_hashes[proof.log2_root_size-log2_size], hash
+            first, second = proof.sibling_hashes[proof.log2_root_size - log2_size], hash
         else
-            first, second = hash, proof.sibling_hashes[proof.log2_root_size-log2_size]
+            first, second = hash, proof.sibling_hashes[proof.log2_root_size - log2_size]
         end
         hash = cartesi.keccak(first, second)
     end
@@ -227,7 +217,6 @@ end
 
 function test_util.align(v, el) return (v >> el << el) end
 
-
 -- Calculate root hash for data buffer of log2_size
 function test_util.calculate_root_hash(data, log2_size)
     if log2_size < test_util.hash.LOG2_WORD_SIZE then
@@ -235,11 +224,8 @@ function test_util.calculate_root_hash(data, log2_size)
     elseif log2_size > test_util.hash.LOG2_WORD_SIZE then
         log2_size = log2_size - 1
         local sz = math.ceil(data:len() / 2)
-        local child1 =
-            test_util.calculate_root_hash(data:sub(1, sz), log2_size)
-        local child2 = test_util.calculate_root_hash(data:sub(sz + 1,
-                                                               data:len()),
-                                                      log2_size)
+        local child1 = test_util.calculate_root_hash(data:sub(1, sz), log2_size)
+        local child2 = test_util.calculate_root_hash(data:sub(sz + 1, data:len()), log2_size)
         local hash = cartesi.keccak(child1, child2)
         return hash
     else
@@ -252,20 +238,14 @@ end
 -- of page size page_log2_size
 -- calculate merke hash for region of up to tree_log2_size,
 -- using zero sibling hashes where needed
-function test_util.calculate_region_hash(data_buffer, data_number_of_pages,
-                                          page_log2_size, tree_log2_size)
-
+function test_util.calculate_region_hash(data_buffer, data_number_of_pages, page_log2_size, tree_log2_size)
     local page_size = 1 << page_log2_size
 
-    local incremental_tree = test_util.incremental_merkle_tree_of_pages:new({},
-                                                                             page_log2_size,
-                                                                             tree_log2_size)
+    local incremental_tree = test_util.incremental_merkle_tree_of_pages:new({}, page_log2_size, tree_log2_size)
 
     for i = 0, data_number_of_pages - 1 do
-        local current_page_data = data_buffer:sub(i * page_size + 1,
-                                                  (i + 1) * page_size)
-        local current_page_hash = test_util.calculate_root_hash(
-                                      current_page_data, page_log2_size)
+        local current_page_data = data_buffer:sub(i * page_size + 1, (i + 1) * page_size)
+        local current_page_hash = test_util.calculate_root_hash(current_page_data, page_log2_size)
         incremental_tree:add_page(current_page_hash)
     end
 
@@ -276,13 +256,11 @@ end
 
 -- Take data hash of some region and extend it with pristine space
 -- up to tree_log2_size, calculating target hash
-function test_util.extend_region_hash(data_hash, data_address, data_log2_size,
-                                       tree_log2_size)
-
+function test_util.extend_region_hash(data_hash, data_address, data_log2_size, tree_log2_size)
     local result_hash = data_hash
     local result_address = data_address
     for n = data_log2_size + 1, tree_log2_size do
-        if result_address & ((1 << n)-1) == 0 then
+        if result_address & ((1 << n) - 1) == 0 then
             local child1 = result_hash
             local child2 = test_util.fromhex(zero_keccak_hash_table[n - 1])
             result_hash = cartesi.keccak(child1, child2)
@@ -302,19 +280,15 @@ end
 -- calculate merke hash for region of up to log2_result_address_space,
 -- using zero sibling hashes where needed. Data_address may not be aligned
 -- to the beginning of the log2_result_address_space
-function test_util.calculate_region_hash_2(data_address, data_buffer,
-                                            log2_data_size,
-                                            log2_result_address_space)
-
+function test_util.calculate_region_hash_2(data_address, data_buffer, log2_data_size, log2_result_address_space)
     data_address = data_address & (~0x01 << (log2_data_size - 1))
 
-    local data_hash =
-        test_util.calculate_root_hash(data_buffer, log2_data_size)
+    local data_hash = test_util.calculate_root_hash(data_buffer, log2_data_size)
 
     local result_hash = data_hash
     local result_address = data_address
     for n = log2_data_size + 1, log2_result_address_space do
-        if result_address & ((1 << n)-1) == 0 then
+        if result_address & ((1 << n) - 1) == 0 then
             local child1 = result_hash
             local child2 = test_util.fromhex(zero_keccak_hash_table[n - 1])
             result_hash = cartesi.keccak(child1, child2)
@@ -327,7 +301,6 @@ function test_util.calculate_region_hash_2(data_address, data_buffer,
     end
 
     return result_hash
-
 end
 
 function test_util.parse_pma_file(filename)
@@ -373,27 +346,30 @@ function test_util.calculate_emulator_hash(test_path, pmas_files)
     local htif = test_util.parse_pma_file(test_path .. pmas_files[6])
     local ram = test_util.parse_pma_file(test_path .. pmas_files[7])
     local uarch_ram = ""
-    if pmas_files[8] then
-        uarch_ram = test_util.parse_pma_file(test_path .. pmas_files[8])
-    end
+    if pmas_files[8] then uarch_ram = test_util.parse_pma_file(test_path .. pmas_files[8]) end
 
     local shadow_rom = shadow_state .. rom .. shadow_pmas
 
     local shadow_rom_hash_size_log2 = ceil_log2(PMA_SHADOW_STATE_LENGTH + PMA_ROM_LENGTH + PMA_SHADOW_PMAS_LENGTH)
-    local shadow_rom_space_hash = calculate_region_hash(shadow_rom,
-        (#shadow_rom + PMA_PAGE_SIZE - 1) // PMA_PAGE_SIZE, PMA_PAGE_SIZE_LOG2, shadow_rom_hash_size_log2)
+    local shadow_rom_space_hash = calculate_region_hash(
+        shadow_rom,
+        (#shadow_rom + PMA_PAGE_SIZE - 1) // PMA_PAGE_SIZE,
+        PMA_PAGE_SIZE_LOG2,
+        shadow_rom_hash_size_log2
+    )
     shadow_rom_space_hash = extend_region_hash(shadow_rom_space_hash, 0, shadow_rom_hash_size_log2, 17)
 
     local tlb_size_log2 = ceil_log2(PMA_SHADOW_TLB_LENGTH)
-    local tlb_space_hash =
-        calculate_region_hash(shadow_tlb,
-            (#shadow_tlb + PMA_PAGE_SIZE - 1) // PMA_PAGE_SIZE,
-            PMA_PAGE_SIZE_LOG2, tlb_size_log2)
+    local tlb_space_hash = calculate_region_hash(
+        shadow_tlb,
+        (#shadow_tlb + PMA_PAGE_SIZE - 1) // PMA_PAGE_SIZE,
+        PMA_PAGE_SIZE_LOG2,
+        tlb_size_log2
+    )
     tlb_space_hash = extend_region_hash(tlb_space_hash, PMA_SHADOW_TLB_START, tlb_size_log2, 17)
 
     local shadow_rom_tlb_space_hash = cartesi.keccak(shadow_rom_space_hash, tlb_space_hash) -- 18
-    shadow_rom_tlb_space_hash =
-        extend_region_hash(shadow_rom_tlb_space_hash, 0, 18, 25)
+    shadow_rom_tlb_space_hash = extend_region_hash(shadow_rom_tlb_space_hash, 0, 18, 25)
 
     local clint_size_log2 = ceil_log2(PMA_CLINT_LENGTH)
     local clint_space_hash =
@@ -409,9 +385,12 @@ function test_util.calculate_emulator_hash(test_path, pmas_files)
     local uarch_ram_space_hash = test_util.fromhex(zero_keccak_hash_table[30])
     if #uarch_ram > 0 then
         local uarch_ram_size_log2 = ceil_log2(#uarch_ram)
-        uarch_ram_space_hash = calculate_region_hash(uarch_ram,
+        uarch_ram_space_hash = calculate_region_hash(
+            uarch_ram,
             (#uarch_ram + PMA_PAGE_SIZE - 1) // PMA_PAGE_SIZE,
-            PMA_PAGE_SIZE_LOG2, uarch_ram_size_log2)
+            PMA_PAGE_SIZE_LOG2,
+            uarch_ram_size_log2
+        )
         uarch_ram_space_hash = extend_region_hash(uarch_ram_space_hash, PMA_UARCH_RAM_START, uarch_ram_size_log2, 30)
     end
     left = cartesi.keccak(left, uarch_ram_space_hash) -- 31

--- a/src/tests/util.lua
+++ b/src/tests/util.lua
@@ -102,7 +102,7 @@ local test_util = {
     tests_path = adjust_images_path(os.getenv("CARTESI_TESTS_PATH"))
 }
 
-function test_util.create_test_uarch_program() 
+function test_util.create_test_uarch_program()
     local file_path = os.tmpname()
     local f = io.open(file_path, 'wb')
     f:write(string.pack("I4", 0x07b00513)) --   li	a0,123
@@ -123,7 +123,7 @@ function test_util.make_do_test(build_machine, type, config)
     end
 end
 
-function test_util.disabled_test(description, f)
+function test_util.disabled_test(description)
     print("Disabled test - "..description)
 end
 
@@ -386,7 +386,9 @@ function test_util.calculate_emulator_hash(test_path, pmas_files)
 
     local tlb_size_log2 = ceil_log2(PMA_SHADOW_TLB_LENGTH)
     local tlb_space_hash =
-        calculate_region_hash(shadow_tlb, (#shadow_tlb + PMA_PAGE_SIZE - 1) // PMA_PAGE_SIZE, PMA_PAGE_SIZE_LOG2, tlb_size_log2)
+        calculate_region_hash(shadow_tlb,
+            (#shadow_tlb + PMA_PAGE_SIZE - 1) // PMA_PAGE_SIZE,
+            PMA_PAGE_SIZE_LOG2, tlb_size_log2)
     tlb_space_hash = extend_region_hash(tlb_space_hash, PMA_SHADOW_TLB_START, tlb_size_log2, 17)
 
     local shadow_rom_tlb_space_hash = cartesi.keccak(shadow_rom_space_hash, tlb_space_hash) -- 18
@@ -407,7 +409,9 @@ function test_util.calculate_emulator_hash(test_path, pmas_files)
     local uarch_ram_space_hash = test_util.fromhex(zero_keccak_hash_table[30])
     if #uarch_ram > 0 then
         local uarch_ram_size_log2 = ceil_log2(#uarch_ram)
-        uarch_ram_space_hash = calculate_region_hash(uarch_ram, (#uarch_ram + PMA_PAGE_SIZE - 1) // PMA_PAGE_SIZE, PMA_PAGE_SIZE_LOG2, uarch_ram_size_log2)
+        uarch_ram_space_hash = calculate_region_hash(uarch_ram,
+            (#uarch_ram + PMA_PAGE_SIZE - 1) // PMA_PAGE_SIZE,
+            PMA_PAGE_SIZE_LOG2, uarch_ram_size_log2)
         uarch_ram_space_hash = extend_region_hash(uarch_ram_space_hash, PMA_UARCH_RAM_START, uarch_ram_size_log2, 30)
     end
     left = cartesi.keccak(left, uarch_ram_space_hash) -- 31

--- a/src/uarch-riscv-tests.lua
+++ b/src/uarch-riscv-tests.lua
@@ -16,69 +16,69 @@
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 --
 
-local cartesi = require"cartesi"
-local util = require"cartesi.util"
+local cartesi = require("cartesi")
+local util = require("cartesi.util")
 
 -- Tests Cases
 -- format {"ram_image_file", number_of_uarch_cycles}
 local riscv_tests = {
-    {"rv64ui-uarch-simple.bin", 12},
-    {"rv64ui-uarch-add.bin", 441},
-    {"rv64ui-uarch-addi.bin", 216},
-    {"rv64ui-uarch-addiw.bin", 213},
-    {"rv64ui-uarch-addw.bin", 436},
-    {"rv64ui-uarch-and.bin", 516},
-    {"rv64ui-uarch-andi.bin", 187},
-    {"rv64ui-uarch-auipc.bin", 30},
-    {"rv64ui-uarch-beq.bin", 262},
-    {"rv64ui-uarch-bge.bin", 280},
-    {"rv64ui-uarch-bgeu.bin", 370},
-    {"rv64ui-uarch-blt.bin", 262},
-    {"rv64ui-uarch-bltu.bin", 348},
-    {"rv64ui-uarch-bne.bin", 262},
-    {"rv64ui-uarch-jal.bin", 26},
-    {"rv64ui-uarch-jalr.bin", 86},
-    {"rv64ui-uarch-lb.bin", 224},
-    {"rv64ui-uarch-lbu.bin", 224},
-    {"rv64ui-uarch-lh.bin", 240},
-    {"rv64ui-uarch-lhu.bin", 249},
-    {"rv64ui-uarch-lw.bin", 254},
-    {"rv64ui-uarch-lwu.bin", 288},
-    {"rv64ui-uarch-ld.bin", 406},
-    {"rv64ui-uarch-lui.bin", 36},
-    {"rv64ui-uarch-or.bin", 549},
-    {"rv64ui-uarch-ori.bin", 180},
-    {"rv64ui-uarch-sb.bin", 425},
-    {"rv64ui-uarch-sh.bin", 478},
-    {"rv64ui-uarch-sw.bin", 485},
-    {"rv64ui-uarch-sd.bin", 597},
-    {"rv64ui-uarch-sll.bin", 511},
-    {"rv64ui-uarch-slli.bin", 241},
-    {"rv64ui-uarch-slliw.bin", 248},
-    {"rv64ui-uarch-sllw.bin", 511},
-    {"rv64ui-uarch-slt.bin", 430},
-    {"rv64ui-uarch-slti.bin", 208},
-    {"rv64ui-uarch-sltiu.bin", 208},
-    {"rv64ui-uarch-sltu.bin", 447},
-    {"rv64ui-uarch-sra.bin", 483},
-    {"rv64ui-uarch-srai.bin", 229},
-    {"rv64ui-uarch-sraiw.bin", 275},
-    {"rv64ui-uarch-sraw.bin", 523},
-    {"rv64ui-uarch-srl.bin", 525},
-    {"rv64ui-uarch-srli.bin", 250},
-    {"rv64ui-uarch-srliw.bin", 257},
-    {"rv64ui-uarch-srlw.bin", 517},
-    {"rv64ui-uarch-sub.bin", 432},
-    {"rv64ui-uarch-subw.bin", 428},
-    {"rv64ui-uarch-xor.bin", 544},
-    {"rv64ui-uarch-xori.bin", 178},
-    {"rv64ui-uarch-fence.bin", 13},
+    { "rv64ui-uarch-simple.bin", 12 },
+    { "rv64ui-uarch-add.bin", 441 },
+    { "rv64ui-uarch-addi.bin", 216 },
+    { "rv64ui-uarch-addiw.bin", 213 },
+    { "rv64ui-uarch-addw.bin", 436 },
+    { "rv64ui-uarch-and.bin", 516 },
+    { "rv64ui-uarch-andi.bin", 187 },
+    { "rv64ui-uarch-auipc.bin", 30 },
+    { "rv64ui-uarch-beq.bin", 262 },
+    { "rv64ui-uarch-bge.bin", 280 },
+    { "rv64ui-uarch-bgeu.bin", 370 },
+    { "rv64ui-uarch-blt.bin", 262 },
+    { "rv64ui-uarch-bltu.bin", 348 },
+    { "rv64ui-uarch-bne.bin", 262 },
+    { "rv64ui-uarch-jal.bin", 26 },
+    { "rv64ui-uarch-jalr.bin", 86 },
+    { "rv64ui-uarch-lb.bin", 224 },
+    { "rv64ui-uarch-lbu.bin", 224 },
+    { "rv64ui-uarch-lh.bin", 240 },
+    { "rv64ui-uarch-lhu.bin", 249 },
+    { "rv64ui-uarch-lw.bin", 254 },
+    { "rv64ui-uarch-lwu.bin", 288 },
+    { "rv64ui-uarch-ld.bin", 406 },
+    { "rv64ui-uarch-lui.bin", 36 },
+    { "rv64ui-uarch-or.bin", 549 },
+    { "rv64ui-uarch-ori.bin", 180 },
+    { "rv64ui-uarch-sb.bin", 425 },
+    { "rv64ui-uarch-sh.bin", 478 },
+    { "rv64ui-uarch-sw.bin", 485 },
+    { "rv64ui-uarch-sd.bin", 597 },
+    { "rv64ui-uarch-sll.bin", 511 },
+    { "rv64ui-uarch-slli.bin", 241 },
+    { "rv64ui-uarch-slliw.bin", 248 },
+    { "rv64ui-uarch-sllw.bin", 511 },
+    { "rv64ui-uarch-slt.bin", 430 },
+    { "rv64ui-uarch-slti.bin", 208 },
+    { "rv64ui-uarch-sltiu.bin", 208 },
+    { "rv64ui-uarch-sltu.bin", 447 },
+    { "rv64ui-uarch-sra.bin", 483 },
+    { "rv64ui-uarch-srai.bin", 229 },
+    { "rv64ui-uarch-sraiw.bin", 275 },
+    { "rv64ui-uarch-sraw.bin", 523 },
+    { "rv64ui-uarch-srl.bin", 525 },
+    { "rv64ui-uarch-srli.bin", 250 },
+    { "rv64ui-uarch-srliw.bin", 257 },
+    { "rv64ui-uarch-srlw.bin", 517 },
+    { "rv64ui-uarch-sub.bin", 432 },
+    { "rv64ui-uarch-subw.bin", 428 },
+    { "rv64ui-uarch-xor.bin", 544 },
+    { "rv64ui-uarch-xori.bin", 178 },
+    { "rv64ui-uarch-fence.bin", 13 },
 }
-
 
 -- Print help and exit
 local function help()
-    io.stderr:write(string.format([=[
+    io.stderr:write(string.format(
+        [=[
 Usage:
   %s [options] <command>
 where options are:
@@ -102,7 +102,9 @@ and command can be:
   json-logs
     generate json log files, used by by Solidity unit tests, to the directory specified by --output-dir
 
-]=], arg[0]))
+]=],
+        arg[0]
+    ))
     os.exit()
 end
 
@@ -111,46 +113,57 @@ local test_pattern = ".*"
 local output_dir
 
 local options = {
-    { "^%-%-h$", function(all)
-        if not all then return false end
-        help()
-    end },
-    { "^%-%-help$", function(all)
-        if not all then return false end
-        help()
-    end },
-    { "^%-%-output%-dir%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        output_dir = o
-        return true
-    end },
-    { "^%-%-test%-path%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        test_path = o
-        return true
-    end },
-    { "^%-%-test%=(.*)$", function(o)
-        if not o or #o < 1 then return false end
-        test_pattern = o
-        return true
-    end },
-    { ".*", function(all)
-        error("unrecognized option " .. all)
-    end }
+    {
+        "^%-%-h$",
+        function(all)
+            if not all then return false end
+            help()
+        end,
+    },
+    {
+        "^%-%-help$",
+        function(all)
+            if not all then return false end
+            help()
+        end,
+    },
+    {
+        "^%-%-output%-dir%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            output_dir = o
+            return true
+        end,
+    },
+    {
+        "^%-%-test%-path%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            test_path = o
+            return true
+        end,
+    },
+    {
+        "^%-%-test%=(.*)$",
+        function(o)
+            if not o or #o < 1 then return false end
+            test_pattern = o
+            return true
+        end,
+    },
+    { ".*", function(all) error("unrecognized option " .. all) end },
 }
 
 local values = {}
 
 -- Process command line options
-for _, argument in ipairs({...}) do
-    if argument:sub(1,1) == "-" then
+for _, argument in ipairs({ ... }) do
+    if argument:sub(1, 1) == "-" then
         for _, option in ipairs(options) do
-            if option[2](argument:match(option[1])) then
-                break
-            end
+            if option[2](argument:match(option[1])) then break end
         end
     else
-        values[#values+1] = argument
+        values[#values + 1] = argument
     end
 end
 
@@ -160,22 +173,21 @@ assert(test_path, "missing test path")
 local function build_machine(test_name)
     local config = {
         rom = {
-            image_filename = test_path .. "/bootstrap.bin"
+            image_filename = test_path .. "/bootstrap.bin",
         },
         ram = {
-            length = 0x20000
+            length = 0x20000,
         },
         uarch = {
             ram = {
                 image_filename = test_path .. "/" .. test_name,
-                length = 0x20000
-            }
-        }
+                length = 0x20000,
+            },
+        },
     }
-    local runtime = { }
+    local runtime = {}
     return assert(cartesi.machine(config, runtime))
 end
-
 
 local function add_error(errors, ram_image, msg, ...)
     local e = string.format(msg, ...)
@@ -184,10 +196,10 @@ local function add_error(errors, ram_image, msg, ...)
     ram_image_errors[#ram_image_errors + 1] = e
 end
 
-local TEST_STATUS_X      = 1 -- When test finishes executing,the value of this register contains the test result code
+local TEST_STATUS_X = 1 -- When test finishes executing,the value of this register contains the test result code
 local FAILED_TEST_CASE_X = 3 -- If test fails, the value of this register contains the failed test case
-local TEST_SUCEEDED      = 0xbe1e7aaa  -- Value indicating that test has passed
-local TEST_FAILED        = 0xdeadbeef  -- Value indicating that test has failed
+local TEST_SUCEEDED = 0xbe1e7aaa -- Value indicating that test has passed
+local TEST_FAILED = 0xdeadbeef -- Value indicating that test has failed
 
 local function check_test_result(machine, ctx, errors)
     local test_status = machine:read_uarch_x(TEST_STATUS_X)
@@ -214,7 +226,7 @@ local function run(tests)
             ram_image = test[1],
             expected_cycles = test[2],
             failed = false,
-            cycles = 0
+            cycles = 0,
         }
         local machine = build_machine(ctx.ram_image)
         io.write(ctx.ram_image, ": ")
@@ -231,9 +243,9 @@ local function run(tests)
     if error_count > 0 then
         io.write(string.format("\nFAILED %d of %d tests:\n\n", error_count, #tests))
         for k, v in pairs(errors) do
-          for _, e in ipairs(v) do
-            io.write(string.format("\t%s: %s\n", k, e))
-          end
+            for _, e in ipairs(v) do
+                io.write(string.format("\t%s: %s\n", k, e))
+            end
         end
         os.exit(1, true)
     else
@@ -255,56 +267,56 @@ local function select_test(test_name, patt)
     return i == 1 and j == #test_name
 end
 
-local function make_json_log_file_name(test_name, suffix)
-    return test_name .. (suffix or "") .. ".json"
-end
+local function make_json_log_file_name(test_name, suffix) return test_name .. (suffix or "") .. ".json" end
 
 local function create_json_log_file(test_name, suffix)
-    local file_path =  output_dir .. "/" .. make_json_log_file_name(test_name, suffix)
+    local file_path = output_dir .. "/" .. make_json_log_file_name(test_name, suffix)
     return assert(io.open(file_path, "w"), "error opening file " .. file_path)
 end
 
-local function open_steps_json_log(test_name)
-    return create_json_log_file(test_name, "-steps")
-end
+local function open_steps_json_log(test_name) return create_json_log_file(test_name, "-steps") end
 
 local function write_access_to_log(access, out, indent, last)
-    util.indentout(out, indent, '{\n')
-    util.indentout(out, indent+1, '"type": "%s",\n', access.type)
-    util.indentout(out, indent+1, '"address": %u,\n', access.address)
+    util.indentout(out, indent, "{\n")
+    util.indentout(out, indent + 1, '"type": "%s",\n', access.type)
+    util.indentout(out, indent + 1, '"address": %u,\n', access.address)
     if access.type == "write" then
-        util.indentout(out, indent+1, '"value": "%s"\n', util.hexstring(access.written))
+        util.indentout(out, indent + 1, '"value": "%s"\n', util.hexstring(access.written))
     else
-        util.indentout(out, indent+1, '"value": "%s"\n', util.hexstring(access.read))
+        util.indentout(out, indent + 1, '"value": "%s"\n', util.hexstring(access.read))
     end
-    util.indentout(out, indent, '}')
-    if not last then out:write(',') end
-    out:write('\n')
+    util.indentout(out, indent, "}")
+    if not last then out:write(",") end
+    out:write("\n")
 end
 
 local function write_step_to_log(log, out, indent, last)
     local n = #log.accesses
-    util.indentout(out, indent, '{\n')
-    util.indentout(out, indent+1, '"accesses": [\n')
+    util.indentout(out, indent, "{\n")
+    util.indentout(out, indent + 1, '"accesses": [\n')
     for i, access in ipairs(log.accesses) do
-        write_access_to_log(access, out, indent+2, i==n)
+        write_access_to_log(access, out, indent + 2, i == n)
     end
-    util.indentout(out, indent+1, ']\n')
-    util.indentout(out, indent, '}')
-    if not last then out:write(',') end
-    out:write('\n')
+    util.indentout(out, indent + 1, "]\n")
+    util.indentout(out, indent, "}")
+    if not last then out:write(",") end
+    out:write("\n")
 end
 
 local function create_catalog_json_log(contexts)
     local out = create_json_log_file("catalog")
-    util.indentout(out, 0, '[\n')
+    util.indentout(out, 0, "[\n")
     local n = #contexts
     for i, ctx in ipairs(contexts) do
         local path = make_json_log_file_name(ctx.test_name, "-steps")
         util.indentout(out, 1, '{"path": "%s", "steps": %d}', path, ctx.step_count)
-        if i < n then out:write(',\n') else out:write('\n') end
+        if i < n then
+            out:write(",\n")
+        else
+            out:write("\n")
+        end
     end
-    util.indentout(out, 0, ']\n')
+    util.indentout(out, 0, "]\n")
     out:close()
 end
 
@@ -320,13 +332,11 @@ local function run_machine_writing_json_logs(machine, ctx)
         local log = machine:step_uarch(log_type)
         step_count = step_count + 1
         local halted = machine:read_uarch_halt_flag()
-        write_step_to_log(log, out, indent+1, halted)
-        if halted then
-            break
-        end
+        write_step_to_log(log, out, indent + 1, halted)
+        if halted then break end
     end
     ctx.step_count = step_count
-    util.indentout(out, indent, '] }\n')
+    util.indentout(out, indent, "] }\n")
     out:close()
 end
 
@@ -337,13 +347,13 @@ local function json_logs(tests)
     for _, test in ipairs(tests) do
         local ctx = {
             ram_image = test[1],
-            test_name = test[1]:gsub(".bin$",""),
+            test_name = test[1]:gsub(".bin$", ""),
             expected_cycles = test[2],
             failed = false,
             step_count = 0,
-            accesses_count = 0
+            accesses_count = 0,
         }
-        contexts[#contexts+1] = ctx
+        contexts[#contexts + 1] = ctx
         local machine = build_machine(ctx.ram_image)
         io.write(ctx.ram_image, ": ")
         run_machine_writing_json_logs(machine, ctx)
@@ -359,9 +369,9 @@ local function json_logs(tests)
     if error_count > 0 then
         io.write(string.format("\nFAILED %d of %d tests:\n\n", error_count, #tests))
         for k, v in pairs(errors) do
-          for _, e in ipairs(v) do
-            io.write(string.format("\t%s: %s\n", k, e))
-          end
+            for _, e in ipairs(v) do
+                io.write(string.format("\t%s: %s\n", k, e))
+            end
         end
         os.exit(1, true)
     else
@@ -369,18 +379,21 @@ local function json_logs(tests)
         create_catalog_json_log(contexts)
         os.exit(0, true)
     end
-
 end
 
 local selected_tests = {}
 for _, test in ipairs(riscv_tests) do
-    if select_test(test[1], test_pattern) then
-        selected_tests[#selected_tests+1] = test
-    end
+    if select_test(test[1], test_pattern) then selected_tests[#selected_tests + 1] = test end
 end
 
-if #selected_tests < 1 then error("no test selected")
-elseif command == "run" then run(selected_tests)
-elseif command == "list" then list(selected_tests)
-elseif command == "json-logs" then json_logs(selected_tests)
-else error("command not found") end
+if #selected_tests < 1 then
+    error("no test selected")
+elseif command == "run" then
+    run(selected_tests)
+elseif command == "list" then
+    list(selected_tests)
+elseif command == "json-logs" then
+    json_logs(selected_tests)
+else
+    error("command not found")
+end

--- a/third-party/riscv-arch-tests/src/run-rv64i-arch-test.lua
+++ b/third-party/riscv-arch-tests/src/run-rv64i-arch-test.lua
@@ -16,10 +16,11 @@
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 --
 
-local cartesi = require "cartesi"
+local cartesi = require("cartesi")
 
-if  #arg ~= 2 then
-  io.stderr:write(string.format([=[
+if #arg ~= 2 then
+    io.stderr:write(string.format(
+        [=[
 Usage:
 
   %s <uarch-ram-image> <output-signature-file>
@@ -30,8 +31,10 @@ where:
 
   <output-signature-file>
   name of file to write test signature results
-  ]=], arg[0]))
-  os.exit(1)
+  ]=],
+        arg[0]
+    ))
+    os.exit(1)
 end
 
 local uarch_ram_image_filename = arg[1]
@@ -39,20 +42,20 @@ local output_signature_file = arg[2]
 local uarch_ram_start = 0x70000000
 local uarch_ram_length = 0x1000000
 local dummy_rom_filename = os.tmpname()
-io.open(dummy_rom_filename, 'w'):close()
+io.open(dummy_rom_filename, "w"):close()
 local deleter = {}
-setmetatable(deleter, { __gc = function() os.remove(dummy_rom_filename) end } )
+setmetatable(deleter, { __gc = function() os.remove(dummy_rom_filename) end })
 
 local config = {
-  uarch ={
-    ram = {
-      image_filename = uarch_ram_image_filename,
-      length = uarch_ram_length
+    uarch = {
+        ram = {
+            image_filename = uarch_ram_image_filename,
+            length = uarch_ram_length,
+        },
     },
-  },
-  processor = {},
-  rom = { image_filename = dummy_rom_filename },
-  ram = { length = 0x1000 }
+    processor = {},
+    rom = { image_filename = dummy_rom_filename },
+    ram = { length = 0x1000 },
 }
 
 local machine = assert(cartesi.machine(config))
@@ -62,24 +65,22 @@ machine:run_uarch()
 
 -- extract test result signature from microarchitecture RAM
 local mem = machine:read_memory(uarch_ram_start, uarch_ram_length)
-local s1, e1 = string.find(mem, "BEGIN_CTSI_SIGNATURE____")
-local s2, e2 = string.find(mem, "END_CTSI_SIGNATURE______")
-local sig = string.sub(mem, e1+1, s2-1)
+local _, e1 = string.find(mem, "BEGIN_CTSI_SIGNATURE____")
+local s2, _ = string.find(mem, "END_CTSI_SIGNATURE______")
+local sig = string.sub(mem, e1 + 1, s2 - 1)
 
 -- write signature to file, in the format expected by the arch test script
 local fd = io.open(output_signature_file, "w")
-for i=1, #sig, 4 do
-  local w = string.reverse(string.sub(sig, i, i+3))
-  for j=1,4,1 do
-    local b = string.byte(string.sub(w, j))
-    fd:write(string.format("%02x", b))
-  end
-  fd:write("\n")
+for i = 1, #sig, 4 do
+    local w = string.reverse(string.sub(sig, i, i + 3))
+    for j = 1, 4, 1 do
+        local b = string.byte(string.sub(w, j))
+        fd:write(string.format("%02x", b))
+    end
+    fd:write("\n")
 end
 
 -- pad fill output file
-if (#sig % 16) ~= 0 then
-  fd:write("00000000\n00000000\n")
-end
+if (#sig % 16) ~= 0 then fd:write("00000000\n00000000\n") end
 
 fd:close()

--- a/tools/benchmarks/run-benchmarks.lua
+++ b/tools/benchmarks/run-benchmarks.lua
@@ -16,8 +16,8 @@
 -- along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 --
 
-local socket = require"socket"
-local cartesi = require"cartesi"
+local socket = require("socket")
+local cartesi = require("cartesi")
 
 -- Number of times each benchmark is measured
 local N_RUNS = 5
@@ -38,42 +38,42 @@ local benchmarks = {
     {
         name = "boot",
         exec_format = "exit %s",
-        params = {0}
+        params = { 0 },
     },
     {
         name = "dhrystone",
         exec_format = "echo %d | /usr/bin/dhrystone",
-        params = {100000, 500000, 1000000}
+        params = { 100000, 500000, 1000000 },
     },
     {
         name = "whetstone",
         exec_format = "/usr/bin/whetstone %d",
-        params = {100, 250, 500}
+        params = { 100, 250, 500 },
     },
     {
         name = "tinymembench",
         exec_format = "/usr/bin/tinymembench",
-        params = {}
+        params = {},
     },
     {
         name = "ramspeed",
         exec_format = "/usr/bin/ramspeed -b %d -g 1",
-        params = {1, 2, 3, 4, 5, 6}
+        params = { 1, 2, 3, 4, 5, 6 },
     },
     {
         name = "iozone",
         exec_format = "/usr/bin/iozone -a -s 65536 -r %d",
-        params = {64, 512, 2048}
+        params = { 64, 512, 2048 },
     },
     {
         name = "dieharder",
         exec_format = "/usr/bin/dieharder -d %d",
-        params = {0, 1, 2}
+        params = { 0, 1, 2 },
     },
     {
         name = "bonnie++",
         exec_format = "/usr/sbin/bonnie++ -d $(mktemp -d) -u root",
-        params = {0, 1, 2}
+        params = { 0, 1, 2 },
     },
 }
 
@@ -87,25 +87,26 @@ local function build_machine(exec_args)
             -- Request automatic default values for versioning CSRs
             mimpid = -1,
             marchid = -1,
-            mvendorid = -1
+            mvendorid = -1,
         },
         rom = {
             image_filename = rom_image_filename,
             bootargs = (
-                "console=hvc0 rootfstype=ext2 root=/dev/mtdblock0 rw " ..
-                "quiet mtdparts=flash.0:-(root) -- " .. exec_args
-            )
+                "console=hvc0 rootfstype=ext2 root=/dev/mtdblock0 rw "
+                .. "quiet mtdparts=flash.0:-(root) -- "
+                .. exec_args
+            ),
         },
         ram = {
             image_filename = ram_image_filename,
-            length = 64 << 20
+            length = 64 << 20,
         },
         flash_drive = {
             {
                 start = 0x80000000000000,
                 length = 0x40000000,
                 image_filename = flash_image_filename,
-            }
+            },
         },
     }
 
@@ -136,7 +137,7 @@ local function measure_all()
             table.insert(results, {
                 name = benchmark.name,
                 param = param,
-                times = times
+                times = times,
             })
         end
     end
@@ -155,9 +156,9 @@ local function stddev(arr)
     local std2 = 0.0
     local avg = average(arr)
     for _, value in ipairs(arr) do
-        std2 = std2 + (value - avg)^2
+        std2 = std2 + (value - avg) ^ 2
     end
-    return math.sqrt(std2/#arr)
+    return math.sqrt(std2 / #arr)
 end
 
 local function print_results(results)
@@ -167,9 +168,7 @@ local function print_results(results)
         io.write(string.format("%-24s", label))
         io.write("|")
         io.write(string.format("%7.3f", average(result.times)))
-        if PRINT_STDDEV then
-            io.write(string.format(" +-%.3f", stddev(result.times)))
-        end
+        if PRINT_STDDEV then io.write(string.format(" +-%.3f", stddev(result.times))) end
         io.write("|\n")
     end
 end

--- a/tools/benchmarks/run-benchmarks.lua
+++ b/tools/benchmarks/run-benchmarks.lua
@@ -114,7 +114,7 @@ end
 
 local function measure(exec_args)
     local results = {}
-    for i = 1, N_RUNS do
+    for _ = 1, N_RUNS do
         local machine = build_machine(exec_args)
         local start = socket.gettime()
         repeat


### PR DESCRIPTION
## This PR contains the following

- Adds static analysis for Lua code in target `make check-lua` and CI using [Luacheck](https://github.com/lunarmodules/luacheck)
- Adds code formatting check for Lua code in target `make check-format-lua` and CI using [StyLua](https://github.com/JohnnyMorganz/StyLua). Lua code can also be formatted using `make format-lua`.
- Fixes all warnings raised by Luacheck.
- Formats all Lua code.

## Details

I tried to choose a Lua style format configuration that would approximate the current Lua style we use.

## This PR depends on

- https://github.com/cartesi/machine-emulator/pull/33

*This PR depends on the above PRs, they should be reviewed first.*