### PR TITLE
Add `--version` to cartesi-machine

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /usr/src/emulator
 COPY . .
 
 RUN make -j$(nproc) dep && \
-    make -j$(nproc) release=$RELEASE && \
+    make -j$(nproc) release=$RELEASE git_commit=$GIT_COMMIT && \
     make -j$(nproc) uarch && \
     make install && \
     make clean && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Build
-        run: make -j$(nproc) release=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+        run: make -j$(nproc) release=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }} git_commit=${GITHUB_SHA}
 
       - name: Build uarch-based interpreter
         run: make uarch-with-toolchain
@@ -753,7 +753,7 @@ jobs:
           load: true
           cache-from: type=gha,mode=max,scope=ubuntu
           cache-to: type=gha,scope=ubuntu
-          build-args: RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+          build-args: RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }} GIT_COMMIT=${GITHUB_SHA}
 
       - name: Download [rootfs.ext2]
         uses: Legion2/download-release-action@v2.1.0
@@ -852,7 +852,7 @@ jobs:
           load: false
           cache-from: type=gha,mode=max,scope=ubuntu
           cache-to: type=gha,scope=ubuntu
-          build-args: RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+          build-args: RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }} GIT_COMMIT=${GITHUB_SHA}
 
   release:
     name: Release machine emulator tarball

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed compile errors with GCC 13.1
 - Fixed Lua path being mixed with different Lua version path
 
+### Added
+
+- Added --version and --version-json command-line options in cartesi-machine
+
 ## [0.14.0] - 2023-05-03
 ### Added
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -9,3 +9,4 @@
 compile_flags.txt
 coverage*
 jsonrpc-discover.cpp
+machine-c-version.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,15 @@
 # along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
 #
 
+# Every new emulator release should bump this constant when its RISC-V interpreter change
+EMULATOR_MARCHID=15
+
+# Every new emulator release should bump these constants
+EMULATOR_VERSION_MAJOR=0
+EMULATOR_VERSION_MINOR=14
+EMULATOR_VERSION_PATCH=0
+EMULATOR_VERSION_LABEL=
+
 UNAME:=$(shell uname)
 
 BUILDDIR ?= $(abspath ../build/$(UNAME)_$(shell uname -m))
@@ -682,6 +691,9 @@ machine-config.o protobuf-util.o: $(CARTESI_PROTOBUF_GEN_OBJS)
 
 grpc-virtual-machine.o grpc-machine-c-api.o remote-machine.o proxy.o: $(CARTESI_GRPC_GEN_OBJS) $(CARTESI_PROTOBUF_GEN_OBJS)
 
+machine-c-version.h: ../tools/template/machine-c-version.h.template
+	sed "s|EMULATOR_MARCHID|$(EMULATOR_MARCHID)|g;s|EMULATOR_VERSION_MAJOR|$(EMULATOR_VERSION_MAJOR)|g;s|EMULATOR_VERSION_MINOR|$(EMULATOR_VERSION_MINOR)|g;s|EMULATOR_VERSION_PATCH|$(EMULATOR_VERSION_PATCH)|g;s|EMULATOR_VERSION_LABEL|$(EMULATOR_VERSION_LABEL)|g" $< > $@
+
 jsonrpc-discover.cpp: jsonrpc-discover.json
 	echo '// This file is auto-generated and should not be modified' > jsonrpc-discover.cpp
 	echo 'namespace cartesi {' >> jsonrpc-discover.cpp
@@ -690,7 +702,7 @@ jsonrpc-discover.cpp: jsonrpc-discover.json
 	echo ')json";' >> jsonrpc-discover.cpp
 	echo '} // namespace cartesi' >> jsonrpc-discover.cpp
 
-%.clang-tidy: %.cpp $(PROTO_SOURCES)
+%.clang-tidy: %.cpp $(PROTO_SOURCES) machine-c-version.h
 	@$(CLANG_TIDY) --header-filter='$(CLANG_TIDY_HEADER_FILTER)' $< -- $(CXXFLAGS) 2>/dev/null
 	@$(CXX) $(CXXFLAGS) $< -MM -MT $@ -MF $@.d > /dev/null 2>&1
 	@touch $@
@@ -700,7 +712,7 @@ jsonrpc-discover.cpp: jsonrpc-discover.json
 	@$(CC) $(CFLAGS) $< -MM -MT $@ -MF $@.d > /dev/null 2>&1
 	@touch $@
 
-%.o: %.cpp
+%.o: %.cpp machine-c-version.h
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 %.o: %.cc $(PROTO_SOURCES)
@@ -712,7 +724,7 @@ jsonrpc-discover.cpp: jsonrpc-discover.json
 clean: clean-auto-generated clean-coverage clean-profile clean-proto-sources clean-tidy clean-libcartesi clean-executables clean-tests
 
 clean-auto-generated:
-	@rm -f jsonrpc-discover.cpp
+	@rm -f jsonrpc-discover.cpp machine-c-version.h
 
 clean-proto-sources:
 	@rm -f *.pb.cc *.pb.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -190,6 +190,11 @@ else
 OPTFLAGS+=-O2 -g
 endif
 
+# Git commit hash (for releases)
+ifneq ($(git_commit),)
+DEFS+=-DGIT_COMMIT='"$(git_commit)"'
+endif
+
 # Optimization flags
 ifneq (,$(filter yes,$(relwithdebinfo) $(release)))
 DEFS+=-DNDEBUG

--- a/src/clua-cartesi.cpp
+++ b/src/clua-cartesi.cpp
@@ -125,6 +125,19 @@ CM_API int luaopen_cartesi(lua_State *L) {
     clua_setintegerfield(L, MVENDORID_INIT, "MVENDORID", -1);
     clua_setintegerfield(L, MARCHID_INIT, "MARCHID", -1);
     clua_setintegerfield(L, MIMPID_INIT, "MIMPID", -1);
+    clua_setintegerfield(L, CM_VERSION_MAJOR, "VERSION_MAJOR", -1);
+    clua_setintegerfield(L, CM_VERSION_MINOR, "VERSION_MINOR", -1);
+    clua_setintegerfield(L, CM_VERSION_PATCH, "VERSION_PATCH", -1);
+    clua_setstringfield(L, CM_VERSION_LABEL, "VERSION_LABEL", -1);
+    clua_setstringfield(L, CM_VERSION, "VERSION", -1);
+    clua_setstringfield(L, BOOST_COMPILER, "COMPILER", -1);
+    clua_setstringfield(L, BOOST_PLATFORM, "PLATFORM", -1);
+#ifdef GIT_COMMIT
+    clua_setstringfield(L, GIT_COMMIT, "GIT_COMMIT", -1);
+#endif
+#if defined(__DATE__) && defined(__TIME__)
+    clua_setstringfield(L, __DATE__ " " __TIME__, "BUILD_TIME", -1);
+#endif
     return 1;
 }
 }

--- a/src/machine-c-defines.h
+++ b/src/machine-c-defines.h
@@ -32,4 +32,21 @@
 #define CM_TREE_LOG2_ROOT_SIZE 64         // NOLINT(cppcoreguidelines-macro-usage)
 #define CM_FLASH_DRIVE_CONFIGS_MAX_SIZE 8 // NOLINT(cppcoreguidelines-macro-usage)
 
+// Every new emulator release should bump this constant when its RISC-V interpreter change
+#define CM_MARCHID 15 // NOLINT(cppcoreguidelines-macro-usage)
+
+// Every new emulator release should bump these constants
+#define CM_VERSION_MAJOR 0  // NOLINT(cppcoreguidelines-macro-usage)
+#define CM_VERSION_MINOR 14 // NOLINT(cppcoreguidelines-macro-usage)
+#define CM_VERSION_PATCH 0  // NOLINT(cppcoreguidelines-macro-usage)
+#define CM_VERSION_LABEL "" // NOLINT(cppcoreguidelines-macro-usage)
+
+#define _CM_STR_HELPER(x) #x
+#define _CM_STR(x) _CM_STR_HELPER(x)
+#define CM_VERSION                                                                                                     \
+    _CM_STR(CM_VERSION_MAJOR) "." _CM_STR(CM_VERSION_MINOR) "." _CM_STR(CM_VERSION_PATCH) CM_VERSION_LABEL
+
+#define CM_MIMPID                                                                                                      \
+    (CM_VERSION_MAJOR * 1000000 + CM_VERSION_MINOR * 1000 + CM_VERSION_PATCH) // NOLINT(cppcoreguidelines-macro-usage)
+
 #endif // MACHINE_EMULATOR_SDK_MACHINE_C_DEFINES_H

--- a/src/machine-c-defines.h
+++ b/src/machine-c-defines.h
@@ -32,21 +32,6 @@
 #define CM_TREE_LOG2_ROOT_SIZE 64         // NOLINT(cppcoreguidelines-macro-usage)
 #define CM_FLASH_DRIVE_CONFIGS_MAX_SIZE 8 // NOLINT(cppcoreguidelines-macro-usage)
 
-// Every new emulator release should bump this constant when its RISC-V interpreter change
-#define CM_MARCHID 15 // NOLINT(cppcoreguidelines-macro-usage)
-
-// Every new emulator release should bump these constants
-#define CM_VERSION_MAJOR 0  // NOLINT(cppcoreguidelines-macro-usage)
-#define CM_VERSION_MINOR 14 // NOLINT(cppcoreguidelines-macro-usage)
-#define CM_VERSION_PATCH 0  // NOLINT(cppcoreguidelines-macro-usage)
-#define CM_VERSION_LABEL "" // NOLINT(cppcoreguidelines-macro-usage)
-
-#define _CM_STR_HELPER(x) #x
-#define _CM_STR(x) _CM_STR_HELPER(x)
-#define CM_VERSION                                                                                                     \
-    _CM_STR(CM_VERSION_MAJOR) "." _CM_STR(CM_VERSION_MINOR) "." _CM_STR(CM_VERSION_PATCH) CM_VERSION_LABEL
-
-#define CM_MIMPID                                                                                                      \
-    (CM_VERSION_MAJOR * 1000000 + CM_VERSION_MINOR * 1000 + CM_VERSION_PATCH) // NOLINT(cppcoreguidelines-macro-usage)
+#include "machine-c-version.h"
 
 #endif // MACHINE_EMULATOR_SDK_MACHINE_C_DEFINES_H

--- a/src/riscv-constants.h
+++ b/src/riscv-constants.h
@@ -17,6 +17,7 @@
 #ifndef RISCV_CONSTANTS_H
 #define RISCV_CONSTANTS_H
 
+#include "machine-c-defines.h"
 #include <cstdint>
 #include <pma-defines.h>
 
@@ -430,8 +431,8 @@ enum CARTESI_init : uint64_t {
     PC_INIT = UINT64_C(0x1000),                    ///< Initial value for pc
     FCSR_INIT = UINT64_C(0),                       ///< Initial value for fcsr
     MVENDORID_INIT = UINT64_C(0x6361727465736920), ///< Initial value for mvendorid
-    MARCHID_INIT = UINT64_C(0xf),                  ///< Initial value for marchid
-    MIMPID_INIT = UINT64_C(1),                     ///< Initial value for mimpid
+    MARCHID_INIT = CM_MARCHID,                     ///< Initial value for marchid
+    MIMPID_INIT = CM_MIMPID,                       ///< Initial value for mimpid
     MCYCLE_INIT = UINT64_C(0),                     ///< Initial value for mcycle
     ICYCLEINSTRET_INIT = UINT64_C(0),              ///< Initial value for icycleinstret
     MSTATUS_INIT =

--- a/tools/template/machine-c-version.h.template
+++ b/tools/template/machine-c-version.h.template
@@ -1,0 +1,36 @@
+// Copyright 2023 Cartesi Pte. Ltd.
+//
+// This file is part of the machine-emulator. The machine-emulator is free
+// software: you can redistribute it and/or modify it under the terms of the GNU
+// Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// The machine-emulator is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the machine-emulator. If not, see http://www.gnu.org/licenses/.
+//
+
+#ifndef MACHINE_EMULATOR_SDK_MACHINE_C_VERSION_H
+#define MACHINE_EMULATOR_SDK_MACHINE_C_VERSION_H
+// NOLINTBEGIN
+
+#define CM_MARCHID EMULATOR_MARCHID
+
+#define CM_VERSION_MAJOR EMULATOR_VERSION_MAJOR
+#define CM_VERSION_MINOR EMULATOR_VERSION_MINOR
+#define CM_VERSION_PATCH EMULATOR_VERSION_PATCH
+#define CM_VERSION_LABEL "EMULATOR_VERSION_LABEL"
+
+#define _CM_STR_HELPER(x) #x
+#define _CM_STR(x) _CM_STR_HELPER(x)
+#define CM_VERSION                                                                                                     \
+    _CM_STR(CM_VERSION_MAJOR) "." _CM_STR(CM_VERSION_MINOR) "." _CM_STR(CM_VERSION_PATCH) CM_VERSION_LABEL
+
+#define CM_MIMPID (CM_VERSION_MAJOR * 1000000 + CM_VERSION_MINOR * 1000 + CM_VERSION_PATCH)
+
+// NOLINTEND
+#endif // MACHINE_EMULATOR_SDK_MACHINE_C_VERSION_H


### PR DESCRIPTION
This PR introduces two new command line options:
- `--version` to be used by users, so they can known what current cartesi machine version is installed
- `--version-json` to be used by tools, so they can retrieve version and some other details about the current cartesi machine installed

This is the output for both commands:

```
$ cartesi-machine --version
cartesi-machine 0.14.0
git commit: 3b11d5e07dc650a1b4c443a8232bc8b2ebd9d363
build time: Jun  7 2023 19:19:03
platform: linux
compiler: GNU C++ version 13.1.1 20230429
Copyright 2019-2023 Cartesi Pte. Ltd.

$ cartesi-machine --version-json
{
  "version": "0.14.0",
  "version_major": 0,
  "version_minor": 14,
  "version_patch": 0,
  "version_label": "",
  "marchid": 15,
  "mimpid": 14000,
  "default_rom_image": "/home/bart/projects/cartesi/corp/images/rom-v0.16.0.bin",
  "default_ram_image": "/home/bart/projects/cartesi/corp/machine-emulator-sdk/kernel/linux-5.15.63-ctsi-2.bin",
  "default_rootfs_image": "/home/bart/projects/cartesi/corp/machine-emulator-sdk/fs/rootfs-v0.16.0.ext2",
  "git_commit": "3b11d5e07dc650a1b4c443a8232bc8b2ebd9d363",
  "build_time": "Jun  7 2023 19:19:03",
  "compiler": "GNU C++ version 13.1.1 20230429",
  "platform": "linux"
}

```

The `git_commit` will only appear for releases, development builds will not have this printed.

Bellow I clarify motivation for each field:

- `version` full version name.
- `version_major`, `version_minor`, `version_patch` tools can use this to do comparisons.
- `version_label` can be used for testing and candidate releases (eg `-rc1`, `-beta1`)
- `marchid` and `mimpid` are values of RISC-V `marchid` and `mimpid`, developers can use this information to know what will be the values of them when inside a cartesi machine. NOTE: Only Linux 6.1 supports reading `marchid` and `mimpid` from inside.
- `default_rom_image`, `default_ram_image`, `default_rootfs_image` can be used to determine rom/ram/rootfs versions
- `git_commit` will only appear for releases, development builds will not have this printed
- `build_time` is the time it was compiled
- `compiler` is the toolchain used to compile cartesi machine libraries
- `platform` is the platform the cartesi machine is running, could be macos for example

The `mimpid` is defined as the following:
```
#define CM_MIMPID                                                                                                      \
    (CM_VERSION_MAJOR * 1000000 + CM_VERSION_MINOR * 1000 + CM_VERSION_PATCH) // NOLINT(cppcoreguidelines-macro-usage)
```
This formula makes easy to retrieve major, minor and patch versions from it.

**Every release will need to update version manually** in the Makefile.