### PR TITLE
chore: compile in release mode with debug info by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           cache-from: type=gha,scope=debian
           cache-to: type=gha,mode=max,scope=debian
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
           project: ${{ vars.DEPOT_PROJECT }}
@@ -63,7 +63,7 @@ jobs:
           cache-from: type=gha,scope=debian
           cache-to: type=gha,mode=max,scope=debian
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
           project: ${{ vars.DEPOT_PROJECT }}
@@ -85,7 +85,7 @@ jobs:
           cache-from: type=gha,scope=debian
           cache-to: type=gha,mode=max,scope=debian
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
           project: ${{ vars.DEPOT_PROJECT }}
@@ -148,7 +148,7 @@ jobs:
           cache-from: type=gha,scope=debian
           cache-to: type=gha,mode=max,scope=debian
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
           project: ${{ vars.DEPOT_PROJECT }}
@@ -166,7 +166,7 @@ jobs:
           cache-from: type=gha,scope=debian
           cache-to: type=gha,mode=max,scope=debian
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
           project: ${{ vars.DEPOT_PROJECT }}
@@ -182,7 +182,7 @@ jobs:
           push: false
           load: true
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
 
       - name: Simple boot inside the docker image
@@ -255,7 +255,7 @@ jobs:
           push: false
           load: true
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
 
       - name: Test microarchitecture interpreter
@@ -319,7 +319,7 @@ jobs:
           cache-from: type=gha,scope=debian
           cache-to: type=gha,mode=max,scope=debian
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
           project: ${{ vars.DEPOT_PROJECT }}
@@ -337,7 +337,7 @@ jobs:
           cache-from: type=gha,scope=debian
           cache-to: type=gha,mode=max,scope=debian
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
           project: ${{ vars.DEPOT_PROJECT }}
@@ -353,7 +353,7 @@ jobs:
           push: false
           load: true
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
 
       - name: Simple boot inside the docker image
@@ -413,7 +413,7 @@ jobs:
           push: false
           load: true
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
 
       - name: Test microarchitecture interpreter
@@ -472,7 +472,7 @@ jobs:
           cache-from: type=gha,scope=debian
           cache-to: type=gha,mode=max,scope=debian
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
           project: ${{ vars.DEPOT_PROJECT }}
@@ -536,7 +536,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=debian-coverage
           build-args: |
             GIT_COMMIT=${GITHUB_SHA}
-            RELEASE=no
+            DEBUG=yes
             COVERAGE=yes
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
           project: ${{ vars.DEPOT_PROJECT }}
@@ -553,7 +553,7 @@ jobs:
           push: false
           load: true
           build-args: |
-            RELEASE=no
+            DEBUG=yes
             COVERAGE=yes
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
 
@@ -617,7 +617,7 @@ jobs:
           cache-from: type=gha,scope=debian-sanitize
           cache-to: type=gha,mode=max,scope=debian-sanitize
           build-args: |
-            RELEASE=no
+            DEBUG=yes
             GIT_COMMIT=${GITHUB_SHA}
             SANITIZE=yes
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
@@ -635,7 +635,7 @@ jobs:
           push: false
           load: true
           build-args: |
-            RELEASE=no
+            DEBUG=yes
             SANITIZE=yes
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
 
@@ -697,7 +697,7 @@ jobs:
           cache-from: type=gha,scope=debian
           cache-to: type=gha,mode=max,scope=debian
           build-args: |
-            RELEASE=${{ (startsWith(github.ref, 'refs/tags/v') && 'yes' || 'no') }}
+            DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
             MACHINE_EMULATOR_VERSION=${{ env.MACHINE_EMULATOR_VERSION }}
           project: ${{ vars.DEPOT_PROJECT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=$TARGETPLATFORM cartesi/toolchain:0.17.0-rv64ima-lp64 as linux-env
 ARG GIT_COMMIT=""
-ARG RELEASE=no
+ARG DEBUG=no
 ARG COVERAGE=no
 ARG SANITIZE=no
 
@@ -36,7 +36,7 @@ COPY third-party third-party
 FROM --platform=$TARGETPLATFORM dep-builder as builder
 
 COPY . .
-RUN make -j$(nproc) git_commit=$GIT_COMMIT release=$RELEASE coverage=$COVERAGE sanitize=$SANITIZE
+RUN make -j$(nproc) git_commit=$GIT_COMMIT debug=$DEBUG coverage=$COVERAGE sanitize=$SANITIZE
 
 FROM --platform=$TARGETPLATFORM builder as debian-packager
 ARG MACHINE_EMULATOR_VERSION=0.0.0

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Both `libcartesi` and `libcartes_jsonrpc` C libraries can be compiled in standal
 
 ```bash
 make bundle-boost
-make -C src release=yes libcartesi.a libcartesi_jsonrpc.a libcartesi.so libcartesi_jsonrpc.so
+make -C src libcartesi.a libcartesi_jsonrpc.a libcartesi.so libcartesi_jsonrpc.so
 ```
 
 The `.a` and `.so` files will be available in `src` directory, you can use any of them to link your application.
@@ -155,17 +155,17 @@ You can even use other toolchains to cross compile targeting other platforms:
 
 ```bash
 # Target WASM with Emscripten toolchain
-make -C src release=yes \
+make -C src \
   CC=emcc CXX=em++ AR="emar rcs" \
   libcartesi.a
 
 # Target WASM with WASI SDK toolchain
-make -C src release=yes \
+make -C src \
   CC=/opt/wasi-sdk/bin/clang CXX=/opt/wasi-sdk/bin/clang++ AR="/opt/wasi-sdk/bin/llvm-ar rcs" \
   libcartesi.a
 
 # Target Windows with mingw-w64 toolchain
-make -C src release=yes \
+make -C src \
   CC=x86_64-w64-mingw32-gcc \
   CXX=x86_64-w64-mingw32-g++ \
   AR="x86_64-w64-mingw32-ar rcs" \

--- a/src/Makefile
+++ b/src/Makefile
@@ -93,11 +93,9 @@ else
 $(warning Neither Homebrew nor MacPorts prefix found)
 endif
 
-LIBCARTESI=libcartesi-$(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR).dylib
+SO_EXT=dylib
 LIBCARTESI_LDFLAGS=-install_name '@rpath/$(LIBCARTESI)'
-LIBCARTESI_MERKLE_TREE=libcartesi_merkle_tree-$(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR).dylib
 LIBCARTESI_MERKLE_TREE_LDFLAGS=-install_name '@rpath/$(LIBCARTESI_MERKLE_TREE)'
-LIBCARTESI_JSONRPC=libcartesi_jsonrpc-$(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR).dylib
 LIBCARTESI_JSONRPC_LDFLAGS=-install_name '@rpath/$(LIBCARTESI_JSONRPC)'
 PROFILE_DATA=default.profdata
 
@@ -119,15 +117,17 @@ INCS=
 BOOST_INC=
 SLIRP_INC=
 SLIRP_LIB=-lslirp
-LIBCARTESI=libcartesi-$(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR).so
+SO_EXT=so
 LIBCARTESI_LDFLAGS=
-LIBCARTESI_MERKLE_TREE=libcartesi_merkle_tree-$(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR).so
 LIBCARTESI_MERKLE_TREE_LDFLAGS=
-LIBCARTESI_JSONRPC=libcartesi_jsonrpc-$(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR).so
 LIBCARTESI_JSONRPC_LDFLAGS=
 PROFILE_DATA=
 
 endif
+
+LIBCARTESI=libcartesi-$(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR).$(SO_EXT)
+LIBCARTESI_MERKLE_TREE=libcartesi_merkle_tree-$(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR).$(SO_EXT)
+LIBCARTESI_JSONRPC=libcartesi_jsonrpc-$(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR).$(SO_EXT)
 
 ifeq ($(slirp),yes)
 # Workaround for building with macports lua-luarocks installation
@@ -308,7 +308,7 @@ SOLDFLAGS+=$(MYSOLDFLAGS)
 LIBLDFLAGS+=$(MYLIBLDFLAGS)
 EXELDFLAGS+=$(MYEXELDFLAGS)
 
-all: libcartesi.a libcartesi_merkle_tree.a libcartesi_jsonrpc.a c-api luacartesi jsonrpc-remote-cartesi-machine hash
+all: libcartesi libcartesi_merkle_tree libcartesi_jsonrpc c-api luacartesi jsonrpc-remote-cartesi-machine hash
 
 luacartesi: cartesi.so cartesi/jsonrpc.so
 
@@ -425,12 +425,15 @@ version:
 so-version:
 	@echo $(EMULATOR_VERSION_MAJOR).$(EMULATOR_VERSION_MINOR)
 
-libcartesi: libcartesi.a $(LIBCARTESI)
-libcartesi.so: $(LIBCARTESI) $(LIBCARTESI_MERKLE_TREE)
-libcartesi_merkle_tree: libcartesi_merkle_tree.a $(LIBCARTESI_MERKLE_TREE)
-libcartesi_merkle_tree.so: $(LIBCARTESI_MERKLE_TREE)
-libcartesi_jsonrpc: libcartesi_jsonrpc.a $(LIBCARTESI_JSONRPC)
-libcartesi_jsonrpc.so: $(LIBCARTESI_JSONRPC)
+libcartesi: libcartesi.a libcartesi.$(SO_EXT)
+libcartesi.$(SO_EXT): $(LIBCARTESI) $(LIBCARTESI_MERKLE_TREE)
+	ln -sf $< $@
+libcartesi_merkle_tree: libcartesi_merkle_tree.a libcartesi_merkle_tree.$(SO_EXT)
+libcartesi_merkle_tree.$(SO_EXT): $(LIBCARTESI_MERKLE_TREE)
+	ln -sf $< $@
+libcartesi_jsonrpc: libcartesi_jsonrpc.a libcartesi_jsonrpc.$(SO_EXT)
+libcartesi_jsonrpc.$(SO_EXT): $(LIBCARTESI_JSONRPC)
+	ln -sf $< $@
 
 libcartesi.a: $(LIBCARTESI_OBJS)
 	$(AR) $@ $^

--- a/src/Makefile
+++ b/src/Makefile
@@ -175,16 +175,22 @@ DEFS+=-DDUMP_HIST
 #DEFS+=-DDUMP_COUNTERS
 endif
 
+# By default we compile in release with debug information,
+# so the emulator is packaged correctly by default.
+ifeq (,$(filter yes,$(relwithdebinfo) $(release) $(debug) $(sanitize)))
+relwithdebinfo=yes
+endif
+
 ifeq ($(relwithdebinfo),yes)
 OPTFLAGS+=-O2 -g
+INTERPRET_CXXFLAGS+=-DNDEBUG # disable asserts only for interpret.cpp
 else ifeq ($(release),yes)
 OPTFLAGS+=-O2
+DEFS+=-DNDEBUG # disable all asserts
 else ifeq ($(debug),yes)
 OPTFLAGS+=-Og -g
 else ifeq ($(sanitize),yes)
-OPTFLAGS+=-Og -g
-else
-OPTFLAGS+=-O2 -g
+OPTFLAGS+=-O1 -g
 endif
 
 # Git commit hash (for releases)
@@ -192,19 +198,21 @@ ifneq ($(git_commit),)
 DEFS+=-DGIT_COMMIT='"$(git_commit)"'
 endif
 
-# Optimization flags
+# The SHA3 is third party library we always want to compile with O3
+SHA3_CFLAGS=-O3
+
+# Optimization flags for the interpreter
 ifneq (,$(filter yes,$(relwithdebinfo) $(release)))
-DEFS+=-DNDEBUG
 ifneq (,$(filter gcc,$(CC)))
 # The following flag helps GCC to eliminate more redundant computations in the interpret loop,
 # saving some host instructions and improving performance.
 # This flag is usually enabled by default at -O3,
 # but we don't use -O3 because it enables some other flags that are not worth for the interpreter.
-OPTFLAGS+=-fgcse-after-reload -fpredictive-commoning -fsplit-paths -ftree-partial-pre
+INTERPRET_CXXFLAGS+=-fgcse-after-reload -fpredictive-commoning -fsplit-paths -ftree-partial-pre
 endif
 # Disable jump tables, because it degrades the instruction decoding performance in the interpret loop,
 # since it generates a memory indirection that has a high cost in opcode switches.
-OPTFLAGS+=-fno-jump-tables
+INTERPRET_CXXFLAGS+=-fno-jump-tables
 endif
 
 # Link time optimizations
@@ -526,13 +534,16 @@ jsonrpc-discover.cpp: jsonrpc-discover.json
 	@touch $@
 
 sha3.o: ../third-party/tiny_sha3/sha3.c
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CC) $(CFLAGS) $(SHA3_CFLAGS) -c -o $@ $<
 
 uarch-pristine-ram.o: $(UARCH_PRISTINE_RAM_C)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 uarch-pristine-hash.o: $(UARCH_PRISTINE_HASH_C)
 	$(CC) $(CFLAGS) -c -o $@ $<
+
+interpret.o: interpret.cpp machine-c-version.h
+	$(CXX) $(CXXFLAGS) $(INTERPRET_CXXFLAGS) -c -o $@ $<
 
 %.o: %.cpp machine-c-version.h
 	$(CXX) $(CXXFLAGS) -c -o $@ $<

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,6 @@
 ARG TAG=devel
 FROM --platform=$TARGETPLATFORM cartesi/toolchain:0.17.0 as machine-tests-builder
-ARG RELEASE=no
+ARG DEBUG=no
 ARG COVERAGE=no
 ARG SANITIZE=no
 
@@ -8,16 +8,16 @@ COPY . /usr/src/emulator
 
 WORKDIR /usr/src/emulator
 
-RUN make -j$(nproc) build-tests-machine release=$RELEASE coverage=$COVERAGE sanitize=$SANITIZE
+RUN make -j$(nproc) build-tests-machine debug=$DEBUG coverage=$COVERAGE sanitize=$SANITIZE
 
 FROM --platform=$TARGETPLATFORM cartesi/machine-emulator:builder as tests-builder
-ARG RELEASE=no
+ARG DEBUG=no
 ARG COVERAGE=no
 ARG SANITIZE=no
 
 COPY --from=machine-tests-builder /usr/src/emulator/tests/build/machine /usr/src/emulator/tests/build/machine
 
-RUN make -j$(nproc) build-tests-misc build-tests-uarch build-tests-images release=$RELEASE coverage=$COVERAGE sanitize=$SANITIZE
+RUN make -j$(nproc) build-tests-misc build-tests-uarch build-tests-images debug=$DEBUG coverage=$COVERAGE sanitize=$SANITIZE
 
 FROM tests-builder as tests-debian-packager
 ARG MACHINE_EMULATOR_VERSION=0.0.0

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -189,7 +189,7 @@ test-uarch:
 	$(LUA) ./lua/cartesi-machine-tests.lua --jobs=$(NUM_JOBS) run_uarch
 
 test-uarch-compare:
-	$(LUA) ./lua/cartesi-machine-tests.lua --test="^rv64ui.*$$" --jobs=$(NUM_JOBS) run_host_and_uarch
+	$(LUA) ./lua/cartesi-machine-tests.lua --test="^rv64ui.*$$" --concurrency=update_merkle_tree:1 --jobs=$(NUM_JOBS) run_host_and_uarch
 
 test-uarch-rv64ui:
 	$(LUA) ./lua/uarch-riscv-tests.lua run


### PR DESCRIPTION
This PR switch the default compilation from release with asserts enabled for everything, to release with debug information with asserts disabled only for `interpret.cpp`. This makes sure people will compile an efficient emulator with just `make` when packaging by default, not requiring the use of `make relwithdebinfo=yes` or `make release=yes` anymore when packaging.

The default make is chosen to contain debug information because some distros may want to strip and move the debug information into a second debug package (for example ArchLinux does this).

Change were mades in CI to always test with debug information, except for tagged releases.

**IMPORTANT:** After this PR, if you want to compile with asserts for `interpret.cpp`, please compile with `make debug=yes`, this is something only emulator developers care.

## PR main changes
- Compile `interpret.cpp` with `-DNDEBUG` for release/relwithdebinfo modes
- Compile with `relwithdebinfo=yes` by default, but use `debug=yes` for CI tests
- Always compile `sha3.c` (third party source) with `-O3` to speed up ci
- Use `-O1` optimizations on sanitize action to make CI faster
- Add `libcartesi.so` symlinks in `src`, to make linkage on external programs dependent on in-development emulator straightforward