### PR TITLE
ci: speed up uarch testing in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Run test suite with microarchitecture and host based interpreters comparing machine hashes at every step
         run: |
-          docker run --rm -t ${{ github.repository_owner }}/machine-emulator:tests cartesi-machine-tests  --test="^rv64ui.*$" --jobs=$(nproc) run_host_and_uarch
+          docker run --rm -t ${{ github.repository_owner }}/machine-emulator:tests cartesi-machine-tests --concurrency=update_merkle_tree:1 --test="^rv64ui.*$" --jobs=$(nproc) run_host_and_uarch
 
       - name: Create uarch json logs to be used to test the Solidity based microarchitecture interpreter
         run: |


### PR DESCRIPTION
This should make the step "Run test suite with microarchitecture and host based interpreters comparing machine hashes at every step" about ~20 minutes faster.

Before this change, 8 tests were being executed in parallel, each one with 8 threads for root hash computation, making the machine use 64 threads on a 8 core machine, not ideal. With this change only 8 threads will be working, speeding up the CI a little.
