### PR TITLE
Make add-generated-files.diff respect src/ directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added a "--jobs" option to "uarch-riscv-tests.lua" test
+- add-created-files.diff should now be applied with `-p1`
 
 ### Fixed
 - Fixed --skip-root-hash-store not skipping root hash computation when using the cli

--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ create-generated-files-patch: $(ADD_GENERATED_FILES_DIFF)
 
 $(ADD_GENERATED_FILES_DIFF): $(GENERATED_FILES)
 	git add -f $(GENERATED_FILES)
-	git diff --no-prefix --staged --output=$(ADD_GENERATED_FILES_DIFF)
+	git diff --default-prefix --staged --output=$(ADD_GENERATED_FILES_DIFF)
 	git reset -- $(GENERATED_FILES)
 
 .PHONY: help all submodules doc clean distclean src luacartesi hash uarch \


### PR DESCRIPTION
By default, MacPorts enters the project directory and applies patch files using `-p0`. 
The `add-generated-files.diff` file was created accordingly. 
Unfortunately, `git apply` expects `-p1`.
This was the source of some confusion.
This PR flips things around.
The diff is created to include the directory, and MacPorts portfile is instructed to use `-p1`.
This makes `git apply` work directly on the diff file.  