### PR TITLE
Changed default init location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move uarch halt from assembler to C++
 - Ensure that uarch does not advance to the next micro instruction  when iflags.H or iflags.Y is set
 - Made flash drive length and ROM image filename optional in machine config
+- Changed default init location
 
 ## [0.14.0] - 2023-05-03
 ### Added

--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -402,7 +402,7 @@ local memory_range_replace = {}
 local ram_image_filename = images_path .. "linux.bin"
 local ram_length = 64 << 20
 local rom_image_filename = images_path .. "rom.bin"
-local rom_bootargs = "console=hvc0 rootfstype=ext2 root=/dev/mtdblock0 rw quiet swiotlb=noforce"
+local rom_bootargs = "console=hvc0 rootfstype=ext2 root=/dev/mtdblock0 rw quiet swiotlb=noforce init=/opt/cartesi/bin/init"
 local rollup
 local uarch
 local rollup_advance

--- a/src/tests/machine-test.lua
+++ b/src/tests/machine-test.lua
@@ -509,7 +509,7 @@ test_util.make_do_test(build_machine, machine_type, {
     },
     rom = {
         image_filename = rom_image,
-        bootargs = "console=hvc0 rootfstype=ext2 root=/dev/mtdblock0 rw quiet swiotlb=noforce single=yes splash=no "
+        bootargs = "console=hvc0 rootfstype=ext2 root=/dev/mtdblock0 rw quiet swiotlb=noforce single=yes splash=no init=/opt/cartesi/bin/init"
             .. "mtdparts=flash.0:-(root);flash.1:-(input);flash.2:-(output) -- "
             .. "cat /mnt/input/etc/issue | dd status=none of=/dev/mtdblock2",
     },


### PR DESCRIPTION
rootfs should not overwrite the system `init`.
We must use a custom location to make this work.

This requires a rootfs with https://github.com/cartesi/machine-emulator-tools/pull/12.