### PR TITLE
fix: allow saving snapshots on first machine yield

### DIFF
--- a/src/virtual-machine.cpp
+++ b/src/virtual-machine.cpp
@@ -469,7 +469,7 @@ void virtual_machine::do_snapshot(void) {
 }
 
 void virtual_machine::do_commit(void) {
-    throw std::runtime_error("commit is not supported");
+    // no-op, we are always committed
 }
 
 void virtual_machine::do_rollback(void) {


### PR DESCRIPTION
This will allows saving local machine snapshots on first yield. This usually worked without any special cli flag, but in the last release only works with `--no-rollback`, this PR make it work as before again.