### PR TITLE
Add runtime options to skip root hash, version check and suppress putchar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added --version and --version-json command-line options in cartesi-machine
 - Added --skip-root-hash-check command line option to speed up machine loading in tests
 - Added --skip-version-check command line option to allow testing old machine snapshots
+- Added --htif-no-console-putchar command line option
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added --version and --version-json command-line options in cartesi-machine
+- Added --skip-root-hash-check command line option to speed up machine loading in tests
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added --version and --version-json command-line options in cartesi-machine
 - Added --skip-root-hash-check command line option to speed up machine loading in tests
+- Added --skip-version-check command line option to allow testing old machine snapshots
 
 ### Changed
 

--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -257,9 +257,16 @@ where options are:
         it can be identified or else a single thread is used.
 
   --skip-root-hash-check
-    skip merkle tree root hash when loading a stored machine,
+    skip merkle tree root hash check when loading a stored machine,
     assuming the stored machine files are not corrupt,
     this is only intended to speed up machine loading in emulator tests.
+
+    DON'T USE THIS OPTION IN PRODUCTION
+
+  --skip-version-check
+    skip emulator version check when loading a stored machine,
+    assuming the stored machine is compatible with current emulator version,
+    this is only intended to test old snapshots during emulator development.
 
     DON'T USE THIS OPTION IN PRODUCTION
 
@@ -396,6 +403,7 @@ local rollup_advance = nil
 local rollup_inspect = nil
 local concurrency_update_merkle_tree = 0
 local skip_root_hash_check = false
+local skip_version_check = false
 local append_rom_bootargs = ""
 local htif_console_getchar = false
 local htif_yield_automatic = false
@@ -700,6 +708,11 @@ local options = {
     { "^%-%-skip%-root%-hash%-check$", function(all)
         if not all then return false end
         skip_root_hash_check = true
+        return true
+    end },
+    { "^%-%-skip%-version%-check$", function(all)
+        if not all then return false end
+        skip_version_check = true
         return true
     end },
     { "^(%-%-initial%-proof%=(.+))$", function(all, opts)
@@ -1194,7 +1207,8 @@ local runtime = {
     concurrency = {
         update_merkle_tree = concurrency_update_merkle_tree
     },
-    skip_root_hash_check = skip_root_hash_check
+    skip_root_hash_check = skip_root_hash_check,
+    skip_version_check = skip_version_check
 }
 
 if remote and not remote_create then

--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -256,6 +256,10 @@ where options are:
         when ommited or defined as 0, the number of hardware threads is used if
         it can be identified or else a single thread is used.
 
+  --htif-no-console-putchar
+    suppress any console output during machine run,
+    this includes anything written to machine's stdout or stderr.
+
   --skip-root-hash-check
     skip merkle tree root hash check when loading a stored machine,
     assuming the stored machine files are not corrupt,
@@ -335,7 +339,7 @@ where options are:
     exit with failure in case the generated machine is not Rolling Cartesi Machine templates compatible.
 
   --quiet
-    supress cartesi-machine.lua output.
+    suppress cartesi-machine.lua output.
     exceptions: --initial-hash, --final-hash and text emitted from the target.
 
   --gdb[=<address>]
@@ -405,6 +409,7 @@ local concurrency_update_merkle_tree = 0
 local skip_root_hash_check = false
 local skip_version_check = false
 local append_rom_bootargs = ""
+local htif_no_console_putchar = false
 local htif_console_getchar = false
 local htif_yield_automatic = false
 local htif_yield_manual = false
@@ -703,6 +708,11 @@ local options = {
         c.update_merkle_tree = assert(util.parse_number(c.update_merkle_tree),
                 "invalid update_merkle_tree number in " .. all)
         concurrency_update_merkle_tree = c.update_merkle_tree
+        return true
+    end },
+    { "^%-%-htif%-no%-console%-putchar$", function(all)
+        if not all then return false end
+        htif_no_console_putchar = true
         return true
     end },
     { "^%-%-skip%-root%-hash%-check$", function(all)
@@ -1206,6 +1216,9 @@ end
 local runtime = {
     concurrency = {
         update_merkle_tree = concurrency_update_merkle_tree
+    },
+    htif = {
+        no_console_putchar = htif_no_console_putchar,
     },
     skip_root_hash_check = skip_root_hash_check,
     skip_version_check = skip_version_check

--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -256,6 +256,13 @@ where options are:
         when ommited or defined as 0, the number of hardware threads is used if
         it can be identified or else a single thread is used.
 
+  --skip-root-hash-check
+    skip merkle tree root hash when loading a stored machine,
+    assuming the stored machine files are not corrupt,
+    this is only intended to speed up machine loading in emulator tests.
+
+    DON'T USE THIS OPTION IN PRODUCTION
+
   --max-mcycle=<number>
     stop at a given mcycle (default: 2305843009213693952).
 
@@ -388,6 +395,7 @@ local uarch = nil
 local rollup_advance = nil
 local rollup_inspect = nil
 local concurrency_update_merkle_tree = 0
+local skip_root_hash_check = false
 local append_rom_bootargs = ""
 local htif_console_getchar = false
 local htif_yield_automatic = false
@@ -687,6 +695,11 @@ local options = {
         c.update_merkle_tree = assert(util.parse_number(c.update_merkle_tree),
                 "invalid update_merkle_tree number in " .. all)
         concurrency_update_merkle_tree = c.update_merkle_tree
+        return true
+    end },
+    { "^%-%-skip%-root%-hash%-check$", function(all)
+        if not all then return false end
+        skip_root_hash_check = true
         return true
     end },
     { "^(%-%-initial%-proof%=(.+))$", function(all, opts)
@@ -1180,7 +1193,8 @@ end
 local runtime = {
     concurrency = {
         update_merkle_tree = concurrency_update_merkle_tree
-    }
+    },
+    skip_root_hash_check = skip_root_hash_check
 }
 
 if remote and not remote_create then

--- a/src/clua-machine-util.cpp
+++ b/src/clua-machine-util.cpp
@@ -1235,6 +1235,7 @@ cm_machine_runtime_config *clua_check_cm_machine_runtime_config(lua_State *L, in
     cm_machine_runtime_config *config = managed.get();
     check_cm_concurrency_runtime_config(L, tabidx, &config->concurrency);
     config->skip_root_hash_check = opt_boolean_field(L, tabidx, "skip_root_hash_check");
+    config->skip_version_check = opt_boolean_field(L, tabidx, "skip_version_check");
     managed.release();
     lua_pop(L, 1);
     return config;

--- a/src/clua-machine-util.cpp
+++ b/src/clua-machine-util.cpp
@@ -1228,12 +1228,25 @@ static void check_cm_concurrency_runtime_config(lua_State *L, int tabidx, cm_con
     lua_pop(L, 1);
 }
 
+/// \brief Loads C api htif runtime config from Lua
+/// \param L Lua state
+/// \param tabidx Runtime config stack index
+/// \param c C api htif runtime config structure to receive results
+static void check_cm_htif_runtime_config(lua_State *L, int tabidx, cm_htif_runtime_config *c) {
+    if (!opt_table_field(L, tabidx, "htif")) {
+        return;
+    }
+    c->no_console_putchar = opt_boolean_field(L, -1, "no_console_putchar");
+    lua_pop(L, 1);
+}
+
 cm_machine_runtime_config *clua_check_cm_machine_runtime_config(lua_State *L, int tabidx, int ctxidx) {
     luaL_checktype(L, tabidx, LUA_TTABLE);
     auto &managed =
         clua_push_to(L, clua_managed_cm_ptr<cm_machine_runtime_config>(new cm_machine_runtime_config{}), ctxidx);
     cm_machine_runtime_config *config = managed.get();
     check_cm_concurrency_runtime_config(L, tabidx, &config->concurrency);
+    check_cm_htif_runtime_config(L, tabidx, &config->htif);
     config->skip_root_hash_check = opt_boolean_field(L, tabidx, "skip_root_hash_check");
     config->skip_version_check = opt_boolean_field(L, tabidx, "skip_version_check");
     managed.release();

--- a/src/clua-machine-util.cpp
+++ b/src/clua-machine-util.cpp
@@ -914,10 +914,10 @@ void clua_push_cm_machine_config(lua_State *L, const cm_machine_config *c) {
 }
 
 #if 0
-/// \brief Pushes an cm_concurrency_config to the Lua stack
+/// \brief Pushes an cm_concurrency_runtime_config to the Lua stack
 /// \param L Lua state.
-/// \param c C api concurrency config to be pushed.
-static void push_cm_concurrency_runtime_config(lua_State *L, const cm_concurrency_config *c) {
+/// \param c C api concurrency runtime config to be pushed.
+static void push_cm_concurrency_runtime_config(lua_State *L, const cm_concurrency_runtime_config *c) {
     lua_newtable(L);
     clua_setintegerfield(L, c->update_merkle_tree, "update_merkle_tree", -1);
 }
@@ -1220,7 +1220,7 @@ cm_machine_config *clua_check_cm_machine_config(lua_State *L, int tabidx, int ct
 /// \param L Lua state
 /// \param tabidx Runtime config stack index
 /// \param c C api concurrency runtime config structure to receive results
-static void check_cm_concurrency_runtime_config(lua_State *L, int tabidx, cm_concurrency_config *c) {
+static void check_cm_concurrency_runtime_config(lua_State *L, int tabidx, cm_concurrency_runtime_config *c) {
     if (!opt_table_field(L, tabidx, "concurrency")) {
         return;
     }

--- a/src/clua-machine-util.cpp
+++ b/src/clua-machine-util.cpp
@@ -1234,6 +1234,7 @@ cm_machine_runtime_config *clua_check_cm_machine_runtime_config(lua_State *L, in
         clua_push_to(L, clua_managed_cm_ptr<cm_machine_runtime_config>(new cm_machine_runtime_config{}), ctxidx);
     cm_machine_runtime_config *config = managed.get();
     check_cm_concurrency_runtime_config(L, tabidx, &config->concurrency);
+    config->skip_root_hash_check = opt_boolean_field(L, tabidx, "skip_root_hash_check");
     managed.release();
     lua_pop(L, 1);
     return config;

--- a/src/htif-factory.cpp
+++ b/src/htif-factory.cpp
@@ -29,7 +29,7 @@ static bool htif_peek(const pma_entry &pma, const machine &m, uint64_t page_offs
     return (page_offset % PMA_PAGE_SIZE) == 0 && page_offset < pma.get_length();
 }
 
-pma_entry make_htif_pma_entry(uint64_t start, uint64_t length) {
+pma_entry make_htif_pma_entry(uint64_t start, uint64_t length, htif_runtime_config *context) {
     pma_entry::flags f{
         true,                // R
         true,                // W
@@ -38,7 +38,7 @@ pma_entry make_htif_pma_entry(uint64_t start, uint64_t length) {
         false,               // IW
         PMA_ISTART_DID::HTIF // DID
     };
-    return make_device_pma_entry("HTIF device", start, length, htif_peek, &htif_driver).set_flags(f);
+    return make_device_pma_entry("HTIF device", start, length, htif_peek, &htif_driver, context).set_flags(f);
 }
 
 } // namespace cartesi

--- a/src/htif-factory.h
+++ b/src/htif-factory.h
@@ -19,12 +19,13 @@
 
 #include "htif.h"
 #include "machine-config.h"
+#include "machine-runtime-config.h"
 #include "pma.h"
 
 namespace cartesi {
 
 /// \brief Creates a PMA entry for the HTIF device
-pma_entry make_htif_pma_entry(uint64_t start, uint64_t length);
+pma_entry make_htif_pma_entry(uint64_t start, uint64_t length, htif_runtime_config *context);
 
 } // namespace cartesi
 

--- a/src/json-util.cpp
+++ b/src/json-util.cpp
@@ -418,6 +418,7 @@ void ju_get_opt_field(const nlohmann::json &j, const K &key, machine_runtime_con
     }
     ju_get_field(j[key], "concurrency"s, value.concurrency, path + to_string(key) + "/");
     ju_get_opt_field(j[key], "skip_root_hash_check"s, value.skip_root_hash_check, path + to_string(key) + "/");
+    ju_get_opt_field(j[key], "skip_version_check"s, value.skip_version_check, path + to_string(key) + "/");
 }
 
 template void ju_get_opt_field<uint64_t>(const nlohmann::json &j, const uint64_t &key, machine_runtime_config &value,
@@ -1196,6 +1197,7 @@ void to_json(nlohmann::json &j, const machine_runtime_config &runtime) {
     j = nlohmann::json{
         {"concurrency", runtime.concurrency},
         {"skip_root_hash_check", runtime.skip_root_hash_check},
+        {"skip_version_check", runtime.skip_version_check},
     };
 }
 

--- a/src/json-util.cpp
+++ b/src/json-util.cpp
@@ -398,18 +398,19 @@ template void ju_get_opt_field<std::string>(const nlohmann::json &j, const std::
     uarch_interpreter_break_reason &value, const std::string &path);
 
 template <typename K>
-void ju_get_opt_field(const nlohmann::json &j, const K &key, concurrency_config &value, const std::string &path) {
+void ju_get_opt_field(const nlohmann::json &j, const K &key, concurrency_runtime_config &value,
+    const std::string &path) {
     if (!contains(j, key)) {
         return;
     }
     ju_get_opt_field(j[key], "update_merkle_tree"s, value.update_merkle_tree, path + to_string(key) + "/");
 }
 
-template void ju_get_opt_field<uint64_t>(const nlohmann::json &j, const uint64_t &key, concurrency_config &value,
-    const std::string &path);
+template void ju_get_opt_field<uint64_t>(const nlohmann::json &j, const uint64_t &key,
+    concurrency_runtime_config &value, const std::string &path);
 
-template void ju_get_opt_field<std::string>(const nlohmann::json &j, const std::string &key, concurrency_config &value,
-    const std::string &path);
+template void ju_get_opt_field<std::string>(const nlohmann::json &j, const std::string &key,
+    concurrency_runtime_config &value, const std::string &path);
 
 template <typename K>
 void ju_get_opt_field(const nlohmann::json &j, const K &key, htif_runtime_config &value, const std::string &path) {
@@ -1202,7 +1203,7 @@ void to_json(nlohmann::json &j, const machine_config &config) {
     }
 }
 
-void to_json(nlohmann::json &j, const concurrency_config &config) {
+void to_json(nlohmann::json &j, const concurrency_runtime_config &config) {
     j = nlohmann::json{
         {"update_merkle_tree", config.update_merkle_tree},
     };

--- a/src/json-util.cpp
+++ b/src/json-util.cpp
@@ -417,6 +417,7 @@ void ju_get_opt_field(const nlohmann::json &j, const K &key, machine_runtime_con
         return;
     }
     ju_get_field(j[key], "concurrency"s, value.concurrency, path + to_string(key) + "/");
+    ju_get_opt_field(j[key], "skip_root_hash_check"s, value.skip_root_hash_check, path + to_string(key) + "/");
 }
 
 template void ju_get_opt_field<uint64_t>(const nlohmann::json &j, const uint64_t &key, machine_runtime_config &value,
@@ -1194,6 +1195,7 @@ void to_json(nlohmann::json &j, const concurrency_config &config) {
 void to_json(nlohmann::json &j, const machine_runtime_config &runtime) {
     j = nlohmann::json{
         {"concurrency", runtime.concurrency},
+        {"skip_root_hash_check", runtime.skip_root_hash_check},
     };
 }
 

--- a/src/json-util.cpp
+++ b/src/json-util.cpp
@@ -412,11 +412,26 @@ template void ju_get_opt_field<std::string>(const nlohmann::json &j, const std::
     const std::string &path);
 
 template <typename K>
+void ju_get_opt_field(const nlohmann::json &j, const K &key, htif_runtime_config &value, const std::string &path) {
+    if (!contains(j, key)) {
+        return;
+    }
+    ju_get_opt_field(j[key], "no_console_putchar"s, value.no_console_putchar, path + to_string(key) + "/");
+}
+
+template void ju_get_opt_field<bool>(const nlohmann::json &j, const bool &key, htif_runtime_config &value,
+    const std::string &path);
+
+template void ju_get_opt_field<std::string>(const nlohmann::json &j, const std::string &key, htif_runtime_config &value,
+    const std::string &path);
+
+template <typename K>
 void ju_get_opt_field(const nlohmann::json &j, const K &key, machine_runtime_config &value, const std::string &path) {
     if (!contains(j, key)) {
         return;
     }
     ju_get_field(j[key], "concurrency"s, value.concurrency, path + to_string(key) + "/");
+    ju_get_field(j[key], "htif"s, value.htif, path + to_string(key) + "/");
     ju_get_opt_field(j[key], "skip_root_hash_check"s, value.skip_root_hash_check, path + to_string(key) + "/");
     ju_get_opt_field(j[key], "skip_version_check"s, value.skip_version_check, path + to_string(key) + "/");
 }
@@ -1193,9 +1208,16 @@ void to_json(nlohmann::json &j, const concurrency_config &config) {
     };
 }
 
+void to_json(nlohmann::json &j, const htif_runtime_config &config) {
+    j = nlohmann::json{
+        {"no_console_putchar", config.no_console_putchar},
+    };
+}
+
 void to_json(nlohmann::json &j, const machine_runtime_config &runtime) {
     j = nlohmann::json{
         {"concurrency", runtime.concurrency},
+        {"htif", runtime.htif},
         {"skip_root_hash_check", runtime.skip_root_hash_check},
         {"skip_version_check", runtime.skip_version_check},
     };

--- a/src/json-util.h
+++ b/src/json-util.h
@@ -156,6 +156,16 @@ template <typename K>
 void ju_get_opt_field(const nlohmann::json &j, const K &key, concurrency_config &value,
     const std::string &path = "params/");
 
+/// \brief Attempts to load an htif_runtime_config object from a field in a JSON object
+/// \tparam K Key type (explicit extern declarations for uint64_t and std::string are provided)
+/// \param j JSON object to load from
+/// \param key Key to load value from
+/// \param value Object to store value
+/// \param path Path to j
+template <typename K>
+void ju_get_opt_field(const nlohmann::json &j, const K &key, htif_runtime_config &value,
+    const std::string &path = "params/");
+
 /// \brief Attempts to load an machine_runtime_config object from a field in a JSON object
 /// \tparam K Key type (explicit extern declarations for uint64_t and std::string are provided)
 /// \param j JSON object to load from
@@ -541,6 +551,7 @@ void to_json(nlohmann::json &j, const uarch_ram_config &config);
 void to_json(nlohmann::json &j, const uarch_config &config);
 void to_json(nlohmann::json &j, const machine_config &config);
 void to_json(nlohmann::json &j, const concurrency_config &config);
+void to_json(nlohmann::json &j, const htif_runtime_config &config);
 void to_json(nlohmann::json &j, const machine_runtime_config &runtime);
 void to_json(nlohmann::json &j, const machine::csr &csr);
 
@@ -578,6 +589,10 @@ extern template void ju_get_opt_field(const nlohmann::json &j, const std::string
 extern template void ju_get_opt_field(const nlohmann::json &j, const uint64_t &key, concurrency_config &value,
     const std::string &base = "params/");
 extern template void ju_get_opt_field(const nlohmann::json &j, const std::string &key, concurrency_config &value,
+    const std::string &base = "params/");
+extern template void ju_get_opt_field(const nlohmann::json &j, const bool &key, htif_runtime_config &value,
+    const std::string &base = "params/");
+extern template void ju_get_opt_field(const nlohmann::json &j, const std::string &key, htif_runtime_config &value,
     const std::string &base = "params/");
 extern template void ju_get_opt_field(const nlohmann::json &j, const uint64_t &key, machine_runtime_config &value,
     const std::string &base = "params/");

--- a/src/json-util.h
+++ b/src/json-util.h
@@ -146,14 +146,14 @@ template <typename K>
 void ju_get_opt_field(const nlohmann::json &j, const K &key, uarch_interpreter_break_reason &value,
     const std::string &path = "params/");
 
-/// \brief Attempts to load an concurrency_config object from a field in a JSON object
+/// \brief Attempts to load an concurrency_runtime_config object from a field in a JSON object
 /// \tparam K Key type (explicit extern declarations for uint64_t and std::string are provided)
 /// \param j JSON object to load from
 /// \param key Key to load value from
 /// \param value Object to store value
 /// \param path Path to j
 template <typename K>
-void ju_get_opt_field(const nlohmann::json &j, const K &key, concurrency_config &value,
+void ju_get_opt_field(const nlohmann::json &j, const K &key, concurrency_runtime_config &value,
     const std::string &path = "params/");
 
 /// \brief Attempts to load an htif_runtime_config object from a field in a JSON object
@@ -550,7 +550,7 @@ void to_json(nlohmann::json &j, const uarch_processor_config &config);
 void to_json(nlohmann::json &j, const uarch_ram_config &config);
 void to_json(nlohmann::json &j, const uarch_config &config);
 void to_json(nlohmann::json &j, const machine_config &config);
-void to_json(nlohmann::json &j, const concurrency_config &config);
+void to_json(nlohmann::json &j, const concurrency_runtime_config &config);
 void to_json(nlohmann::json &j, const htif_runtime_config &config);
 void to_json(nlohmann::json &j, const machine_runtime_config &runtime);
 void to_json(nlohmann::json &j, const machine::csr &csr);
@@ -586,10 +586,10 @@ extern template void ju_get_opt_field(const nlohmann::json &j, const uint64_t &k
     uarch_interpreter_break_reason &value, const std::string &base = "params/");
 extern template void ju_get_opt_field(const nlohmann::json &j, const std::string &key,
     uarch_interpreter_break_reason &value, const std::string &base = "params/");
-extern template void ju_get_opt_field(const nlohmann::json &j, const uint64_t &key, concurrency_config &value,
+extern template void ju_get_opt_field(const nlohmann::json &j, const uint64_t &key, concurrency_runtime_config &value,
     const std::string &base = "params/");
-extern template void ju_get_opt_field(const nlohmann::json &j, const std::string &key, concurrency_config &value,
-    const std::string &base = "params/");
+extern template void ju_get_opt_field(const nlohmann::json &j, const std::string &key,
+    concurrency_runtime_config &value, const std::string &base = "params/");
 extern template void ju_get_opt_field(const nlohmann::json &j, const bool &key, htif_runtime_config &value,
     const std::string &base = "params/");
 extern template void ju_get_opt_field(const nlohmann::json &j, const std::string &key, htif_runtime_config &value,

--- a/src/jsonrpc-discover.json
+++ b/src/jsonrpc-discover.json
@@ -1607,11 +1607,24 @@
         }
       },
 
+      "HTIFRuntimeConfig": {
+        "title": "HTIFRuntimeConfig",
+        "type": "object",
+        "properties": {
+          "no_console_putchar": {
+            "type": "boolean"
+          }
+        }
+      },
+
       "MachineRuntimeConfig": {
         "type": "object",
         "properties": {
           "concurrency": {
             "$ref": "#/components/schemas/ConcurrencyConfig"
+          },
+          "htif": {
+            "$ref": "#/components/schemas/HTIFRuntimeConfig"
           },
           "skip_root_hash_check": {
             "type": "boolean"

--- a/src/jsonrpc-discover.json
+++ b/src/jsonrpc-discover.json
@@ -1598,7 +1598,7 @@
         }
       },
 
-      "ConcurrencyConfig": {
+      "ConcurrencyRuntimeConfig": {
         "type": "object",
         "properties": {
           "update_merkle_tree": {
@@ -1621,7 +1621,7 @@
         "type": "object",
         "properties": {
           "concurrency": {
-            "$ref": "#/components/schemas/ConcurrencyConfig"
+            "$ref": "#/components/schemas/ConcurrencyRuntimeConfig"
           },
           "htif": {
             "$ref": "#/components/schemas/HTIFRuntimeConfig"

--- a/src/jsonrpc-discover.json
+++ b/src/jsonrpc-discover.json
@@ -1615,6 +1615,9 @@
           },
           "skip_root_hash_check": {
             "type": "boolean"
+          },
+          "skip_version_check": {
+            "type": "boolean"
           }
         }
       }

--- a/src/jsonrpc-discover.json
+++ b/src/jsonrpc-discover.json
@@ -1612,6 +1612,9 @@
         "properties": {
           "concurrency": {
             "$ref": "#/components/schemas/ConcurrencyConfig"
+          },
+          "skip_root_hash_check": {
+            "type": "boolean"
           }
         }
       }

--- a/src/machine-c-api.cpp
+++ b/src/machine-c-api.cpp
@@ -365,7 +365,8 @@ cartesi::machine_runtime_config convert_from_c(const cm_machine_runtime_config *
         throw std::invalid_argument("invalid machine runtime configuration");
     }
     cartesi::machine_runtime_config new_cpp_machine_runtime_config{};
-    new_cpp_machine_runtime_config.concurrency = cartesi::concurrency_config{c_config->concurrency.update_merkle_tree};
+    new_cpp_machine_runtime_config.concurrency =
+        cartesi::concurrency_runtime_config{c_config->concurrency.update_merkle_tree};
     new_cpp_machine_runtime_config.htif = cartesi::htif_runtime_config{c_config->htif.no_console_putchar};
     new_cpp_machine_runtime_config.skip_root_hash_check = c_config->skip_root_hash_check;
     new_cpp_machine_runtime_config.skip_version_check = c_config->skip_version_check;

--- a/src/machine-c-api.cpp
+++ b/src/machine-c-api.cpp
@@ -365,7 +365,7 @@ cartesi::machine_runtime_config convert_from_c(const cm_machine_runtime_config *
         throw std::invalid_argument("invalid machine runtime configuration");
     }
     cartesi::machine_runtime_config new_cpp_machine_runtime_config{
-        cartesi::concurrency_config{c_config->concurrency.update_merkle_tree}};
+        cartesi::concurrency_config{c_config->concurrency.update_merkle_tree}, c_config->skip_root_hash_check};
 
     return new_cpp_machine_runtime_config;
 }

--- a/src/machine-c-api.cpp
+++ b/src/machine-c-api.cpp
@@ -366,6 +366,7 @@ cartesi::machine_runtime_config convert_from_c(const cm_machine_runtime_config *
     }
     cartesi::machine_runtime_config new_cpp_machine_runtime_config{};
     new_cpp_machine_runtime_config.concurrency = cartesi::concurrency_config{c_config->concurrency.update_merkle_tree};
+    new_cpp_machine_runtime_config.htif = cartesi::htif_runtime_config{c_config->htif.no_console_putchar};
     new_cpp_machine_runtime_config.skip_root_hash_check = c_config->skip_root_hash_check;
     new_cpp_machine_runtime_config.skip_version_check = c_config->skip_version_check;
     return new_cpp_machine_runtime_config;

--- a/src/machine-c-api.cpp
+++ b/src/machine-c-api.cpp
@@ -364,9 +364,10 @@ cartesi::machine_runtime_config convert_from_c(const cm_machine_runtime_config *
     if (c_config == nullptr) {
         throw std::invalid_argument("invalid machine runtime configuration");
     }
-    cartesi::machine_runtime_config new_cpp_machine_runtime_config{
-        cartesi::concurrency_config{c_config->concurrency.update_merkle_tree}, c_config->skip_root_hash_check};
-
+    cartesi::machine_runtime_config new_cpp_machine_runtime_config{};
+    new_cpp_machine_runtime_config.concurrency = cartesi::concurrency_config{c_config->concurrency.update_merkle_tree};
+    new_cpp_machine_runtime_config.skip_root_hash_check = c_config->skip_root_hash_check;
+    new_cpp_machine_runtime_config.skip_version_check = c_config->skip_version_check;
     return new_cpp_machine_runtime_config;
 }
 

--- a/src/machine-c-api.h
+++ b/src/machine-c-api.h
@@ -361,6 +361,7 @@ typedef struct { // NOLINT(modernize-use-using)
 typedef struct { // NOLINT(modernize-use-using)
     cm_concurrency_config concurrency;
     bool skip_root_hash_check;
+    bool skip_version_check;
 } cm_machine_runtime_config;
 
 /// \brief Machine instance handle

--- a/src/machine-c-api.h
+++ b/src/machine-c-api.h
@@ -357,9 +357,15 @@ typedef struct { // NOLINT(modernize-use-using)
     uint64_t update_merkle_tree;
 } cm_concurrency_config;
 
+/// \brief HTIF runtime configuration
+typedef struct { // NOLINT(modernize-use-using)
+    bool no_console_putchar;
+} cm_htif_runtime_config;
+
 /// \brief Machine runtime configuration
 typedef struct { // NOLINT(modernize-use-using)
     cm_concurrency_config concurrency;
+    cm_htif_runtime_config htif;
     bool skip_root_hash_check;
     bool skip_version_check;
 } cm_machine_runtime_config;

--- a/src/machine-c-api.h
+++ b/src/machine-c-api.h
@@ -360,6 +360,7 @@ typedef struct { // NOLINT(modernize-use-using)
 /// \brief Machine runtime configuration
 typedef struct { // NOLINT(modernize-use-using)
     cm_concurrency_config concurrency;
+    bool skip_root_hash_check;
 } cm_machine_runtime_config;
 
 /// \brief Machine instance handle

--- a/src/machine-c-api.h
+++ b/src/machine-c-api.h
@@ -355,7 +355,7 @@ typedef struct {                    // NOLINT(modernize-use-using)
 /// \brief Concurrency runtime configuration
 typedef struct { // NOLINT(modernize-use-using)
     uint64_t update_merkle_tree;
-} cm_concurrency_config;
+} cm_concurrency_runtime_config;
 
 /// \brief HTIF runtime configuration
 typedef struct { // NOLINT(modernize-use-using)
@@ -364,7 +364,7 @@ typedef struct { // NOLINT(modernize-use-using)
 
 /// \brief Machine runtime configuration
 typedef struct { // NOLINT(modernize-use-using)
-    cm_concurrency_config concurrency;
+    cm_concurrency_runtime_config concurrency;
     cm_htif_runtime_config htif;
     bool skip_root_hash_check;
     bool skip_version_check;

--- a/src/machine-runtime-config.h
+++ b/src/machine-runtime-config.h
@@ -31,6 +31,7 @@ struct concurrency_config {
 struct machine_runtime_config {
     concurrency_config concurrency{};
     bool skip_root_hash_check{};
+    bool skip_version_check{};
 };
 
 /// \brief CONCURRENCY constants

--- a/src/machine-runtime-config.h
+++ b/src/machine-runtime-config.h
@@ -30,6 +30,7 @@ struct concurrency_config {
 /// \brief Machine runtime configuration
 struct machine_runtime_config {
     concurrency_config concurrency{};
+    bool skip_root_hash_check{};
 };
 
 /// \brief CONCURRENCY constants

--- a/src/machine-runtime-config.h
+++ b/src/machine-runtime-config.h
@@ -23,7 +23,7 @@
 namespace cartesi {
 
 /// \brief Concurrency runtime configuration
-struct concurrency_config {
+struct concurrency_runtime_config {
     uint64_t update_merkle_tree{};
 };
 
@@ -34,7 +34,7 @@ struct htif_runtime_config {
 
 /// \brief Machine runtime configuration
 struct machine_runtime_config {
-    concurrency_config concurrency{};
+    concurrency_runtime_config concurrency{};
     htif_runtime_config htif{};
     bool skip_root_hash_check{};
     bool skip_version_check{};

--- a/src/machine-runtime-config.h
+++ b/src/machine-runtime-config.h
@@ -27,9 +27,15 @@ struct concurrency_config {
     uint64_t update_merkle_tree{};
 };
 
+/// \brief HTIF runtime configuration
+struct htif_runtime_config {
+    bool no_console_putchar;
+};
+
 /// \brief Machine runtime configuration
 struct machine_runtime_config {
     concurrency_config concurrency{};
+    htif_runtime_config htif{};
     bool skip_root_hash_check{};
     bool skip_version_check{};
 };

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -284,24 +284,24 @@ machine::machine(const machine_config &c, const machine_runtime_config &r) :
         m_c.processor.marchid = MARCHID_INIT;
     }
 
-    if (m_c.processor.marchid != MARCHID_INIT) {
-        throw std::invalid_argument{"marchid mismatch."};
+    if (m_c.processor.marchid != MARCHID_INIT && !r.skip_version_check) {
+        throw std::invalid_argument{"marchid mismatch, emulator version is incompatible"};
     }
 
     if (m_c.processor.mvendorid == UINT64_C(-1)) {
         m_c.processor.mvendorid = MVENDORID_INIT;
     }
 
-    if (m_c.processor.mvendorid != MVENDORID_INIT) {
-        throw std::invalid_argument{"mvendorid mismatch."};
+    if (m_c.processor.mvendorid != MVENDORID_INIT && !r.skip_version_check) {
+        throw std::invalid_argument{"mvendorid mismatch, emulator version is incompatible"};
     }
 
     if (m_c.processor.mimpid == UINT64_C(-1)) {
         m_c.processor.mimpid = MIMPID_INIT;
     }
 
-    if (m_c.processor.mimpid != MIMPID_INIT) {
-        throw std::invalid_argument{"mimpid mismatch."};
+    if (m_c.processor.mimpid != MIMPID_INIT && !r.skip_version_check) {
+        throw std::invalid_argument{"mimpid mismatch, emulator version is incompatible"};
     }
 
     // General purpose registers

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -463,6 +463,9 @@ static void load_hash(const std::string &dir, machine::hash_type &h) {
 }
 
 machine::machine(const std::string &dir, const machine_runtime_config &r) : machine{machine_config::load(dir), r} {
+    if (r.skip_root_hash_check) {
+        return;
+    }
     hash_type hstored;
     hash_type hrestored;
     load_hash(dir, hstored);

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -382,7 +382,7 @@ machine::machine(const machine_config &c, const machine_runtime_config &r) :
     }
 
     // Register HTIF device
-    register_pma_entry(make_htif_pma_entry(PMA_HTIF_START, PMA_HTIF_LENGTH));
+    register_pma_entry(make_htif_pma_entry(PMA_HTIF_START, PMA_HTIF_LENGTH, &m_r.htif));
 
     // Copy HTIF state to from config to machine
     write_htif_tohost(m_c.htif.tohost);

--- a/src/machine.h
+++ b/src/machine.h
@@ -743,6 +743,11 @@ public:
         return m_c;
     }
 
+    /// \brief Returns the machine runtime config.
+    const machine_runtime_config &get_runtime_config(void) const {
+        return m_r;
+    }
+
     /// \brief Replaces a memory range.
     /// \param range Configuration of the new memory range.
     /// \details The machine must contain an existing memory range


### PR DESCRIPTION
This issue implements #72

Using the new `--skip-root-hash-check` option we can run a test suite without the merkle tree root hash checking every machine load, saving several seconds when running dapp test suites. I am using this feature with JSONRPC to speed up Lua unit tests I am creating.

Using the new `--skip-version-check` option we can test old snapshots created by Sunodo. Ideally we should not run snapshots targeting old emulator releases, but for development users like us, who need to test stuff before they are actually released, this check is a pain, because it prevents us from testing old snapshots created by Sunodo with emulators in development.

Using the new `--htif-no-console-putchar` option we can suppress anything written to machine's stdout/stderr. This is useful when stress testing dapps that prints to stdout.

I deliberately left out gRPC interface changes related to the new config, mostly to avoid grpc-interface changes and we plan to deprecate it anyway. Let me know if it would be useful to have these options available in gRPC.