### PR TITLE
feat: add new runtime option to skip storing machine root hash

### DIFF
--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -274,6 +274,13 @@ where options are:
 
     DON'T USE THIS OPTION IN PRODUCTION
 
+  --skip-root-hash-store
+    skip merkle tree root hash saving when storing a machine.
+    i.e., assume the stored machine will use --skip-root-hash-check when loading.
+    this is only intended to speed up machine saving in emulator tests.
+
+    DON'T USE THIS OPTION IN PRODUCTION
+
   --skip-version-check
     skip emulator version check when loading a stored machine.
     i.e., assume the stored machine is compatible with current emulator version.
@@ -595,6 +602,7 @@ local rollup_advance
 local rollup_inspect
 local concurrency_update_merkle_tree = 0
 local skip_root_hash_check = false
+local skip_root_hash_store = false
 local skip_version_check = false
 local htif_no_console_putchar = false
 local htif_console_getchar = false
@@ -1143,6 +1151,14 @@ local options = {
         function(all)
             if not all then return false end
             skip_root_hash_check = true
+            return true
+        end,
+    },
+    {
+        "^%-%-skip%-root%-hash%-store$",
+        function(all)
+            if not all then return false end
+            skip_root_hash_store = true
             return true
         end,
     },
@@ -1761,6 +1777,7 @@ local runtime = {
         no_console_putchar = htif_no_console_putchar,
     },
     skip_root_hash_check = skip_root_hash_check,
+    skip_root_hash_store = skip_root_hash_store,
     skip_version_check = skip_version_check,
 }
 

--- a/src/clua-machine-util.cpp
+++ b/src/clua-machine-util.cpp
@@ -1490,6 +1490,7 @@ cm_machine_runtime_config *clua_check_cm_machine_runtime_config(lua_State *L, in
     check_cm_concurrency_runtime_config(L, tabidx, &config->concurrency);
     check_cm_htif_runtime_config(L, tabidx, &config->htif);
     config->skip_root_hash_check = opt_boolean_field(L, tabidx, "skip_root_hash_check");
+    config->skip_root_hash_store = opt_boolean_field(L, tabidx, "skip_root_hash_store");
     config->skip_version_check = opt_boolean_field(L, tabidx, "skip_version_check");
     config->soft_yield = opt_boolean_field(L, tabidx, "soft_yield");
     managed.release();

--- a/src/json-util.cpp
+++ b/src/json-util.cpp
@@ -443,6 +443,7 @@ void ju_get_opt_field(const nlohmann::json &j, const K &key, machine_runtime_con
     ju_get_field(j[key], "concurrency"s, value.concurrency, path + to_string(key) + "/");
     ju_get_field(j[key], "htif"s, value.htif, path + to_string(key) + "/");
     ju_get_opt_field(j[key], "skip_root_hash_check"s, value.skip_root_hash_check, path + to_string(key) + "/");
+    ju_get_opt_field(j[key], "skip_root_hash_store"s, value.skip_root_hash_store, path + to_string(key) + "/");
     ju_get_opt_field(j[key], "skip_version_check"s, value.skip_version_check, path + to_string(key) + "/");
     ju_get_opt_field(j[key], "soft_yield"s, value.soft_yield, path + to_string(key) + "/");
 }
@@ -1369,6 +1370,7 @@ void to_json(nlohmann::json &j, const machine_runtime_config &runtime) {
         {"concurrency", runtime.concurrency},
         {"htif", runtime.htif},
         {"skip_root_hash_check", runtime.skip_root_hash_check},
+        {"skip_root_hash_store", runtime.skip_root_hash_store},
         {"skip_version_check", runtime.skip_version_check},
         {"soft_yield", runtime.soft_yield},
     };

--- a/src/jsonrpc-discover.json
+++ b/src/jsonrpc-discover.json
@@ -1808,6 +1808,9 @@
           "skip_root_hash_check": {
             "type": "boolean"
           },
+          "skip_root_hash_store": {
+            "type": "boolean"
+          },
           "skip_version_check": {
             "type": "boolean"
           },

--- a/src/machine-c-api.cpp
+++ b/src/machine-c-api.cpp
@@ -477,6 +477,7 @@ cartesi::machine_runtime_config convert_from_c(const cm_machine_runtime_config *
         cartesi::concurrency_runtime_config{c_config->concurrency.update_merkle_tree};
     new_cpp_machine_runtime_config.htif = cartesi::htif_runtime_config{c_config->htif.no_console_putchar};
     new_cpp_machine_runtime_config.skip_root_hash_check = c_config->skip_root_hash_check;
+    new_cpp_machine_runtime_config.skip_root_hash_store = c_config->skip_root_hash_store;
     new_cpp_machine_runtime_config.skip_version_check = c_config->skip_version_check;
     new_cpp_machine_runtime_config.soft_yield = c_config->soft_yield;
     return new_cpp_machine_runtime_config;

--- a/src/machine-c-api.h
+++ b/src/machine-c-api.h
@@ -436,6 +436,7 @@ typedef struct { // NOLINT(modernize-use-using)
     cm_concurrency_runtime_config concurrency;
     cm_htif_runtime_config htif;
     bool skip_root_hash_check;
+    bool skip_root_hash_store;
     bool skip_version_check;
     bool soft_yield;
 } cm_machine_runtime_config;

--- a/src/machine-runtime-config.h
+++ b/src/machine-runtime-config.h
@@ -39,6 +39,7 @@ struct machine_runtime_config {
     concurrency_runtime_config concurrency{};
     htif_runtime_config htif{};
     bool skip_root_hash_check{};
+    bool skip_root_hash_store{};
     bool skip_version_check{};
     bool soft_yield{};
 };

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -832,9 +832,11 @@ void machine::store(const std::string &dir) const {
     if (!update_merkle_tree()) {
         throw std::runtime_error{"error updating Merkle tree"};
     }
-    hash_type h;
-    m_t.get_root_hash(h);
-    store_hash(h, dir);
+    if (!m_r.skip_root_hash_store) {
+        hash_type h;
+        m_t.get_root_hash(h);
+        store_hash(h, dir);
+    }
     auto c = get_serialization_config();
     c.store(dir);
     store_pmas(c, dir);


### PR DESCRIPTION
I needed this feature to speed up development/testing until we have a faster way to save/load merkle tree root hashes without doing whole computation all the time, it should not be used in production, it is complementary to the `--skip-root-hash-check` runtime option.

This is also useful when saving snapshots in WASM environment, machine root hash computation takes forever there, and storing machine snapshots in WASM is useful to save the state of the machine locally to later be resumed.