### PR TITLE
Add support for snapshot/rollback in local machines

### DIFF
--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -2106,10 +2106,7 @@ if gdb_address then
 end
 if config.processor.iunrep ~= 0 then stderr("Running in unreproducible mode!\n") end
 if store_config == stderr then store_machine_config(config, stderr) end
-if cmio_advance or cmio_inspect then
-    check_cmio_htif_config(config.htif)
-    assert(remote_address or not perform_rollbacks, "cmio requires --remote-address for snapshot/commit/rollback")
-end
+if cmio_advance or cmio_inspect then check_cmio_htif_config(config.htif) end
 if initial_hash then
     assert(config.processor.iunrep == 0, "hashes are meaningless in unreproducible mode")
     print_root_hash(machine, stderr_unsilenceable)

--- a/src/machine-state.h
+++ b/src/machine-state.h
@@ -44,16 +44,16 @@ struct unpacked_iflags {
 /// \brief Machine state.
 /// \details The machine_state structure contains the entire
 /// state of a Cartesi machine.
-struct machine_state {
-
-    ~machine_state() {
-        ;
-    } // Due to bug in clang++
-
-    /// \brief No copy or move constructor or assignment
-    machine_state(const machine_state &other) = delete;
+struct machine_state final {
+    /// \brief Destructor
+    ~machine_state() = default;
+    /// \brief Copy constructor
+    machine_state(const machine_state &other) = default;
+    /// \brief No move constructor
     machine_state(machine_state &&other) = delete;
+    /// \brief No copy assignment
     machine_state &operator=(const machine_state &other) = delete;
+    /// \brief No move assignment
     machine_state &operator=(machine_state &&other) = delete;
 
     // The following state fields are very hot,

--- a/src/machine.h
+++ b/src/machine.h
@@ -72,6 +72,9 @@ private:
     static const pma_entry::flags m_cmio_rx_buffer_flags; ///< PMA flags used for cmio rx buffer
     static const pma_entry::flags m_cmio_tx_buffer_flags; ///< PMA flags used for cmio tx buffer
 
+    /// \brief Build PMA list from machine state and uarch machine state.
+    void build_pma_list();
+
     /// \brief Allocates a new PMA entry.
     /// \param pma PMA entry to add to machine.
     /// \returns Reference to corresponding entry in machine state.
@@ -186,8 +189,8 @@ public:
 
     /// \brief No default constructor
     machine(void) = delete;
-    /// \brief No copy constructor
-    machine(const machine &other) = delete;
+    /// \brief Copy constructor
+    machine(const machine &other);
     /// \brief No move constructor
     machine(machine &&other) = delete;
     /// \brief No copy assignment

--- a/src/os.h
+++ b/src/os.h
@@ -88,11 +88,22 @@ void os_putchars(const uint8_t *data, size_t len);
 /// \brief Creates a new directory
 int os_mkdir(const char *path, int mode);
 
-/// \brief Maps a file to memory
-unsigned char *os_map_file(const char *path, uint64_t length, bool shared);
+/// \brief Mapped memory entry
+struct mmapd {
+    unsigned char *host_memory = nullptr; ///< Start of associated memory region in host.
+    uint64_t length = 0;                  ///< Length of memory range (copy of PMA length field).
+    int backing_file = -1;                ///< File descriptor backing the memory
+    bool shared = false;                  ///< True when the memory is shared with the file descriptor
+};
 
-/// \brief Unmaps a file from memory
-void os_unmap_file(unsigned char *host_memory, uint64_t length);
+/// \brief Maps memory
+mmapd os_mmap_mem(uint64_t length);
+
+/// \brief Maps memory from a file
+mmapd os_mmap_file(const char *path, uint64_t length, bool shared);
+
+/// \brief Unmaps memory
+void os_munmap(const mmapd &m);
 
 /// \brief Get time elapsed since its first call with microsecond precision
 int64_t os_now_us();

--- a/src/uarch-machine.h
+++ b/src/uarch-machine.h
@@ -40,8 +40,8 @@ public:
 
     /// \brief No default constructor
     uarch_machine(void) = delete;
-    /// \brief No copy constructor
-    uarch_machine(const uarch_machine &other) = delete;
+    /// \brief Copy constructor
+    uarch_machine(const uarch_machine &other) = default;
     /// \brief No move constructor
     uarch_machine(uarch_machine &&other) = delete;
     /// \brief No copy assignment

--- a/src/uarch-state.h
+++ b/src/uarch-state.h
@@ -28,15 +28,16 @@
 
 namespace cartesi {
 
-struct uarch_state {
-    ~uarch_state() {
-        ;
-    }
-
-    /// \brief No copy or move constructor or assignment
-    uarch_state(const uarch_state &other) = delete;
+struct uarch_state final {
+    /// \brief Destructor
+    ~uarch_state() = default;
+    /// \brief Copy constructor
+    uarch_state(const uarch_state &other) = default;
+    /// \brief No move constructor
     uarch_state(uarch_state &&other) = delete;
+    /// \brief No copy assignment
     uarch_state &operator=(const uarch_state &other) = delete;
+    /// \brief No move assignment
     uarch_state &operator=(uarch_state &&other) = delete;
 
     uint64_t pc;                               ///< Program counter.

--- a/src/virtual-machine.h
+++ b/src/virtual-machine.h
@@ -28,6 +28,7 @@ namespace cartesi {
 class virtual_machine : public i_virtual_machine {
     using machine = cartesi::machine;
     machine *m_machine;
+    machine *m_forked_machine = nullptr;
 
 public:
     virtual_machine(const machine_config &c, const machine_runtime_config &r = {});

--- a/tests/misc/test-machine-c-api.cpp
+++ b/tests/misc/test-machine-c-api.cpp
@@ -1592,29 +1592,24 @@ BOOST_AUTO_TEST_CASE_NOLINT(snapshot_null_machine_test) {
     BOOST_CHECK_EQUAL(error_code, CM_ERROR_INVALID_ARGUMENT);
 }
 
-BOOST_FIXTURE_TEST_CASE_NOLINT(snapshot_basic_test, ordinary_machine_fixture) {
+BOOST_FIXTURE_TEST_CASE_NOLINT(snapshot_rollback_basic_test, ordinary_machine_fixture) {
     char *err_msg = nullptr;
     int error_code = cm_snapshot(_machine, &err_msg);
-    std::string result = err_msg;
-    std::string origin("snapshot is not supported");
-    BOOST_CHECK_EQUAL(error_code, CM_ERROR_RUNTIME_ERROR);
-    BOOST_CHECK_EQUAL(origin, result);
-    cm_delete_cstring(err_msg);
+    BOOST_CHECK_EQUAL(error_code, CM_ERROR_OK);
+    BOOST_CHECK_EQUAL(err_msg, nullptr);
+    error_code = cm_rollback(_machine, &err_msg);
+    BOOST_CHECK_EQUAL(error_code, CM_ERROR_OK);
+    BOOST_CHECK_EQUAL(err_msg, nullptr);
 }
 
-BOOST_AUTO_TEST_CASE_NOLINT(rollback_null_machine_test) {
-    int error_code = cm_rollback(nullptr, nullptr);
-    BOOST_CHECK_EQUAL(error_code, CM_ERROR_INVALID_ARGUMENT);
-}
-
-BOOST_FIXTURE_TEST_CASE_NOLINT(rollback_basic_test, ordinary_machine_fixture) {
+BOOST_FIXTURE_TEST_CASE_NOLINT(snapshot_commit_basic_test, ordinary_machine_fixture) {
     char *err_msg = nullptr;
-    int error_code = cm_rollback(_machine, &err_msg);
-    std::string result = err_msg;
-    std::string origin("rollback is not supported");
-    BOOST_CHECK_EQUAL(error_code, CM_ERROR_RUNTIME_ERROR);
-    BOOST_CHECK_EQUAL(origin, result);
-    cm_delete_cstring(err_msg);
+    int error_code = cm_snapshot(_machine, &err_msg);
+    BOOST_CHECK_EQUAL(error_code, CM_ERROR_OK);
+    BOOST_CHECK_EQUAL(err_msg, nullptr);
+    error_code = cm_commit(_machine, &err_msg);
+    BOOST_CHECK_EQUAL(error_code, CM_ERROR_OK);
+    BOOST_CHECK_EQUAL(err_msg, nullptr);
 }
 
 BOOST_AUTO_TEST_CASE_NOLINT(read_x_null_machine_test) {


### PR DESCRIPTION
This is an experimental PR adding support for performing snapshot/rollback on local machines. Making the APIs available in Windows and WASM. It uses the naive implementation of duplicating the whole machine memory.

This PR does not try to optimize this operation to compete with JSONRPC `fork()`, it just provides the naive implementation that will work on any system.

## TODO
- [ ] add lua tests
- [ ] make deep copy of merkle tree and use it
- [ ] avoid deep copy of read only PMAs and design a way to share them between multiple machines
  - [ ] introduce read only flash drives, so we can avoid copying them, useful for machines with read-only rootfs
- [ ] optimize Windows memory map to not use calloc
- [ ] add disable CMIO option again, so we don't have to deep copy them on WASM
- [ ] add fork method to machine C API?

## Benchmark

To comparise the of performance of `local` vs `jsonrpc` machines, I tested booting the last release of tools rootfs tanking random roollbacks:

```lua
math.randomseed(0)
while not machine:read_iflags_H() do
    machine:snapshot()
    machine:run(machine:read_mcycle() + 1000)
    if math.random() < 0.3 then
        machine:rollback()
    else
        machine:commit()
    end
end
```

This is the result:
```
local       67 iterations/s
jsonrpc    895 iterations/s
```

Therefore `jsonrpc` is about 13x times faster than `local`, the performance for local would be even worse from bigger machines.
