### PR TITLE
Add new docker like command line options

### DIFF
--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -496,6 +496,15 @@ where options are:
     appends to init the user who should execute the entrypoint command.
     when omitted, the user is set to "dapp" by rootfs init script.
 
+  -e=<name>=<value> or --env=<name>=<value>
+    appends to init an environment variable export.
+
+  -w=<dir> or --workdir=<dir>
+    appends to init the entrypoint working directory.
+
+  -h=<name> or --hostname=<name>
+    appends to init a machine hostname change.
+
   --append-init=<string>
     append <string> to the machine's init script, to execute as root.
     <string> is executed on boot after mounting flash drives but before
@@ -685,6 +694,24 @@ end
 local function handle_user(user)
     if not user then return false end
     append_init = append_init .. "USER=" .. user .. "\n"
+    return true
+end
+
+local function handle_env(name, value)
+    if not name or not value then return false end
+    append_init = append_init .. "export " .. name .. "=" .. value .. "\n"
+    return true
+end
+
+local function handle_workdir(value)
+    if not value then return false end
+    append_init = append_init .. "WORKDIR=" .. value .. "\n"
+    return true
+end
+
+local function handle_hostname(name)
+    if not name then return false end
+    append_init = append_init .. "busybox hostname " .. name .. "\n"
     return true
 end
 
@@ -1444,6 +1471,30 @@ local options = {
     {
         "^%-%-user%=(.*)$",
         handle_user,
+    },
+    {
+        "^%-e%=([%w_]+)%=(.*)$",
+        handle_env,
+    },
+    {
+        "^%-%-env%=([%w_]+)%=(.*)$",
+        handle_env,
+    },
+    {
+        "^%-w%=(.*)$",
+        handle_workdir,
+    },
+    {
+        "^%-%-workdir%=(.*)$",
+        handle_workdir,
+    },
+    {
+        "^%-h%=(.*)$",
+        handle_hostname,
+    },
+    {
+        "^%-%-hostname%=(.*)$",
+        handle_hostname,
     },
     {
         "^%-%-append%-init%=(.*)$",

--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -786,7 +786,7 @@ local function handle_network_option(opts)
 busybox ip link set dev eth0 up
 busybox ip addr add 10.0.2.15/24 dev eth0
 busybox ip route add default via 10.0.2.2 dev eth0
-echo 'nameserver 10.0.2.3' > /etc/resolv.conf
+[ -w /etc/resolv.conf ] && echo 'nameserver 10.0.2.3' > /etc/resolv.conf
 ]]
     -- sync guest date with host date, otherwise SSL connections may fail to validate certificates
     handle_sync_init_date(true)


### PR DESCRIPTION
This PR introduces `--env`, `--workdir` and `--hostname` Docker like options for convenience.

For instance you execute the following now:

```
cartesi-machine \
  --hostname=test-cm \
  --user=root  \
  --volume=.:/mnt \
  --workdir=/mnt \
  --env=VAR=1 \
  -it bash
Running in unreproducible mode!

         .
        / \
      /    \
\---/---\  /----\
 \       X       \
  \----/  \---/---\
       \    / CARTESI
        \ /   MACHINE
         '

root@test-cm:/mnt# env | grep VAR
VAR=1
root@test-cm:/mnt#
```

Looking more similar to `docker run` usage.