### PR TITLE
Use keep alive connection for JSONRPC client

### DIFF
--- a/src/jsonrpc-remote-machine.cpp
+++ b/src/jsonrpc-remote-machine.cpp
@@ -669,7 +669,6 @@ static json jsonrpc_fork_handler(const json &j, mg_connection *con, http_handler
 /// \details Changes the address the server is listening to.
 /// After this call, all new connections should be established using the new server address.
 static json jsonrpc_rebind_handler(const json &j, mg_connection *con, http_handler_data *h) {
-    (void) con;
     static const char *param_name[] = {"address"};
     auto args = parse_args<std::string>(j, param_name);
     const std::string new_server_address = std::get<0>(args);
@@ -678,6 +677,8 @@ static json jsonrpc_rebind_handler(const json &j, mg_connection *con, http_handl
     if (!new_listen_connection) {
         return jsonrpc_response_server_error(j, "rebind failed listening on "s + new_server_address);
     }
+    // Mark connection to be drained
+    con->is_draining = 1;
     // Mark previous listen connection to be closed
     h->listen_connection->is_closing = 1;
     // Set the new listen connection
@@ -1784,7 +1785,6 @@ static json jsonrpc_machine_verify_send_cmio_response_state_transition_handler(c
 /// \param j JSON response object
 void jsonrpc_http_reply(mg_connection *con, http_handler_data *h, const json &j) {
     SLOG(trace) << h->server_address << " response is " << j.dump().data();
-    con->is_draining = 1;
     return mg_http_reply(con, 200, "Access-Control-Allow-Origin: *\r\nContent-Type: application/json\r\n", "%s",
         j.dump().data());
 }
@@ -1793,7 +1793,6 @@ void jsonrpc_http_reply(mg_connection *con, http_handler_data *h, const json &j)
 /// \param con Mongoose connection
 void jsonrpc_send_empty_reply(mg_connection *con, http_handler_data *h) {
     SLOG(trace) << h->server_address << " response is empty";
-    con->is_draining = 1;
     return mg_http_reply(con, 200, "Access-Control-Allow-Origin: *\r\nContent-Type: application/json\r\n", "");
 }
 

--- a/src/virtual-machine.cpp
+++ b/src/virtual-machine.cpp
@@ -469,7 +469,7 @@ void virtual_machine::do_snapshot(void) {
 }
 
 void virtual_machine::do_commit(void) {
-    throw std::runtime_error("commit is not supported");
+    // no-op, we are always committed
 }
 
 void virtual_machine::do_rollback(void) {


### PR DESCRIPTION
This PR optimizes JSONRPC remote machine client to use keep alive connections when performing subsequent requests. This is an optimization that increases the amount of request throughput we can perform via remote machines, and also fixes possible issues about exhausting the amount of available client ports for an OS that does not support SO_LINGER socket workaround.

The SO_LINGER workaround is still available in the code, because it is still very useful when performing thousands of fork requests per second, where we cannot make full use of keep alive connections.

The improvement of performance is almost 2x, for instance, for the following loop:

```lua
  while true do
    machine:read_mcycle()
  end
```

These are the statistics in number of iterations per second:
```
JSONRPC (before this PR)  52500 req/s
JSONRPC ( after this PR)  95105 req/s
local                     19699651 req/s
```

Therefore this is about +81% of throughput improvement, still way below local machines, but fair enough.

## Depends on

- https://github.com/cartesi/machine-emulator/pull/234