### PR TITLE
Add proofs to uarch riscv tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
       - name: Create uarch json logs to be used  to test the Solidity based microarchitecture interpreter
         run: |
           mkdir -p /tmp/uarch-riscv-tests-json-logs
-          /opt/cartesi/bin/uarch-riscv-tests --test-path=/opt/cartesi/tests --output-dir=/tmp/uarch-riscv-tests-json-logs json-logs
+          /opt/cartesi/bin/uarch-riscv-tests --test-path=/opt/cartesi/tests --output-dir=/tmp/uarch-riscv-tests-json-logs --proofs --proofs-frequency=50 json-logs
 
       - name: Upload uarch json logs to be used  to test the Solidity based microarchitecture interpreter
         uses: actions/upload-artifact@master

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -1606,12 +1606,9 @@ bool machine::verify_merkle_tree(void) const {
     return m_t.verify_tree();
 }
 
-machine_merkle_tree::proof_type machine::get_proof(uint64_t address, int log2_size) const {
+machine_merkle_tree::proof_type machine::get_proof(uint64_t address, int log2_size, skip_merkle_tree_update_t) const {
     static_assert(PMA_PAGE_SIZE == machine_merkle_tree::get_page_size(),
         "PMA and machine_merkle_tree page sizes must match");
-    if (!update_merkle_tree()) {
-        throw std::runtime_error{"error updating Merkle tree"};
-    }
     // Check for valid target node size
     if (log2_size > machine_merkle_tree::get_log2_root_size() ||
         log2_size < machine_merkle_tree::get_log2_word_size()) {
@@ -1651,6 +1648,13 @@ machine_merkle_tree::proof_type machine::get_proof(uint64_t address, int log2_si
     } else {
         return m_t.get_proof(address, log2_size, nullptr);
     }
+}
+
+machine_merkle_tree::proof_type machine::get_proof(uint64_t address, int log2_size) const {
+    if (!update_merkle_tree()) {
+        throw std::runtime_error{"error updating Merkle tree"};
+    }
+    return get_proof(address, log2_size, skip_merkle_tree_update);
 }
 
 void machine::read_memory(uint64_t address, unsigned char *data, uint64_t length) const {

--- a/src/machine.h
+++ b/src/machine.h
@@ -34,6 +34,14 @@
 
 namespace cartesi {
 
+/// \brief Tag type used to indicate that merkle tree updates should be skipped.
+struct skip_merkle_tree_update_t {
+    explicit skip_merkle_tree_update_t() = default;
+};
+
+/// \brief Tag indicating that merkle tree updates should be skipped.
+constexpr skip_merkle_tree_update_t skip_merkle_tree_update;
+
 /// \class machine
 /// \brief Cartesi Machine implementation
 class machine final {
@@ -262,8 +270,18 @@ public:
     /// \param log2_size log<sub>2</sub> of size subintended by target node.
     /// Must be between 3 (for a word) and 64 (for the entire address space), inclusive.
     /// \param proof Receives the proof.
-    /// \details If the node is smaller than a page size, then it must lie entirely inside the same PMA range.
+    /// \details If the node is
+    /// smaller than a page size, then it must lie entirely inside the same PMA range.
     machine_merkle_tree::proof_type get_proof(uint64_t address, int log2_size) const;
+
+    /// \brief Obtains the proof for a node in the Merkle tree without making any modifications to the tree.
+    /// \param address Address of target node. Must be aligned to a 2<sup>log2_size</sup> boundary.
+    /// \param log2_size log<sub>2</sub> of size subintended by target node.
+    /// Must be between 3 (for a word) and 64 (for the entire address space), inclusive.
+    /// \param proof Receives the proof.
+    /// \details If the node is smaller than a page size, then it must lie entirely inside the same PMA range.
+    /// This overload is used to optimize proof generation when the caller knows that the tree is already up to date.
+    machine_merkle_tree::proof_type get_proof(uint64_t address, int log2_size, skip_merkle_tree_update_t) const;
 
     /// \brief Obtains the root hash of the Merkle tree.
     /// \param hash Receives the hash.


### PR DESCRIPTION
This branch adds the option to include proofs in the json log files produced by uarch-riscv-tests.lua.
The logged proofs will be used as test fixture by the Solidity step.

This PR also includes a fix to a bug that was found while testing the new option `--proofs-frequency=<number>`.
This bug occurs when proofs are not requesdted, leaving the merkle tree inconsistent because updated pmas are not marked dirty, causing the following exception:
```
merkle tree must be consistent when stepping alternating with and without proofs...
lua5.4: tests/machine-bind.lua:809: inconsistent merkle tree
stack traceback:
	[C]: in method 'step_uarch'
	tests/machine-bind.lua:809: in local 'f'
```