### PR TITLE
feat: add C API to translate virtual address

### DIFF
--- a/src/clua-i-virtual-machine.cpp
+++ b/src/clua-i-virtual-machine.cpp
@@ -499,6 +499,16 @@ static int machine_obj_index_write_virtual_memory(lua_State *L) {
     return 1;
 }
 
+/// \brief This is the machine:translate_virtual_address() method implementation.
+/// \param L Lua state.
+static int machine_obj_index_translate_virtual_address(lua_State *L) {
+    auto &m = clua_check<clua_managed_cm_ptr<cm_machine>>(L, 1);
+    uint64_t paddr_value{0};
+    TRY_EXECUTE(cm_translate_virtual_address(m.get(), luaL_checkinteger(L, 2), &paddr_value, err_msg));
+    lua_pushinteger(L, static_cast<lua_Integer>(paddr_value));
+    return 1;
+}
+
 /// \brief Replaces a memory range.
 /// \param L Lua state.
 static int machine_obj_index_replace_memory_range(lua_State *L) {
@@ -657,6 +667,7 @@ static const auto machine_obj_index = cartesi::clua_make_luaL_Reg_array({
     {"write_stvec", machine_obj_index_write_stvec},
     {"write_x", machine_obj_index_write_x},
     {"write_f", machine_obj_index_write_f},
+    {"translate_virtual_address", machine_obj_index_translate_virtual_address},
     {"replace_memory_range", machine_obj_index_replace_memory_range},
     {"destroy", machine_obj_index_destroy},
     {"snapshot", machine_obj_index_snapshot},

--- a/src/i-virtual-machine.h
+++ b/src/i-virtual-machine.h
@@ -111,6 +111,11 @@ public:
         do_write_virtual_memory(address, data, length);
     }
 
+    /// \brief Translates a virtual memory address to its corresponding physical memory address.
+    uint64_t translate_virtual_address(uint64_t vaddr) const {
+        return do_translate_virtual_address(vaddr);
+    }
+
     /// \brief Reads the value of a general-purpose register.
     uint64_t read_x(int i) const {
         return do_read_x(i);
@@ -688,6 +693,7 @@ private:
     virtual void do_write_memory(uint64_t address, const unsigned char *data, size_t length) = 0;
     virtual void do_read_virtual_memory(uint64_t address, unsigned char *data, uint64_t length) const = 0;
     virtual void do_write_virtual_memory(uint64_t address, const unsigned char *data, size_t length) = 0;
+    virtual uint64_t do_translate_virtual_address(uint64_t vaddr) const = 0;
     virtual uint64_t do_read_x(int i) const = 0;
     virtual void do_write_x(int i, uint64_t val) = 0;
     virtual uint64_t do_read_f(int i) const = 0;

--- a/src/jsonrpc-discover.json
+++ b/src/jsonrpc-discover.json
@@ -591,6 +591,27 @@
     },
 
     {
+      "name": "machine.translate_virtual_address",
+      "summary": "Translates a virtual memory address to its corresponding physical memory address",
+      "params": [ {
+          "name":"vaddr",
+          "description": "Virtual address to translate",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/UnsignedInteger"
+          }
+        }
+      ],
+      "result": {
+        "name": "value",
+        "description": "Value of corresponding physical address (little-endian)",
+        "schema": {
+          "$ref": "#/components/schemas/UnsignedInteger"
+        }
+      }
+    },
+
+    {
       "name": "machine.replace_memory_range",
       "summary": "Replaces a memory range",
       "params": [ {

--- a/src/jsonrpc-remote-machine.cpp
+++ b/src/jsonrpc-remote-machine.cpp
@@ -1146,6 +1146,22 @@ static json jsonrpc_machine_write_virtual_memory_handler(const json &j, mg_conne
     return jsonrpc_response_ok(j);
 }
 
+/// \brief JSONRPC handler for the machine.translate_virtual_address method
+/// \param j JSON request object
+/// \param con Mongoose connection
+/// \param h Handler data
+/// \returns JSON response object
+static json jsonrpc_machine_translate_virtual_address_handler(const json &j, mg_connection *con, http_handler_data *h) {
+    (void) con;
+    if (!h->machine) {
+        return jsonrpc_response_invalid_request(j, "no machine");
+    }
+    static const char *param_name[] = {"vaddr"};
+    auto args = parse_args<uint64_t>(j, param_name);
+    auto vaddr = std::get<0>(args);
+    return jsonrpc_response_ok(j, h->machine->translate_virtual_address(vaddr));
+}
+
 /// \brief JSONRPC handler for the machine.replace_memory_range method
 /// \param j JSON request object
 /// \param con Mongoose connection
@@ -1653,6 +1669,7 @@ static json jsonrpc_dispatch_method(const json &j, mg_connection *con, http_hand
         {"machine.write_memory", jsonrpc_machine_write_memory_handler},
         {"machine.read_virtual_memory", jsonrpc_machine_read_virtual_memory_handler},
         {"machine.write_virtual_memory", jsonrpc_machine_write_virtual_memory_handler},
+        {"machine.translate_virtual_address", jsonrpc_machine_translate_virtual_address_handler},
         {"machine.replace_memory_range", jsonrpc_machine_replace_memory_range_handler},
         {"machine.read_csr", jsonrpc_machine_read_csr_handler},
         {"machine.write_csr", jsonrpc_machine_write_csr_handler},

--- a/src/jsonrpc-virtual-machine.cpp
+++ b/src/jsonrpc-virtual-machine.cpp
@@ -447,6 +447,13 @@ void jsonrpc_virtual_machine::do_write_virtual_memory(uint64_t address, const un
         std::tie(address, b64), result);
 }
 
+uint64_t jsonrpc_virtual_machine::do_translate_virtual_address(uint64_t vaddr) const {
+    uint64_t result = 0;
+    jsonrpc_request(m_mgr->get_mgr(), m_mgr->get_remote_address(), "machine.translate_virtual_address", std::tie(vaddr),
+        result);
+    return result;
+}
+
 uint64_t jsonrpc_virtual_machine::do_read_pc(void) const {
     return read_csr(csr::pc);
 }

--- a/src/jsonrpc-virtual-machine.h
+++ b/src/jsonrpc-virtual-machine.h
@@ -87,6 +87,7 @@ private:
     void do_write_memory(uint64_t address, const unsigned char *data, size_t length) override;
     void do_read_virtual_memory(uint64_t address, unsigned char *data, uint64_t length) const override;
     void do_write_virtual_memory(uint64_t address, const unsigned char *data, size_t length) override;
+    uint64_t do_translate_virtual_address(uint64_t vaddr) const override;
     uint64_t do_read_pc(void) const override;
     void do_write_pc(uint64_t val) override;
     uint64_t do_read_fcsr(void) const override;

--- a/src/machine-c-api.cpp
+++ b/src/machine-c-api.cpp
@@ -1254,6 +1254,14 @@ int cm_write_virtual_memory(cm_machine *m, uint64_t address, const unsigned char
     return cm_result_failure(err_msg);
 }
 
+int cm_translate_virtual_address(cm_machine *m, uint64_t vaddr, uint64_t *paddr, char **err_msg) try {
+    const auto *cpp_machine = convert_from_c(m);
+    *paddr = cpp_machine->translate_virtual_address(vaddr);
+    return cm_result_success(err_msg);
+} catch (...) {
+    return cm_result_failure(err_msg);
+}
+
 int cm_read_x(const cm_machine *m, int i, uint64_t *val, char **err_msg) try {
     if (val == nullptr) {
         throw std::invalid_argument("invalid val output");

--- a/src/machine-c-api.h
+++ b/src/machine-c-api.h
@@ -739,6 +739,17 @@ CM_API int cm_read_virtual_memory(const cm_machine *m, uint64_t address, unsigne
 CM_API int cm_write_virtual_memory(cm_machine *m, uint64_t address, const unsigned char *data, size_t length,
     char **err_msg);
 
+/// \brief Translates a virtual memory address to its corresponding physical memory address.
+/// \param m Pointer to valid machine instance
+/// \param vaddr Virtual address to translate.
+/// \param paddr Receives the physical memory address.
+/// \param err_msg Receives the error message if function execution fails
+/// or NULL in case of successful function execution. In case of failure error_msg
+/// must be deleted by the function caller using cm_delete_cstring.
+/// err_msg can be NULL, meaning the error message won't be received.
+/// \returns 0 for success, non zero code for error
+CM_API int cm_translate_virtual_address(cm_machine *m, uint64_t vaddr, uint64_t *paddr, char **err_msg);
+
 /// \brief Reads the value of a general-purpose register.
 /// \param m Pointer to valid machine instance
 /// \param i Register index. Between 0 and X_REG_COUNT-1, inclusive.

--- a/src/machine.h
+++ b/src/machine.h
@@ -408,6 +408,11 @@ public:
     /// \param length Size of chunk.
     void write_virtual_memory(uint64_t vaddr_start, const unsigned char *data, size_t length);
 
+    /// \brief Translates a virtual memory address to its corresponding physical memory address.
+    /// \param vaddr Virtual address to translate.
+    /// \returns The corresponding physical address.
+    uint64_t translate_virtual_address(uint64_t vaddr);
+
     /// \brief Reads the value of a general-purpose register.
     /// \param index Register index. Between 0 and X_REG_COUNT-1, inclusive.
     /// \returns The value of the register.

--- a/src/virtual-machine.cpp
+++ b/src/virtual-machine.cpp
@@ -76,6 +76,10 @@ void virtual_machine::do_write_virtual_memory(uint64_t address, const unsigned c
     m_machine->write_virtual_memory(address, data, length);
 }
 
+uint64_t virtual_machine::do_translate_virtual_address(uint64_t vaddr) const {
+    return m_machine->translate_virtual_address(vaddr);
+}
+
 uint64_t virtual_machine::do_read_x(int i) const {
     return m_machine->read_x(i);
 }

--- a/src/virtual-machine.h
+++ b/src/virtual-machine.h
@@ -51,6 +51,7 @@ private:
     void do_write_memory(uint64_t address, const unsigned char *data, size_t length) override;
     void do_read_virtual_memory(uint64_t address, unsigned char *data, uint64_t length) const override;
     void do_write_virtual_memory(uint64_t address, const unsigned char *data, size_t length) override;
+    uint64_t do_translate_virtual_address(uint64_t vaddr) const override;
     uint64_t do_read_x(int i) const override;
     void do_write_x(int i, uint64_t val) override;
     uint64_t do_read_f(int i) const override;

--- a/tests/misc/test-machine-c-api.cpp
+++ b/tests/misc/test-machine-c-api.cpp
@@ -1002,6 +1002,12 @@ BOOST_FIXTURE_TEST_CASE_NOLINT(read_write_virtual_memory_basic_test, ordinary_ma
     BOOST_REQUIRE_EQUAL(err_msg, nullptr);
     memcpy(&read_value, read_data.data(), read_data.size());
     BOOST_CHECK_EQUAL(read_value, write_value);
+
+    uint64_t paddr = 0;
+    error_code = cm_translate_virtual_address(_machine, address, &paddr, &err_msg);
+    BOOST_REQUIRE_EQUAL(error_code, CM_ERROR_OK);
+    BOOST_REQUIRE_EQUAL(err_msg, nullptr);
+    BOOST_REQUIRE_EQUAL(paddr, address);
 }
 
 BOOST_FIXTURE_TEST_CASE_NOLINT(read_write_virtual_memory_scattered_data, ordinary_machine_fixture) {


### PR DESCRIPTION
This PR adds a new function to the public C API:

1. `cm_translate_virtual_address` - Translates a virtual memory address to its corresponding physical memory address

The use case is to debug address translation from outside, this function was exposed to Lua and JSONRPC.