### PR TITLE
fix: update makefile to make it compatible with a homebrew formulae

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,27 +66,30 @@ CXX=clang++
 AR=libtool -static -o
 INCS=
 
+BREW_PREFIX=$(shell which brew)
+PORT_PREFIX=$(shell which port)
+
 ifeq ($(MACOSX_DEPLOYMENT_TARGET),)
 export MACOSX_DEPLOYMENT_TARGET := $(shell sw_vers -productVersion | sed -E "s/([[:digit:]]+)\.([[:digit:]]+)\..+/\1.\2.0/")
 endif
 
 # Homebrew installation
-ifneq (,$(shell which brew))
-BREW_PREFIX = $(shell brew --prefix)
+ifneq (,$(BREW_PREFIX))
 BOOST_LIB_DIR=-L$(BREW_PREFIX)/lib
 BOOST_INC=-I$(BREW_PREFIX)/include
 SLIRP_LIB=-L$(BREW_PREFIX)/lib -lslirp
 SLIRP_INC=-I$(BREW_PREFIX)/libslirp/include
 
 # Macports installation
-else ifneq (,$(shell which port))
-PORT_PREFIX = /opt/local
-BOOST_LIB_DIR=-L$(PORT_PREFIX)/libexec/boost/1.81/lib
-BOOST_INC=-I$(PORT_PREFIX)/libexec/boost/1.81/include
-SLIRP_LIB=-L$(PORT_PREFIX)/lib -lslirp
-SLIRP_INC=-I$(PORT_PREFIX)/include
+else ifneq (,$(PORT_PREFIX))
+INSTALL_PREFIX=/opt/local
+BOOST_LIB_DIR=-L$(INSTALL_PREFIX)/libexec/boost/1.81/lib
+BOOST_INC=-I$(INSTALL_PREFIX)/libexec/boost/1.81/include
+SLIRP_LIB=-L$(INSTALL_PREFIX)/lib -lslirp
+SLIRP_INC=-I$(INSTALL_PREFIX)/include
+
 else
-$(error Neither Homebrew nor MacPorts is installed)
+$(warning Neither Homebrew nor MacPorts prefix found)
 endif
 
 LIBCARTESI=libcartesi-$(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR).dylib


### PR DESCRIPTION
This fix makes our Makefile compatible with Homebrew formulae. Below is an explanation of the patch:

1. During the processing of a formula by Homebrew, `$(brew --prefix)/bin` is not included in the `PATH`, resulting in an empty result for which brew. To address this issue, I propose allowing manual setting of `BREW_PREFIX`. This manual approach will be utilized in the formula: `system "make", "BREW_PREFIX=#{prefix}"`. The flow of `PORT_PREFIX` was changed for consistency.
1. During the execution of `make install`, [a couple of targets from src/Makefile](https://github.com/cartesi/machine-emulator/blob/1837a0ce12997eec802460662fcb0c3ae991ac0a/Makefile#L23) are used for version generation. When make install is invoked from the context of Homebrew formula installation, `BREW_PREFIX` is empty, causing the installation process to abort with the message `Neither Homebrew nor MacPorts is installed`. I propose changing error to warning here. This will prevent the process from aborting, making the user responsible for not specifying a prefix. Considering that this aspect is intended for developers only, I believe this approach is adequate.