### PR TITLE
Use install path instead of a runtime path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,8 +347,8 @@ install-bins: $(BIN_INSTALL_PATH)
 	$(STRIP_BINARY) $(subst src/,$(BIN_INSTALL_PATH)/,$(EMU_TO_BIN))
 
 install-lua-bins: $(BIN_INSTALL_PATH)
-	cat tools/template/cartesi-machine.template | sed 's|ARG_LUA_PATH|$(LUA_RUNTIME_PATH)/?.lua|g;s|ARG_LUA_CPATH|$(LUA_RUNTIME_CPATH)/?.so|g;s|ARG_IMAGES_PATH|$(IMAGES_RUNTIME_PATH)|g;s|ARG_LUA_RUNTIME_PATH|$(LUA_RUNTIME_PATH)|g' > $(BIN_INSTALL_PATH)/cartesi-machine
-	cat tools/template/cartesi-machine-stored-hash.template | sed 's|ARG_LUA_PATH|$(LUA_RUNTIME_PATH)/?.lua|g;s|ARG_LUA_CPATH|$(LUA_RUNTIME_CPATH)/?.so|g;s|ARG_LUA_RUNTIME_PATH|$(LUA_RUNTIME_PATH)|g' > $(BIN_INSTALL_PATH)/cartesi-machine-stored-hash
+	cat tools/template/cartesi-machine.template | sed 's|ARG_LUA_PATH|$(LUA_INSTALL_PATH)/?.lua|g;s|ARG_LUA_CPATH|$(LUA_INSTALL_CPATH)/?.so|g;s|ARG_IMAGES_PATH|$(IMAGES_INSTALL_PATH)|g;s|ARG_LUA_RUNTIME_PATH|$(LUA_INSTALL_PATH)|g' > $(BIN_INSTALL_PATH)/cartesi-machine
+	cat tools/template/cartesi-machine-stored-hash.template | sed 's|ARG_LUA_PATH|$(LUA_INSTALL_PATH)/?.lua|g;s|ARG_LUA_CPATH|$(LUA_INSTALL_CPATH)/?.so|g;s|ARG_LUA_RUNTIME_PATH|$(LUA_INSTALL_PATH)|g' > $(BIN_INSTALL_PATH)/cartesi-machine-stored-hash
 	$(CHMOD_EXEC) $(BIN_INSTALL_PATH)/cartesi-machine $(BIN_INSTALL_PATH)/cartesi-machine-stored-hash
 
 install-shared-files: $(IMAGES_INSTALL_PATH)
@@ -373,8 +373,8 @@ install-tests: | $(LUA_INSTALL_PATH) $(BIN_INSTALL_PATH) $(TESTS_SCRIPTS_INSTALL
 	$(INSTALL_DIR) $(TESTS_LUA_TO_LUA_PATH) $(LUA_INSTALL_PATH)
 	$(INSTALL_DIR) $(TESTS_LUA_TO_TEST_LUA_PATH) $(TESTS_LUA_INSTALL_PATH)
 	$(INSTALL_DIR) $(TESTS_SCRIPTS_TO_TEST_SCRIPTS_PATH) $(TESTS_SCRIPTS_INSTALL_PATH)
-	sed 's|ARG_LUA_PATH|$(LUA_RUNTIME_PATH)/?.lua|g;s|ARG_LUA_CPATH|$(LUA_RUNTIME_CPATH)/?.so|g;s|ARG_LUA_RUNTIME_PATH|$(TESTS_LUA_RUNTIME_PATH)|g;s|ARG_TESTS_PATH|$(TESTS_DATA_RUNTIME_PATH)/machine|g' tools/template/cartesi-machine-tests.template > $(BIN_INSTALL_PATH)/cartesi-machine-tests
-	sed 's|ARG_LUA_PATH|$(LUA_RUNTIME_PATH)/?.lua|g;s|ARG_LUA_CPATH|$(LUA_RUNTIME_CPATH)/?.so|g;s|ARG_LUA_RUNTIME_PATH|$(TESTS_LUA_RUNTIME_PATH)|g;s|ARG_TESTS_UARCH_PATH|$(TESTS_DATA_RUNTIME_PATH)/uarch|g' tools/template/uarch-riscv-tests.template > $(BIN_INSTALL_PATH)/uarch-riscv-tests
+	sed 's|ARG_LUA_PATH|$(LUA_INSTALL_PATH)/?.lua|g;s|ARG_LUA_CPATH|$(LUA_INSTALL_CPATH)/?.so|g;s|ARG_LUA_RUNTIME_PATH|$(TESTS_LUA_INSTALL_PATH)|g;s|ARG_TESTS_PATH|$(TESTS_DATA_INSTALL_PATH)/machine|g' tools/template/cartesi-machine-tests.template > $(BIN_INSTALL_PATH)/cartesi-machine-tests
+	sed 's|ARG_LUA_PATH|$(LUA_INSTALL_PATH)/?.lua|g;s|ARG_LUA_CPATH|$(LUA_INSTALL_CPATH)/?.so|g;s|ARG_LUA_RUNTIME_PATH|$(TESTS_LUA_INSTALL_PATH)|g;s|ARG_TESTS_UARCH_PATH|$(TESTS_DATA_INSTALL_PATH)/uarch|g' tools/template/uarch-riscv-tests.template > $(BIN_INSTALL_PATH)/uarch-riscv-tests
 	$(CHMOD_EXEC) $(BIN_INSTALL_PATH)/cartesi-machine-tests $(BIN_INSTALL_PATH)/uarch-riscv-tests
 
 tests-data-debian-package: install-tests-data


### PR DESCRIPTION
`cartesi-machine` and similar scripts are omitting `DESTDIR`. As a result, the scripts fail when the machine emulator is installed in a custom location.