### PR TITLE
fix: missing climits include in json-util.cpp

### DIFF
--- a/src/json-util.cpp
+++ b/src/json-util.cpp
@@ -14,6 +14,7 @@
 // with this program (see COPYING). If not, see <https://www.gnu.org/licenses/>.
 //
 
+#include <climits>
 #include <exception>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Some recent commit has indirectly caused `INT_MAX` not to be defined in `json-util.cpp` and it fails to compile under `g++ (Ubuntu 12.3.0-1ubuntu1~23.04) 12.3.0`. This PR includes `<climits>` to fix the problem.