### PR TITLE
Rework machine snapshots API

### DIFF
--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -2079,7 +2079,7 @@ if config.processor.iunrep ~= 0 then stderr("Running in unreproducible mode!\n")
 if store_config == stderr then store_machine_config(config, stderr) end
 if cmio_advance or cmio_inspect then
     check_cmio_htif_config(config.htif)
-    assert(remote_address, "cmio requires --remote-address for snapshot/rollback")
+    assert(remote_address, "cmio requires --remote-address for snapshot/commit/rollback")
 end
 local cycles = machine:read_mcycle()
 if initial_hash then
@@ -2135,6 +2135,7 @@ while math.ult(cycles, max_mcycle) do
         elseif cmio_advance and cmio_advance.next_input_index < cmio_advance.input_index_end then
             -- previous reason was an accept
             if reason == cartesi.machine.HTIF_YIELD_MANUAL_REASON_RX_ACCEPTED then
+                machine:commit()
                 -- save only if we have already run an input and have just accepted it
                 if cmio_advance.next_input_index > cmio_advance.input_index_begin then
                     assert(length == 32, "expected root hash in tx buffer")

--- a/src/clua-i-virtual-machine.cpp
+++ b/src/clua-i-virtual-machine.cpp
@@ -545,6 +545,14 @@ static int machine_obj_index_snapshot(lua_State *L) {
     return 0;
 }
 
+/// \brief This is the machine:commit() method implementation.
+/// \param L Lua state.
+static int machine_obj_index_commit(lua_State *L) {
+    auto &m = clua_check<clua_managed_cm_ptr<cm_machine>>(L, 1);
+    TRY_EXECUTE(cm_commit(m.get(), err_msg));
+    return 0;
+}
+
 /// \brief This is the machine:rollback() method implementation.
 /// \param L Lua state.
 static int machine_obj_index_rollback(lua_State *L) {
@@ -701,6 +709,7 @@ static const auto machine_obj_index = cartesi::clua_make_luaL_Reg_array({
     {"replace_memory_range", machine_obj_index_replace_memory_range},
     {"destroy", machine_obj_index_destroy},
     {"snapshot", machine_obj_index_snapshot},
+    {"commit", machine_obj_index_commit},
     {"rollback", machine_obj_index_rollback},
     {"read_uarch_halt_flag", machine_obj_index_read_uarch_halt_flag},
     {"set_uarch_halt_flag", machine_obj_index_set_uarch_halt_flag},

--- a/src/clua-jsonrpc-machine.cpp
+++ b/src/clua-jsonrpc-machine.cpp
@@ -311,6 +311,15 @@ static int jsonrpc_server_class_shutdown(lua_State *L) {
     return 1;
 }
 
+/// \brief This is the rebind method implementation.
+static int jsonrpc_server_class_rebind(lua_State *L) {
+    auto &managed_jsonrpc_mg_mgr =
+        clua_check<clua_managed_cm_ptr<cm_jsonrpc_mg_mgr>>(L, lua_upvalueindex(1), lua_upvalueindex(2));
+    const char *address = luaL_checkstring(L, 1);
+    TRY_EXECUTE(cm_jsonrpc_rebind(managed_jsonrpc_mg_mgr.get(), address, err_msg));
+    return 1;
+}
+
 /// \brief This is the fork method implementation.
 static int jsonrpc_server_class_fork(lua_State *L) {
     auto &managed_jsonrpc_mg_mgr =
@@ -328,6 +337,7 @@ static const auto jsonrpc_server_static_methods = cartesi::clua_make_luaL_Reg_ar
     {"get_version", jsonrpc_server_class_get_version},
     {"shutdown", jsonrpc_server_class_shutdown},
     {"fork", jsonrpc_server_class_fork},
+    {"rebind", jsonrpc_server_class_rebind},
 });
 
 /// \brief This is the jsonrpc.stub() method implementation.

--- a/src/i-virtual-machine.h
+++ b/src/i-virtual-machine.h
@@ -156,14 +156,19 @@ public:
         return do_get_initial_config();
     }
 
+    /// \brief destroy
+    void destroy(void) {
+        do_destroy();
+    }
+
     /// \brief snapshot
     void snapshot(void) {
         do_snapshot();
     }
 
-    /// \brief destroy
-    void destroy(void) {
-        do_destroy();
+    /// \brief commit
+    void commit(void) {
+        do_commit();
     }
 
     /// \brief rollback
@@ -802,6 +807,7 @@ private:
     virtual machine_config do_get_initial_config(void) const = 0;
     virtual void do_snapshot() = 0;
     virtual void do_destroy() = 0;
+    virtual void do_commit() = 0;
     virtual void do_rollback() = 0;
     virtual uint64_t do_read_uarch_x(int i) const = 0;
     virtual void do_write_uarch_x(int i, uint64_t val) = 0;

--- a/src/jsonrpc-discover.json
+++ b/src/jsonrpc-discover.json
@@ -35,6 +35,27 @@
     },
 
     {
+      "name": "rebind",
+      "summary": "Changes the address the server is listening to",
+      "params": [ {
+          "name": "address",
+          "description": "URL of the new address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/UnsignedInteger"
+          }
+        }
+      ],
+      "result": {
+        "name": "address",
+        "description": "URL of rebound server",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+
+    {
       "name": "shutdown",
       "summary": "Causes the server to shutdown and exit",
       "params": [],

--- a/src/jsonrpc-machine-c-api.cpp
+++ b/src/jsonrpc-machine-c-api.cpp
@@ -190,6 +190,14 @@ int cm_jsonrpc_fork(const cm_jsonrpc_mg_mgr *mgr, char **address, char **err_msg
     return cm_result_failure(err_msg);
 }
 
+int cm_jsonrpc_rebind(const cm_jsonrpc_mg_mgr *mgr, const char *address, char **err_msg) try {
+    const auto *cpp_mgr = convert_from_c(mgr);
+    cartesi::jsonrpc_virtual_machine::rebind(*cpp_mgr, address);
+    return cm_result_success(err_msg);
+} catch (...) {
+    return cm_result_failure(err_msg);
+}
+
 int cm_jsonrpc_get_x_address(const cm_jsonrpc_mg_mgr *mgr, int i, uint64_t *val, char **err_msg) try {
     const auto *cpp_mgr = convert_from_c(mgr);
     *val = cartesi::jsonrpc_virtual_machine::get_x_address(*cpp_mgr, i);

--- a/src/jsonrpc-machine-c-api.h
+++ b/src/jsonrpc-machine-c-api.h
@@ -152,6 +152,15 @@ CM_API int cm_jsonrpc_verify_uarch_step_state_transition(const cm_jsonrpc_mg_mgr
 /// \returns 0 for successful verification, non zero code for error
 CM_API int cm_jsonrpc_fork(const cm_jsonrpc_mg_mgr *mgr, char **address, char **err_msg);
 
+/// \brief Changes the address the server is listening to
+/// \param mgr Cartesi jsonrpc connection manager. Must be pointer to valid object
+/// \param address New address that the remote server should bind to
+/// \param err_msg Receives the error message if function execution fails
+/// or NULL in case of successful function execution. In case of failure error_msg
+/// must be deleted by the function caller using cm_delete_cstring
+/// \returns 0 for successful verification, non zero code for error
+CM_API int cm_jsonrpc_rebind(const cm_jsonrpc_mg_mgr *mgr, const char *address, char **err_msg);
+
 /// \brief Gets the address of a general-purpose register from remote cartesi server
 /// \param mgr Cartesi jsonrpc connection manager. Must be pointer to valid object
 /// \param i Register index. Between 0 and X_REG_COUNT-1, inclusive.

--- a/src/jsonrpc-mg-mgr.h
+++ b/src/jsonrpc-mg-mgr.h
@@ -42,6 +42,7 @@ public:
     const std::string &get_remote_address(void) const;
     const std::string &get_remote_parent_address(void) const;
     void snapshot(void);
+    void commit(void);
     void rollback(void);
     void shutdown(void);
 };

--- a/src/jsonrpc-virtual-machine.cpp
+++ b/src/jsonrpc-virtual-machine.cpp
@@ -237,7 +237,10 @@ void jsonrpc_mg_mgr::commit() {
     // To commit, we kill the parent server and replace its address with the child's
     bool result = false;
     jsonrpc_request(get_mgr(), get_remote_parent_address(), "shutdown", std::tie(), result);
-    std::swap(m_address[0], m_address[1]);
+
+    // Rebind the remote server to continue listening in the original port
+    result = false;
+    jsonrpc_request(get_mgr(), get_remote_address(), "rebind", std::tie(m_address[0]), result);
     m_address.pop_back();
 }
 
@@ -398,6 +401,11 @@ std::string jsonrpc_virtual_machine::fork(const jsonrpc_mg_mgr_ptr &mgr) {
     std::string result;
     jsonrpc_request(mgr->get_mgr(), mgr->get_remote_address(), "fork", std::tie(), result);
     return result;
+}
+
+void jsonrpc_virtual_machine::rebind(const jsonrpc_mg_mgr_ptr &mgr, const std::string &address) {
+    bool result = false;
+    jsonrpc_request(mgr->get_mgr(), mgr->get_remote_address(), "rebind", std::tie(address), result);
 }
 
 uint64_t jsonrpc_virtual_machine::do_read_f(int i) const {

--- a/src/jsonrpc-virtual-machine.h
+++ b/src/jsonrpc-virtual-machine.h
@@ -192,6 +192,7 @@ private:
     access_log do_log_uarch_step(const access_log::type &log_type, bool /*one_based = false*/) override;
     void do_destroy() override;
     void do_snapshot() override;
+    void do_commit() override;
     void do_rollback() override;
     bool do_verify_dirty_page_maps(void) const override;
     uint64_t do_read_word(uint64_t address) const override;

--- a/src/jsonrpc-virtual-machine.h
+++ b/src/jsonrpc-virtual-machine.h
@@ -74,6 +74,7 @@ public:
         const hash_type &root_hash_after, const machine_runtime_config &r = {}, bool one_based = false);
 
     static std::string fork(const jsonrpc_mg_mgr_ptr &mgr);
+    static void rebind(const jsonrpc_mg_mgr_ptr &mgr, const std::string &address);
     static uint64_t get_x_address(const jsonrpc_mg_mgr_ptr &mgr, int i);
     static uint64_t get_f_address(const jsonrpc_mg_mgr_ptr &mgr, int i);
     static uint64_t get_uarch_x_address(const jsonrpc_mg_mgr_ptr &mgr, int i);

--- a/src/machine-c-api.cpp
+++ b/src/machine-c-api.cpp
@@ -1589,6 +1589,14 @@ int cm_snapshot(cm_machine *m, char **err_msg) try {
     return cm_result_failure(err_msg);
 }
 
+int cm_commit(cm_machine *m, char **err_msg) try {
+    auto *cpp_machine = convert_from_c(m);
+    cpp_machine->commit();
+    return cm_result_success(err_msg);
+} catch (...) {
+    return cm_result_failure(err_msg);
+}
+
 int cm_rollback(cm_machine *m, char **err_msg) try {
     auto *cpp_machine = convert_from_c(m);
     cpp_machine->rollback();

--- a/src/machine-c-api.h
+++ b/src/machine-c-api.h
@@ -1769,7 +1769,15 @@ CM_API int cm_destroy(cm_machine *m, char **err_msg);
 /// \returns 0 for success, non zero code for error
 CM_API int cm_snapshot(cm_machine *m, char **err_msg);
 
-/// \brief Performs rollback
+/// \brief Performs commit of the machine, discarding last snapshot.
+/// \param err_msg Receives the error message if function execution fails
+/// or NULL in case of successful function execution. In case of failure error_msg
+/// must be deleted by the function caller using cm_delete_cstring.
+/// err_msg can be NULL, meaning the error message won't be received.
+/// \returns 0 for success, non zero code for error
+CM_API int cm_commit(cm_machine *m, char **err_msg);
+
+/// \brief Performs rollback of the machine, restoring last snapshot.
 /// \param err_msg Receives the error message if function execution fails
 /// or NULL in case of successful function execution. In case of failure error_msg
 /// must be deleted by the function caller using cm_delete_cstring.

--- a/src/virtual-machine.cpp
+++ b/src/virtual-machine.cpp
@@ -468,6 +468,10 @@ void virtual_machine::do_snapshot(void) {
     throw std::runtime_error("snapshot is not supported");
 }
 
+void virtual_machine::do_commit(void) {
+    throw std::runtime_error("commit is not supported");
+}
+
 void virtual_machine::do_rollback(void) {
     throw std::runtime_error("rollback is not supported");
 }

--- a/src/virtual-machine.h
+++ b/src/virtual-machine.h
@@ -149,6 +149,7 @@ private:
     machine_config do_get_initial_config(void) const override;
     void do_snapshot() override;
     void do_destroy() override;
+    void do_commit() override;
     void do_rollback() override;
     uint64_t do_read_uarch_x(int i) const override;
     void do_write_uarch_x(int i, uint64_t val) override;


### PR DESCRIPTION
This is a fix for https://github.com/cartesi/machine-emulator/issues/202 and also adds new command line options `--no-rollback` that fulfills https://github.com/cartesi/machine-emulator/issues/206