### PR TITLE
fix: HTIF_YIELD_MANUAL is nil, this blocks cli assert-rolling-template

### DIFF
--- a/src/cartesi-machine.lua
+++ b/src/cartesi-machine.lua
@@ -2319,7 +2319,7 @@ if assert_rolling_template then
     local cmd, reason = get_yield(machine)
     if
         not (
-            cmd == cartesi.machine.HTIF_YIELD_MANUAL
+            cmd == cartesi.machine.HTIF_YIELD_CMD_MANUAL
             and reason == cartesi.machine.HTIF_YIELD_MANUAL_REASON_RX_ACCEPTED
         )
     then


### PR DESCRIPTION
- When having a valid rolling template, assert_rolling_template always fails. This is because of it using HTIF_YIELD_MANUAL for comparison which doesn't exist. It should be HTIF_YIELD_CMD_MANUAL.