### PR TITLE
Use Sv39 address spacing by default to support nodejs and improve performance

### DIFF
--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -575,7 +575,7 @@ local memory_range_replace = {}
 local ram_image_filename = images_path .. "linux.bin"
 local ram_length = 128 << 20 -- 128MB
 local dtb_image_filename = nil
-local bootargs = "quiet earlycon=sbi console=hvc0"
+local bootargs = "no4lvl quiet earlycon=sbi console=hvc0"
     -- rootfs related arguments must come at the end to be replaced by --no-root-flash-drive
     .. " rootfstype=ext2 root=/dev/pmem0 rw init=/usr/sbin/cartesi-init"
 local init_splash = true


### PR DESCRIPTION
Currently the machine is using Sv57 virtual memory address spacing (5 level), however nodejs does not work with Sv57, furthermore address translation with a 5 level has more overhead on TLB misses than Sv39 which only has 3 levels.

I checked there is only two ways to force using Sv39 in recent kernel:
1. Add `no4lvl` to bootargs
2. Disable Sv48 and Sv57 modes in `satp` CSR.

While option 2. would be optimal in terms of performance, I decided to go for 1. in case a dapp wants to remove `no4lvl` from bootargs to map more 512GB to virtual memory.

Looks like `mmu-type: riscv,sv39` in DTB is ignored in recent kernels, but I left the entry there to keep supporting old kernels.
