### PR TITLE
fix: avoid extra root hash computation when storing an image snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+### Changed
+
+### Fixed
+- Fixed --skip-root-hash-store not skipping root hash computation when using the cli
 
 ## [0.18.1] - 2024-08-12
 ### Changed

--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -2078,8 +2078,9 @@ end
 local function store_machine(machine, config, dir)
     assert(config.processor.iunrep == 0, "hashes are meaningless in unreproducible mode")
     stderr("Storing machine: please wait\n")
-    local h = util.hexhash(machine:get_root_hash())
-    local name = instantiate_filename(dir, { h = h })
+    local values = {}
+    if dir:find("%%h") then values.h = util.hexhash(machine:get_root_hash()) end
+    local name = instantiate_filename(dir, values)
     machine:store(name)
 end
 

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -769,10 +769,10 @@ void machine::store(const std::string &dir) const {
     if (os_mkdir(dir.c_str(), 0700)) {
         throw std::system_error{errno, std::generic_category(), "error creating directory '"s + dir + "'"s};
     }
-    if (!update_merkle_tree()) {
-        throw std::runtime_error{"error updating Merkle tree"};
-    }
     if (!m_r.skip_root_hash_store) {
+        if (!update_merkle_tree()) {
+            throw std::runtime_error{"error updating Merkle tree"};
+        }
         hash_type h;
         m_t.get_root_hash(h);
         store_hash(h, dir);


### PR DESCRIPTION
I found out while investigating why a "reader node" using the CLI was too slow, that `--store` is always requesting a root hash computation when saving a snapshot, despite not using it, making the store operation slow, and this PR fixes the issue.