### PR TITLE
Fix JSONRPC connection issues on edge cases

### DIFF
--- a/src/jsonrpc-remote-machine.cpp
+++ b/src/jsonrpc-remote-machine.cpp
@@ -539,6 +539,8 @@ static json jsonrpc_shutdown_handler(const json &j, mg_connection *con, http_han
     jsonrpc_check_no_params(j);
     con->is_draining = 1;
     con->data[0] = 'X';
+    // Mark listen connection to be closed immediately so its port can be reused in subsequent rebind call
+    h->listen_connection->is_closing = 1;
     return jsonrpc_response_ok(j);
 }
 

--- a/src/jsonrpc-virtual-machine.cpp
+++ b/src/jsonrpc-virtual-machine.cpp
@@ -59,7 +59,6 @@ struct http_request_data {
 
 // Performs additional client socket configuration
 static void setup_client_socket(struct mg_connection *c) {
-#if defined(__APPLE__)
 #if defined(SO_LINGER)
     // Minimize socket close time by setting the linger time to 0.
     // On macOS, it avoids accumulating socket in TIME_WAIT state, after rapid successive requests, which can consume
@@ -72,7 +71,6 @@ static void setup_client_socket(struct mg_connection *c) {
     auto socket = static_cast<MG_SOCKET_TYPE>(reinterpret_cast<size_t>(c->fd));
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     (void) setsockopt(socket, SOL_SOCKET, SO_LINGER, reinterpret_cast<char *>(&so_linger), sizeof(so_linger));
-#endif
 #endif
 }
 


### PR DESCRIPTION
This will fix hard to happen problems when:
- Doing `shutdown()` followed by a `rebind()` with JSON-RPC.
- Connection TIME_WAIT accumulation when doing thousands of snapshots per second.
