### PR TITLE
refactor: bundle nlohmann-json into third-party

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
         libreadline-dev libboost-filesystem1.81-dev libssl-dev libc-ares-dev zlib1g-dev \
         ca-certificates automake libtool patchelf cmake pkg-config lua5.4 liblua5.4-dev \
         libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
-        luarocks libcrypto++-dev nlohmann-json3-dev && \
+        luarocks libcrypto++-dev && \
         update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 120 && \
         update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 120 && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Docker targets:
 - GRPC >= 1.45.0
 - Lua >= 5.4.4
 - Boost >= 1.81
-- nlohmann JSON >= 3.10
 
 Obs: Please note that Apple Clang Version number does not follow upstream LLVM/Clang.
 
@@ -37,7 +36,7 @@ apt-get install build-essential wget git clang-tidy-15 clang-format-15 \
         libboost-filesystem1.81-dev libssl-dev libc-ares-dev zlib1g-dev \
         ca-certificates automake libtool patchelf cmake pkg-config lua5.4 liblua5.4-dev \
         libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
-        luarocks libcrypto++-dev nlohmann-json3-dev
+        luarocks libcrypto++-dev
 
 sudo luarocks install --lua-version=5.4 lpeg
 sudo luarocks install --lua-version=5.4 dkjson
@@ -49,7 +48,7 @@ sudo luarocks install --lua-version=5.4 luaposix
 
 ##### MacPorts
 ```
-sudo port install clang-15 automake boost libtool wget cmake pkgconfig grpc zlib openssl lua libcryptopp nlohmann-json lua-luarocks
+sudo port install clang-15 automake boost libtool wget cmake pkgconfig grpc zlib openssl lua libcryptopp lua-luarocks
 
 sudo luarocks install --lua-version=5.4 lpeg
 sudo luarocks install --lua-version=5.4 dkjson
@@ -60,7 +59,7 @@ sudo luarocks install --lua-version=5.4 luaposix
 
 ##### Homebrew
 ```
-brew install llvm@15 automake boost libomp wget cmake cryptopp pkg-config grpc zlib openssl lua@5.4 nlohmann-json luarocks
+brew install llvm@15 automake boost libomp wget cmake cryptopp pkg-config grpc zlib openssl lua@5.4 luarocks
 luarocks --lua-dir=$(brew --prefix)/opt/lua@5.4 install lpeg
 luarocks --lua-dir=$(brew --prefix)/opt/lua@5.4 install dkjson
 luarocks --lua-dir=$(brew --prefix)/opt/lua@5.4 install luasocket

--- a/src/Makefile
+++ b/src/Makefile
@@ -68,7 +68,6 @@ BOOST_LIB_DIR_Darwin=-L$(BREW_PREFIX)/lib
 BOOST_INC_Darwin=-I$(BREW_PREFIX)/include
 CRYPTOPP_LIB_Darwin:=-L$(BREW_PREFIX)/lib -lcryptopp
 CRYPTOPP_INC_Darwin:=-I$(BREW_PREFIX)/include
-NLOHMANN_JSON_INC_Darwin:=-I$(BREW_PREFIX)/include
 GRPC_INC_Darwin:=$(shell pkg-config --cflags-only-I grpc++)
 GRPC_LIB_Darwin:=$(shell pkg-config --libs grpc++)
 PROTOBUF_INC_Darwin:=$(shell pkg-config --cflags-only-I protobuf)
@@ -137,7 +136,6 @@ BOOST_FILESYSTEM_LIB=$(BOOST_FILESYSTEM_LIB_$(UNAME))
 BOOST_INC=$(BOOST_INC_$(UNAME))
 CRYPTOPP_LIB=$(CRYPTOPP_LIB_$(UNAME))
 CRYPTOPP_INC=$(CRYPTOPP_INC_$(UNAME))
-NLOHMANN_JSON_INC=$(NLOHMANN_JSON_INC_$(UNAME))
 MONGOOSE_INC=-I$(BUILDDIR)/include
 GRPC_INC:=$(GRPC_INC_$(UNAME))
 GRPC_LIB:=$(GRPC_LIB_$(UNAME))
@@ -169,8 +167,8 @@ HASH_LIBS:=$(CRYPTOPP_LIB)
 WARNS=-W -Wall -pedantic
 
 # Place our include directories before the system's
-INCS=-I../lib/machine-emulator-defines -I../third-party/llvm-flang-uint128 \
-	$(LUA_INC) $(CRYPTOPP_INC) $(NLOHMANN_JSON_INC) $(MONGOOSE_INC) $(BOOST_INC) $(PROTOBUF_INC) $(GRPC_INC) $(INCS_$(UNAME))
+INCS=-I../lib/machine-emulator-defines -I../third-party/llvm-flang-uint128 -I../third-party/downloads \
+	$(LUA_INC) $(CRYPTOPP_INC) $(MONGOOSE_INC) $(BOOST_INC) $(PROTOBUF_INC) $(GRPC_INC) $(INCS_$(UNAME))
 
 ifeq ($(dump),yes)
 #DEFS+=-DDUMP_ILLEGAL_INSN_EXCEPTIONS

--- a/src/json-util.h
+++ b/src/json-util.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <type_traits>
 
-#include <nlohmann/json.hpp>
+#include <json.hpp>
 
 #include "base64.h"
 #include "machine-merkle-tree.h"

--- a/src/jsonrpc-remote-machine.cpp
+++ b/src/jsonrpc-remote-machine.cpp
@@ -37,8 +37,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <json.hpp>
 #include <mongoose.h>
-#include <nlohmann/json.hpp>
 
 #include "base64.h"
 #include "json-util.h"

--- a/src/jsonrpc-virtual-machine.cpp
+++ b/src/jsonrpc-virtual-machine.cpp
@@ -19,8 +19,8 @@
 #include <cstdint>
 #include <string>
 
+#include <json.hpp>
 #include <mongoose.h>
-#include <nlohmann/json.hpp>
 
 #include "jsonrpc-mg-mgr.h"
 #include "jsonrpc-virtual-machine.h"

--- a/src/test-machine-c-api.cpp
+++ b/src/test-machine-c-api.cpp
@@ -21,7 +21,7 @@
 #include <tuple>
 #include <vector>
 
-#include <nlohmann/json.hpp>
+#include <json.hpp>
 
 #include "grpc-machine-c-api.h"
 #include "machine-c-api.h"

--- a/third-party/dependencies
+++ b/third-party/dependencies
@@ -1,1 +1,2 @@
 https://github.com/cesanta/mongoose/archive/refs/tags/7.9.tar.gz
+https://github.com/nlohmann/json/releases/download/v3.11.2/json.hpp

--- a/third-party/shasumfile
+++ b/third-party/shasumfile
@@ -1,1 +1,2 @@
 6e60602441678ced30ec3bc6e7799b528b8521b9  downloads/7.9.tar.gz
+ce36f0cfc3ebba05259186ad6fd2233e14e0e698  downloads/json.hpp


### PR DESCRIPTION
This is to simplify our dependencies, so the cartesi machine is easier to build on more platforms.

I could copy the single file to our repository, but I choose to download it instead, to avoid license issues.