### PR TITLE
fix: Pages not marked dirty after uarch reset

### DIFF
--- a/src/uarch-reset-state-access.h
+++ b/src/uarch-reset-state-access.h
@@ -73,8 +73,8 @@ private:
         if (uarch_pristine_ram_len > m_us.ram.get_length()) {
             throw std::runtime_error("embedded uarch ram image does not fit in uarch ram pma");
         }
-        memset(m_us.ram.get_memory().get_host_memory(), 0, m_us.ram.get_length());
-        memcpy(m_us.ram.get_memory().get_host_memory(), uarch_pristine_ram, uarch_pristine_ram_len);
+        m_us.ram.fill_memory(m_us.ram.get_start(), 0, m_us.ram.get_length());
+        m_us.ram.write_memory(m_us.ram.get_start(), uarch_pristine_ram, uarch_pristine_ram_len);
     }
 };
 


### PR DESCRIPTION
This branch fixes a bug where PMA pages are not marked dirty by uarch_reset() creating inconsistent root hash.