### PR TITLE
WIP: Migrate to meson (This is completely experimental)

### DIFF
--- a/src/json-util.h
+++ b/src/json-util.h
@@ -23,7 +23,7 @@
 
 // Disable JSON filesystem support because it is not supported in some targets
 #define JSON_HAS_FILESYSTEM 0 // NOLINT(cppcoreguidelines-macro-usage)
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 
 #include "machine-merkle-tree.h"
 #include "machine.h"

--- a/src/jsonrpc-discover.cpp.in
+++ b/src/jsonrpc-discover.cpp.in
@@ -1,0 +1,6 @@
+// This file is auto-generated and should not be modified
+namespace cartesi {
+extern char const *const jsonrpc_discover_json = R"json(
+@jsonrpc-discover@
+)json";
+} // namespace cartesi

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,89 @@
+project('machine-emulator', 'c', 'cpp')
+
+deps = [
+  dependency('nlohmann_json', required: true),
+  dependency('protobuf', required: true)]
+
+protoc = generator(find_program('protoc', required : true),
+  output : ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
+  arguments : ['--proto_path=@CURRENT_SOURCE_DIR@/../lib/grpc-interfaces', '--cpp_out=@BUILD_DIR@', '@INPUT@'])
+
+libcartesi_sources = [
+  'pma-driver.cpp',
+  'clint.cpp',
+  'clint-factory.cpp',
+  'dtb.cpp',
+  'os.cpp',
+  'htif.cpp',
+  'htif-factory.cpp',
+  'shadow-state.cpp',
+  'shadow-state-factory.cpp',
+  'shadow-pmas.cpp',
+  'shadow-pmas-factory.cpp',
+  'shadow-tlb.cpp',
+  'shadow-tlb-factory.cpp',
+  'shadow-uarch-state.cpp',
+  'shadow-uarch-state-factory.cpp',
+  'pma.cpp',
+  'machine.cpp',
+  'machine-config.cpp',
+  'json-util.cpp',
+  'base64.cpp',
+  'interpret.cpp',
+  'virtual-machine.cpp',
+  'uarch-machine.cpp',
+  'uarch-step.cpp',
+  'uarch-reset-state.cpp',
+  '../third-party/tiny_sha3/sha3.c',
+  'machine-merkle-tree.cpp',
+  'pristine-merkle-tree.cpp',
+  'uarch-interpret.cpp',
+  'machine-c-api.cpp',
+  'uarch-pristine-ram.c',
+  'uarch-pristine-state-hash.cpp',
+  '../uarch/uarch-pristine-hash.c',
+  ]
+
+libcartesi = library('cartesi',
+  libcartesi_sources,
+  dependencies: deps,
+  include_directories: [
+    '../third-party/tiny_sha3',
+    '../third-party/llvm-flang-uint128',
+    ],
+  version: '1.2.3', soversion: '1',
+  install : true,
+  )
+
+data = configuration_data()
+data.set('jsonrpc-discover', import('fs').read('jsonrpc-discover.json').strip())
+configure_file(
+  input: 'jsonrpc-discover.cpp.in',
+  output: 'jsonrpc-discover.cpp',
+  configuration: data)
+
+mongoose = dependency('mongoose', required: true, static: true)
+jsonrpc_remote_cartesi_machine_sources = [
+  'jsonrpc-remote-machine.cpp',
+  'jsonrpc-discover.cpp',
+  'slog.cpp',
+  'uarch-pristine-ram.c',
+  'uarch-pristine-state-hash.cpp',
+  '../uarch/uarch-pristine-hash.c',
+  ]
+
+jsonrpc_remote_cartesi_machine = executable('jsonrpc-remote-cartesi-machine',
+  jsonrpc_remote_cartesi_machine_sources,
+  dependencies: mongoose,
+  include_directories: [
+    '../third-party/tiny_sha3',
+    ],
+  link_with: libcartesi,
+  install: true)
+
+
+grpc_files = [
+  protoc.process('../lib/grpc-interfaces/versioning.proto'),
+  protoc.process('../lib/grpc-interfaces/cartesi-machine.proto'),
+  protoc.process('../lib/grpc-interfaces/cartesi-machine-checkin.proto'),
+]

--- a/src/subprojects/mongoose.wrap
+++ b/src/subprojects/mongoose.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = mongoose-7.12
+source_url = https://github.com/cesanta/mongoose/archive/refs/tags/7.12.tar.gz
+source_filename = 7.12.tar.gz
+source_hash = 91e719e164816b349be3cb71293927f3f6abbe3fb02187e2d9b5e56f542c2063
+patch_directory = mongoose
+
+[provide]
+mongoose = mongoose_dep

--- a/src/subprojects/packagefiles/mongoose/meson.build
+++ b/src/subprojects/packagefiles/mongoose/meson.build
@@ -1,0 +1,9 @@
+project('mongoose', 'c', default_options: {'default_library': 'both'})
+
+mongoose_inc = include_directories('.')
+mongoose_lib = library('mongoose', ['mongoose.c', 'mongoose.h'], install: true)
+install_headers('mongoose.h', subdir: 'mongoose')
+
+mongoose_dep = declare_dependency(
+  include_directories: mongoose_inc,
+  link_with: mongoose_lib)


### PR DESCRIPTION
This is an experiment to see how one would migrate the build system from `GNU make` to `meson`.

- build: libcartesi.so
- build: libcartesi.a
- build: jsonrpc-discover.cpp
- build: jsonrpc-remote-cartesi-machine