### PR TITLE
fix: configure target terminal with -onlcr

### DIFF
--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -580,7 +580,7 @@ local bootargs = "quiet earlycon=sbi console=hvc0"
     .. " rootfstype=ext2 root=/dev/pmem0 rw init=/usr/sbin/cartesi-init"
 local init_splash = true
 local append_bootargs = ""
-local default_init = "USER=dapp\n"
+local default_init = "busybox stty -onlcr\nUSER=dapp\n"
 local append_init = ""
 local append_entrypoint = ""
 local rollup = {
@@ -1801,7 +1801,7 @@ else
     if init_splash then
         config.dtb.init = config.dtb.init
             .. ([[
-echo "
+busybox stty -onlcr; cat <<EOF
          .
         / \
       /    \
@@ -1811,7 +1811,8 @@ echo "
        \    / CARTESI
         \ /   MACHINE
          '
-"
+
+EOF
 ]]):gsub("\\", "\\\\")
     end
 


### PR DESCRIPTION
The expected behavior of the emulator is to pass through new-line control-characters directly from the inside to the outside. On the outside, if the output of the emulator is connected to a file, there should be no addition of a carriage-return. If, however, the output is connected to a terminal, the terminal itself will have been configured to add the carriage-return on its own. 

In other words, we expect the following command to have the output shown
```
cartesi-machine.lua --no-init-splash --quiet -- echo | xxd
00000000: 0a                                       .
```

Instead, what we see before this PR (but when using a yet-to-be-released kernel linked to [opensbi-1.3.1-ctsi-2](https://github.com/cartesi/opensbi/releases/tag/v1.3.1-ctsi-2)) is

```
cartesi-machine.lua --no-init-splash --quiet -- echo | xxd
00000000: 0d0a                                     ..
```

This is because the terminal inside the emulator is configured with `onlcr`, so it is adding the carriage-return whenever it sees a new-line.

The PR configures the terminal with `-onlcr` so this doesn't happen.

Interestingly, prior to opensbi-1.3.1-ctsi-2, opensbi itself was adding yet another carriage-return on its own, whenever it saw a new-line sent to the legacy putchar we use with HTIF console. So the output was

```
cartesi-machine.lua --no-init-splash --quiet -- echo | xxd
00000000: 0d0d 0a                                  ...
```