### PR TITLE
fix: show system error when mkdir fails

### DIFF
--- a/src/machine-config.cpp
+++ b/src/machine-config.cpp
@@ -60,7 +60,7 @@ machine_config machine_config::load(const std::string &dir) {
     auto name = machine_config::get_config_filename(dir);
     std::ifstream ifs(name, std::ios::binary);
     if (!ifs) {
-        throw std::runtime_error{"unable to open '" + name + "' for reading"};
+        throw std::system_error{errno, std::generic_category(), "unable to open '" + name + "' for reading"};
     }
     try {
         auto j = nlohmann::json::parse(ifs);
@@ -90,7 +90,7 @@ void machine_config::store(const std::string &dir) const {
     j["config"] = *this;
     std::ofstream ofs(name, std::ios::binary);
     if (!ofs) {
-        throw std::runtime_error{"unable to open '" + name + "' for writing"};
+        throw std::system_error{errno, std::generic_category(), "unable to open '" + name + "' for writing"};
     }
     ofs << j;
 }

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -767,7 +767,7 @@ static void store_hash(const machine::hash_type &h, const std::string &dir) {
 
 void machine::store(const std::string &dir) const {
     if (os_mkdir(dir.c_str(), 0700)) {
-        throw std::runtime_error{"error creating directory '" + dir + "'"};
+        throw std::system_error{errno, std::generic_category(), "error creating directory '"s + dir + "'"s};
     }
     if (!update_merkle_tree()) {
         throw std::runtime_error{"error updating Merkle tree"};

--- a/tests/misc/test-machine-c-api.cpp
+++ b/tests/misc/test-machine-c-api.cpp
@@ -117,8 +117,7 @@ BOOST_FIXTURE_TEST_CASE_NOLINT(load_machine_unknown_dir_test, default_machine_fi
     BOOST_CHECK_EQUAL(error_code, CM_ERROR_RUNTIME_ERROR);
 
     std::string result = err_msg;
-    std::string origin("unable to open '/unknown_dir/config.json' for reading");
-    BOOST_CHECK_EQUAL(origin, result);
+    BOOST_REQUIRE(result.find("unable to open '/unknown_dir/config.json' for reading") == 0);
 
     cm_delete_cstring(err_msg);
 }
@@ -129,8 +128,7 @@ BOOST_FIXTURE_TEST_CASE_NOLINT(load_machine_null_path_test, default_machine_fixt
     BOOST_CHECK_EQUAL(error_code, CM_ERROR_RUNTIME_ERROR);
 
     std::string result = err_msg;
-    std::string origin("unable to open '/config.json' for reading");
-    BOOST_CHECK_EQUAL(origin, result);
+    BOOST_REQUIRE(result.find("unable to open '/config.json' for reading") == 0);
 
     cm_delete_cstring(err_msg);
 }
@@ -562,8 +560,7 @@ BOOST_FIXTURE_TEST_CASE_NOLINT(store_null_dir_path_test, ordinary_machine_fixtur
     int error_code = cm_store(_machine, nullptr, &err_msg);
     BOOST_CHECK_EQUAL(error_code, CM_ERROR_RUNTIME_ERROR);
     std::string result = err_msg;
-    std::string origin("error creating directory ''");
-    BOOST_CHECK_EQUAL(origin, result);
+    BOOST_REQUIRE(result.find("error creating directory") == 0);
 
     cm_delete_cstring(err_msg);
 }


### PR DESCRIPTION
We had a problem in production inside a cloud where saving snapshot failed due to `mkdir` failing, I think the disk was corrupt or something, we couldn't know the reason because `mkdir` is not showing the failure reason and we could not reproduce again. This PR improves the `mkdir` error with more context, so when it happens again we will know the reason.