### PR TITLE
Increase word log2 size

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ CXX=clang++
 AR=libtool -static -o
 INCS=
 
-BREW_PREFIX=$(shell which brew)
+BREW_PREFIX=$(shell brew --prefix)
 PORT_PREFIX=$(shell which port)
 
 ifeq ($(MACOSX_DEPLOYMENT_TARGET),)

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,7 @@ EMULATOR_MARCHID=17
 
 # Every new emulator release should bump these constants
 EMULATOR_VERSION_MAJOR=0
-EMULATOR_VERSION_MINOR=17
+EMULATOR_VERSION_MINOR=18
 EMULATOR_VERSION_PATCH=0
 EMULATOR_VERSION_LABEL=
 
@@ -66,7 +66,7 @@ CXX=clang++
 AR=libtool -static -o
 INCS=
 
-BREW_PREFIX=$(shell brew --prefix)
+BREW_PREFIX=$(shell which brew)
 PORT_PREFIX=$(shell which port)
 
 ifeq ($(MACOSX_DEPLOYMENT_TARGET),)

--- a/src/clua-cartesi.cpp
+++ b/src/clua-cartesi.cpp
@@ -114,6 +114,9 @@ CM_API int luaopen_cartesi(lua_State *L) {
     luaL_setfuncs(L, cartesi_mod.data(), 1); // cluactx cartesi
 
     // Set cartesi constants
+
+    clua_setintegerfield(L, CM_TREE_LOG2_ROOT_SIZE, "TREE_LOG2_ROOT_SIZE", -1);
+    clua_setintegerfield(L, CM_TREE_LOG2_WORD_SIZE, "TREE_LOG2_WORD_SIZE", -1);
     clua_setintegerfield(L, CM_BREAK_REASON_FAILED, "BREAK_REASON_FAILED", -1);
     clua_setintegerfield(L, CM_BREAK_REASON_HALTED, "BREAK_REASON_HALTED", -1);
     clua_setintegerfield(L, CM_BREAK_REASON_YIELDED_MANUALLY, "BREAK_REASON_YIELDED_MANUALLY", -1);

--- a/src/machine-c-defines.h
+++ b/src/machine-c-defines.h
@@ -27,7 +27,7 @@
 #define CM_MACHINE_F_REG_COUNT 32       // NOLINT(cppcoreguidelines-macro-usage, modernize-macro-to-enum)
 #define CM_MACHINE_UARCH_X_REG_COUNT 32 // NOLINT(cppcoreguidelines-macro-usage, modernize-macro-to-enum)
 
-#define CM_TREE_LOG2_WORD_SIZE 3              // NOLINT(cppcoreguidelines-macro-usage, modernize-macro-to-enum)
+#define CM_TREE_LOG2_WORD_SIZE 5              // NOLINT(cppcoreguidelines-macro-usage, modernize-macro-to-enum)
 #define CM_TREE_LOG2_PAGE_SIZE 12             // NOLINT(cppcoreguidelines-macro-usage, modernize-macro-to-enum)
 #define CM_TREE_LOG2_ROOT_SIZE 64             // NOLINT(cppcoreguidelines-macro-usage, modernize-macro-to-enum)
 #define CM_FLASH_DRIVE_CONFIGS_MAX_SIZE 8     // NOLINT(cppcoreguidelines-macro-usage, modernize-macro-to-enum)

--- a/src/machine-merkle-tree.h
+++ b/src/machine-merkle-tree.h
@@ -71,7 +71,7 @@ private:
     /// \brief LOG2_WORD_SIZE Number of bits covered by a word.
     /// I.e., log<sub>2</sub> of number of bytes subintended by the
     /// the deepest tree nodes.
-    static constexpr int LOG2_WORD_SIZE = 3;
+    static constexpr int LOG2_WORD_SIZE = 5;
     /// \brief DEPTH Depth of Merkle tree.
     static constexpr int DEPTH = LOG2_ROOT_SIZE - LOG2_WORD_SIZE;
 

--- a/src/send-cmio-response.cpp
+++ b/src/send-cmio-response.cpp
@@ -37,10 +37,10 @@ void send_cmio_response(STATE_ACCESS &a, uint16 reason, bytes data, uint32 dataL
     }
     // A zero length data is a valid response. We just skip writing to the rx buffer.
     if (dataLength > 0) {
-        // Find the write length: the smallest power of 2 that is >= length and >= word size
+        // Find the write length: the smallest power of 2 that is >= dataLength and >= tree leaf size
         uint32 writeLengthLog2Size = uint32Log2(dataLength);
-        if (writeLengthLog2Size < 3) {
-            writeLengthLog2Size = 3; // minimum write size is a word
+        if (writeLengthLog2Size < machine_merkle_tree::get_log2_word_size()) {
+            writeLengthLog2Size = 5; // minimum write size is the tree leaf size
         }
         if (uint32ShiftLeft(1, writeLengthLog2Size) < dataLength) {
             writeLengthLog2Size += 1;

--- a/tests/lua/mcycle-overflow.lua
+++ b/tests/lua/mcycle-overflow.lua
@@ -88,7 +88,9 @@ for _, proofs in ipairs({ true, false }) do
         assert(#log.accesses == 1)
         assert(log.accesses[1].type == "read")
         assert(log.accesses[1].address == cartesi.UARCH_SHADOW_START_ADDRESS + 8) -- address of uarch_cycle
-        assert(log.accesses[1].read == string.pack("J", MAX_UARCH_CYCLE))
+        assert(#log.accesses[1].read == 32)
+        -- log data has 32 bytes. The uarch_cycle is the 2nd 8-byte word
+        assert(log.accesses[1].read:sub(9, 16) == string.pack("J", MAX_UARCH_CYCLE))
         assert((log.accesses[1].sibling_hashes ~= nil) == proofs)
     end)
 end

--- a/tests/lua/uarch-riscv-tests.lua
+++ b/tests/lua/uarch-riscv-tests.lua
@@ -389,19 +389,18 @@ local function write_access_to_log(access, out, indent, last)
     util.indentout(out, indent + 1, '"type": "%s",\n', access.type)
     util.indentout(out, indent + 1, '"address": %u,\n', access.address)
     util.indentout(out, indent + 1, '"log2_size": %u,\n', access.log2_size)
+    local read_value = "" -- Solidity JSON parser breaks, if this field is null
+    if access.read then read_value = util.hexstring(access.read) end
+    util.indentout(out, indent + 1, '"read_value": "%s",\n', read_value)
+    util.indentout(out, indent + 1, '"read_hash": "%s",\n', util.hexhash(access.read_hash))
+    local written_value = ""
+    local written_hash = ""
     if access.type == "write" then
-        local value = "null"
-        if access.written then value = '"' .. util.hexstring(access.written) .. '"' end
-        util.indentout(out, indent + 1, '"value": %s,', value)
-        util.indentout(out, indent + 1, '"hash": "%s",', util.hexhash(access.written_hash))
-        util.indentout(out, indent + 1, '"read_hash": "%s"', util.hexhash(access.read_hash))
-    else
-        local value = "null"
-        if access.read then value = '"' .. util.hexstring(access.read) .. '"' end
-        util.indentout(out, indent + 1, '"value": %s,', value)
-        util.indentout(out, indent + 1, '"hash": "%s",', util.hexhash(access.read_hash))
-        util.indentout(out, indent + 1, '"read_hash": "%s"', util.hexhash(access.read_hash))
+        written_hash = util.hexhash(access.written_hash)
+        if access.written then written_value = util.hexstring(access.written) end
     end
+    util.indentout(out, indent + 1, '"written_value": "%s",\n', written_value)
+    util.indentout(out, indent + 1, '"written_hash": "%s"', written_hash)
     if access.sibling_hashes then
         out:write(",\n")
         write_sibling_hashes_to_log(access.sibling_hashes, out, indent + 2)

--- a/tests/misc/test-machine-c-api.cpp
+++ b/tests/misc/test-machine-c-api.cpp
@@ -44,9 +44,9 @@
 #include <machine-c-api.h>
 #include <riscv-constants.h>
 #include <uarch-constants.h>
-#include <uarch-solidity-compat.h>
 
 #include "test-utils.h"
+#include "uarch-solidity-compat.h"
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-do-while)
 
@@ -718,7 +718,7 @@ BOOST_FIXTURE_TEST_CASE_NOLINT(get_proof_inconsistent_tree_test, ordinary_machin
 
     // merkle tree is always consistent now as it updates on access
 
-    error_code = cm_get_proof(_machine, 0, 3, &proof, &err_msg);
+    error_code = cm_get_proof(_machine, 0, CM_TREE_LOG2_PAGE_SIZE, &proof, &err_msg);
     BOOST_CHECK_EQUAL(error_code, CM_ERROR_OK);
     cm_delete_merkle_tree_proof(proof);
 }

--- a/tests/misc/test-utils.h
+++ b/tests/misc/test-utils.h
@@ -25,7 +25,7 @@ using hash_type = cartesi::keccak_256_hasher::hash_type;
 // Calculate root hash for data buffer of log2_size
 namespace detail {
 
-constexpr int WORD_LOG2_SIZE = 3;
+constexpr int WORD_LOG2_SIZE = 5;
 constexpr int MERKLE_PAGE_LOG2_SIZE = 12;
 constexpr int MERKLE_PAGE_SIZE = (UINT64_C(1) << MERKLE_PAGE_LOG2_SIZE);
 
@@ -84,7 +84,7 @@ static hash_type calculate_proof_root_hash(const cm_merkle_tree_proof *proof) {
 }
 
 static hash_type calculate_emulator_hash(cm_machine *machine) {
-    cartesi::back_merkle_tree tree(64, 12, 3);
+    cartesi::back_merkle_tree tree(CM_TREE_LOG2_ROOT_SIZE, CM_TREE_LOG2_PAGE_SIZE, CM_TREE_LOG2_WORD_SIZE);
     std::string page;
     page.resize(detail::MERKLE_PAGE_SIZE);
     cm_memory_range_descr_array *mrds = nullptr;


### PR DESCRIPTION
This branch increases the merkle tree leaf size to 32 bytes.
We are still able to log accesses to data smaller than 32 bytes. We log the entire 32-byte leaf where the smaller data is located.

#### Related PR
https://github.com/cartesi/machine-solidity-step/pull/68

