### PR TITLE
Fix trailing comma in jsonrpc-discover.json

### DIFF
--- a/src/jsonrpc-discover.json
+++ b/src/jsonrpc-discover.json
@@ -1648,7 +1648,7 @@
           },
           "girqsrvd": {
             "$ref": "#/components/schemas/UnsignedInteger"
-          },
+          }
         }
       },
 


### PR DESCRIPTION
Pasting the content into https://playground.open-rpc.org/ makes it complain about this issue.

