### PR TITLE
Fix typos across the codebase

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,7 @@ Checks: >-
   -cppcoreguidelines-avoid-c-arrays,
   google*,
   -google-build-using-namespace,
+  -google-objc-*,
   hicpp*,
   -hicpp-avoid-c-arrays,
   -hicpp-no-array-decay,

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ doc/api.md
 doc/html/
 doc/xml/
 
+.clangd
 .venv
 .vscode
 .ycm_extra_conf.py

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,11 @@
+[files]
+extend-exclude = ["third-party/*", "*.S"]
+
+[default.extend-words]
+fle = "fle"
+sie = "sie"
+stip = "stip"
+stap = "stap"
+wronly = "wronly"
+optin = "optin"
+sxl = "sxl"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,17 @@
 
 Thank you for your interest in Cartesi! We highly appreciate even the smallest of fixes or additions to our project.
 
-Make sure to review our [Contributing License Agreement](https://forms.gle/k3E9ZNkZY6Vy3mkK9), 
-sign and send it to info@cartesi.io with the title of "CLA Signed" before taking part in the project. We are happy to automate 
+Make sure to review our [Contributing License Agreement](https://forms.gle/k3E9ZNkZY6Vy3mkK9),
+sign and send it to info@cartesi.io with the title of "CLA Signed" before taking part in the project. We are happy to automate
 this for you via DocuSign upon request in the Google Form as well.
 
 ## Basic Contributing Guidelines
 
-We use the same guidelines for contributing code to any of our repositories, any developers wanting to contribute to Cartesi 
-must create pull requests. This process is described in the [GitHub documentation](https://help.github.com/en/articles/creating-a-pull-request). Each pull request should be started against the master branch 
-in the respective Cartesi repository. After a pull request is submitted the Cartesi team will review the submission and 
-give feedback via the comments section of the pull request. After the submission is reviewed and approved, it will be merged 
-into the master branch of the source. 
+We use the same guidelines for contributing code to any of our repositories, any developers wanting to contribute to Cartesi
+must create pull requests. This process is described in the [GitHub documentation](https://help.github.com/en/articles/creating-a-pull-request). Each pull request should be started against the master branch
+in the respective Cartesi repository. After a pull request is submitted the Cartesi team will review the submission and
+give feedback via the comments section of the pull request. After the submission is reviewed and approved, it will be merged
+into the master branch of the source.
 
 Please note the below! We appreciate everyone following the guidelines.
 
@@ -22,5 +22,5 @@ Please note the below! We appreciate everyone following the guidelines.
 
 ## Get in Touch
 
-When contributing in a deeper manner to this repository, please first discuss the change you wish to make via our 
-[Discord channel here](https://discord.gg/Pt2NrnS), or contact us at info@cartesi.io email before working on the change.
+When contributing in a deeper manner to this repository, please first discuss the change you wish to make via our
+[Discord channel here](https://discord.gg/cartesi), or contact us at info@cartesi.io email before working on the change.

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -129,7 +129,7 @@ static size_t b64decode(uint8_t c, uint8_t *input, size_t size, std::ostringstre
         decoded[1] = static_cast<uint8_t>(value & 0xff);
         value >>= 8;
         decoded[0] = static_cast<uint8_t>(value);
-        // take care of paddding
+        // take care of padding
         if (input[2] == '=') {
             valid = 1;
         } else if (input[3] == '=') {

--- a/src/cartesi/gdbstub.lua
+++ b/src/cartesi/gdbstub.lua
@@ -91,7 +91,7 @@ function GDBStub:_recv()
         sum = sum + c:byte()
         escaped_data[#escaped_data + 1] = c
     end
-    escaped_data = table.concat(escaped_data)
+    local escaped_data_str = table.concat(escaped_data)
     -- validate checksum
     local checksum = assert(self.conn:receive(2))
     if sum % 256 ~= hex2int(checksum) then
@@ -104,7 +104,7 @@ function GDBStub:_recv()
         assert(self.conn:send("+")) -- send acknowledge packet
     end
     -- escape packet data
-    local data = escaped_data:gsub("}(.)", xorchr)
+    local data = escaped_data_str:gsub("}(.)", xorchr)
     if GDBSTUB_DEBUG_PROTOCOL then stderr("Packet recv: %s", data) end
     return data
 end
@@ -174,8 +174,7 @@ function GDBStub:_handle_query(_, query)
             if supported_features[feature] then table.insert(res, feature .. "+") end
         end
         -- reply with features we support
-        res = table.concat(res, ";")
-        return self:_send(res)
+        return self:_send(table.concat(res, ";"))
     elseif query == "qTStatus" then -- GDB is asking whether a trace experiment is currently running
         return self:_send_unsupported()
     elseif query == "qfThreadInfo" or query == "qC" or query:find("^qL") then -- GDB is asking thread info
@@ -341,8 +340,7 @@ function GDBStub:_handle_read_all_regs()
     end
     -- read program counter
     table.insert(res, reg2hex(self.machine:read_reg("pc")))
-    res = table.concat(res)
-    return self:_send(res)
+    return self:_send(table.concat(res))
 end
 
 -- GDB is writing all machine registers.

--- a/src/cartesi/util.lua
+++ b/src/cartesi/util.lua
@@ -205,8 +205,8 @@ local function accessdatastring(data, data_hash, data_log2_size, address)
         if data_size < #data then
             -- access data is  smaller than the tree leaf size
             -- the logged data is the entire tree leaf, but we only need the data that was accessed
-            local leaf_aligned_addrss = address & ~((1 << cartesi.TREE_LOG2_WORD_SIZE) - 1)
-            local word_offset = address - leaf_aligned_addrss
+            local leaf_aligned_address = address & ~((1 << cartesi.TREE_LOG2_WORD_SIZE) - 1)
+            local word_offset = address - leaf_aligned_address
             data = data:sub(word_offset + 1, word_offset + data_size)
         end
         data = string.unpack("<I8", data)

--- a/src/complete-merkle-tree.cpp
+++ b/src/complete-merkle-tree.cpp
@@ -117,7 +117,7 @@ void complete_merkle_tree::bubble_up() {
         // Next level needs half as many (rounded up) as previous
         next.resize((prev.size() + 1) / 2);
         assert(first_entry <= next.size());
-        // Last safe entry has two non-pristine leafs
+        // Last safe entry has two non-pristine leaves
         auto last_safe_entry = prev.size() / 2;
         // Do all entries for which we have two non-pristine children
         for (; first_entry < last_safe_entry; ++first_entry) {

--- a/src/jsonrpc-discover.json
+++ b/src/jsonrpc-discover.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Remote Cartesi Machine",
     "version": "0.5.0",
-    "description": "API for controling a remote Cartesi Machine server",
+    "description": "API for controlling a remote Cartesi Machine server",
     "license": {
       "name": "MIT"
     }
@@ -865,11 +865,7 @@
       "SemanticVersion": {
         "title": "SemanticVersion",
         "type": "object",
-        "required": [
-          "major",
-          "minor",
-          "patch"
-        ],
+        "required": ["major", "minor", "patch"],
         "properties": {
           "major": {
             "$ref": "#/components/schemas/UnsignedInteger"
@@ -1232,9 +1228,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "length"
-        ]
+        "required": ["length"]
       },
       "DTBConfig": {
         "title": "DTBConfig",
@@ -1315,9 +1309,7 @@
       "VirtIODeviceConfig": {
         "title": "VirtIODeviceConfig",
         "type": "object",
-        "required": [
-          "type"
-        ],
+        "required": ["type"],
         "properties": {
           "type": {
             "type": "string"
@@ -1600,10 +1592,7 @@
       },
       "UarchInterpreterBreakReason": {
         "title": "UarchInterpreterBreakReason",
-        "enum": [
-          "reached_target_cycle",
-          "uarch_halted"
-        ]
+        "enum": ["reached_target_cycle", "uarch_halted"]
       },
       "Base64String": {
         "title": "Base64String",
@@ -1640,10 +1629,7 @@
       },
       "BracketType": {
         "title": "BracketType",
-        "enum": [
-          "begin",
-          "end"
-        ]
+        "enum": ["begin", "end"]
       },
       "Bracket": {
         "title": "Bracket",
@@ -1659,11 +1645,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "type",
-          "where",
-          "text"
-        ]
+        "required": ["type", "where", "text"]
       },
       "Proof": {
         "title": "Proof",
@@ -1726,12 +1708,7 @@
             "$ref": "#/components/schemas/Base64HashArray"
           }
         },
-        "required": [
-          "type",
-          "address",
-          "log2_size",
-          "read_hash"
-        ]
+        "required": ["type", "address", "log2_size", "read_hash"]
       },
       "AccessArray": {
         "title": "AccessArray",
@@ -1742,10 +1719,7 @@
       },
       "AccessType": {
         "title": "AccessType",
-        "enum": [
-          "read",
-          "write"
-        ]
+        "enum": ["read", "write"]
       },
       "AccessLogType": {
         "title": "AccessLogType",
@@ -1758,10 +1732,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "has_annotations",
-          "has_large_data"
-        ]
+        "required": ["has_annotations", "has_large_data"]
       },
       "AccessLog": {
         "title": "AccessLog",
@@ -1780,10 +1751,7 @@
             "$ref": "#/components/schemas/BracketArray"
           }
         },
-        "required": [
-          "log_type",
-          "accesses"
-        ]
+        "required": ["log_type", "accesses"]
       },
       "REG": {
         "title": "REG",

--- a/src/jsonrpc-machine-c-api.h
+++ b/src/jsonrpc-machine-c-api.h
@@ -75,7 +75,7 @@ CM_API cm_error cm_jsonrpc_connect_server(const char *address, cm_machine **new_
 /// \param address If function succeeds, receives address the forked server bound to,
 /// guaranteed to remain valid only until the next CM_API function is called again on the same thread.
 /// Set to NULL on failure.
-/// \param pid If function suceeds, receives the forked child process id (can be NULL). Set to 0 on failure.
+/// \param pid If function succeeds, receives the forked child process id (can be NULL). Set to 0 on failure.
 /// \returns 0 for success, non zero code for error.
 /// \details If the remote machine server already holds a machine instance, the forked copy is ready for use.
 /// Otherwise, use cm_create() or cm_load() to instantiate a machine into the forked server object.

--- a/src/jsonrpc-remote-machine.cpp
+++ b/src/jsonrpc-remote-machine.cpp
@@ -807,7 +807,7 @@ static json jsonrpc_rebind_handler(const json &j, const std::shared_ptr<http_ses
         session->handler->rebind(tcp::acceptor{session->handler->ioc, new_local_endpoint});
         SLOG(trace) << session->handler->local_endpoint << " rebound to " << session->handler->local_endpoint;
     } else {
-        SLOG(trace) << session->handler->local_endpoint << " rebind unecessary";
+        SLOG(trace) << session->handler->local_endpoint << " rebind unnecessary";
     }
     const std::string result = endpoint_to_string(session->handler->local_endpoint);
     return jsonrpc_response_ok(j, result);
@@ -876,7 +876,7 @@ static json jsonrpc_machine_destroy_handler(const json &j, const std::shared_ptr
 /// \param j JSON request object
 /// \param session HTTP session
 /// \returns JSON response object
-/// \details This method causes the server to sleep for a number of miliseconds before the next call
+/// \details This method causes the server to sleep for a number of milliseconds before the next call
 static json jsonrpc_delay_next_request_handler(const json &j, const std::shared_ptr<http_session> &session) {
     static const char *param_name[] = {"ms"};
     auto args = parse_args<uint64_t>(j, param_name);

--- a/src/machine-c-api.h
+++ b/src/machine-c-api.h
@@ -362,7 +362,7 @@ CM_API void cm_delete(cm_machine *m);
 /// \param config Machine configuration as a JSON object in a string.
 /// \param runtime_config Machine runtime configuration as a JSON object in a string (can be NULL).
 /// \returns 0 for success, non zero code for error.
-/// \details Use cm_destroy() to destroy the machine istance and remove it from the object.
+/// \details Use cm_destroy() to destroy the machine instance and remove it from the object.
 CM_API cm_error cm_create(cm_machine *m, const char *config, const char *runtime_config);
 
 /// \brief Combines cm_new() and cm_create() for convenience.
@@ -370,7 +370,7 @@ CM_API cm_error cm_create(cm_machine *m, const char *config, const char *runtime
 /// \param runtime_config Machine runtime configuration as a JSON object in a string (can be NULL).
 /// \param new_m Receives the pointer to the new machine object with a machine instance. Set to NULL on failure.
 /// \returns 0 for success, non zero code for error.
-/// \details Use cm_destroy() to destroy the machine istance and remove it from the object.
+/// \details Use cm_destroy() to destroy the machine instance and remove it from the object.
 /// \details Use cm_delete() to delete the object.
 CM_API cm_error cm_create_new(const char *config, const char *runtime_config, cm_machine **new_m);
 
@@ -379,7 +379,7 @@ CM_API cm_error cm_create_new(const char *config, const char *runtime_config, cm
 /// \param dir Directory where previous machine is stored.
 /// \param runtime_config Machine runtime configuration as a JSON object in a string (can be NULL).
 /// \returns 0 for success, non zero code for error.
-/// \details Use cm_destroy() to destroy the machine istance and remove it from the object.
+/// \details Use cm_destroy() to destroy the machine instance and remove it from the object.
 CM_API cm_error cm_load(cm_machine *m, const char *dir, const char *runtime_config);
 
 /// \brief Combines cm_new() and cm_load() for convenience.
@@ -387,7 +387,7 @@ CM_API cm_error cm_load(cm_machine *m, const char *dir, const char *runtime_conf
 /// \param runtime_config Machine runtime configuration as a JSON object in a string (can be NULL).
 /// \param new_m Receives the pointer to the new machine object with a machine instance. Set to NULL on failure.
 /// \returns 0 for success, non zero code for error.
-/// \details Use cm_destroy() to destroy the machine istance and remove it from the object.
+/// \details Use cm_destroy() to destroy the machine instance and remove it from the object.
 /// \details Use cm_delete() to delete the object.
 CM_API cm_error cm_load_new(const char *dir, const char *runtime_config, cm_machine **new_m);
 

--- a/src/machine.h
+++ b/src/machine.h
@@ -560,13 +560,13 @@ public:
 
     /// \brief Sends cmio response
     /// \param reason Reason for sending response.
-    /// \param data Reponse data.
+    /// \param data Response data.
     /// \param length Length of response data.
     void send_cmio_response(uint16_t reason, const unsigned char *data, uint64_t length);
 
     /// \brief Sends cmio response and returns an access log
     /// \param reason Reason for sending response.
-    /// \param data Reponse data.
+    /// \param data Response data.
     /// \param length Length of response data.
     /// \param log_type Type of access log to generate.
     /// \return The state access log.

--- a/src/merkle-tree-proof.h
+++ b/src/merkle-tree-proof.h
@@ -225,7 +225,7 @@ public:
             throw std::out_of_range{"log2_root_size is too large"};
         }
         if (new_log2_target_size < get_log2_target_size()) {
-            throw std::out_of_range{"log2_taget_size is too small"};
+            throw std::out_of_range{"log2_target_size is too small"};
         }
         merkle_tree_proof<HASH_TYPE, ADDRESS_TYPE> sliced(new_log2_root_size, new_log2_target_size);
         hash_type hash = get_target_hash();
@@ -258,7 +258,7 @@ public:
 
 private:
     /// \brief Converts log2_size to index into siblings array
-    /// \return Index into siblings array, or throws exception if out of bouds
+    /// \return Index into siblings array, or throws exception if out of bounds
     int log2_size_to_index(int log2_size) const {
         const int index = log2_size - m_log2_target_size;
         if (index < 0 || index >= static_cast<int>(m_sibling_hashes.size())) {

--- a/src/record-state-access.h
+++ b/src/record-state-access.h
@@ -192,7 +192,7 @@ private:
         update_after_write(paligned);
     }
 
-    // Declare interface as friend to it can forward calls to the "overriden" methods.
+    // Declare interface as friend to it can forward calls to the "overridden" methods.
     friend i_state_access<record_state_access, pma_entry>;
 
     void do_push_bracket(bracket_type &type, const char *text) {

--- a/src/uarch-record-state-access.h
+++ b/src/uarch-record-state-access.h
@@ -129,7 +129,7 @@ public:
         std::string m_text;                ///< String with the text for the annotation
 
     public:
-        /// \brief Constructor adds the "begin" bracketting note
+        /// \brief Constructor adds the "begin" bracketing note
         /// \param log Pointer to access log receiving annotations
         /// \param text Pointer to annotation text
         /// \details A note is added at the moment of construction
@@ -148,16 +148,16 @@ public:
         /// \brief Default move constructor
         /// \details This is OK because the shared_ptr to log will be
         /// empty afterwards and we explicitly test for this
-        /// condition before writing the "end" bracketting note
+        /// condition before writing the "end" bracketing note
         scoped_note(scoped_note &&) = default;
 
         /// \brief Default move assignment
         /// \details This is OK because the shared_ptr to log will be
         /// empty afterwards and we explicitly test for this
-        /// condition before writing the "end" bracketting note
+        /// condition before writing the "end" bracketing note
         scoped_note &operator=(scoped_note &&) = default;
 
-        /// \brief Destructor adds the "end" bracketting note
+        /// \brief Destructor adds the "end" bracketing note
         /// if the log shared_ptr is not empty
         ~scoped_note() {
             if (m_log) {
@@ -167,7 +167,7 @@ public:
                     // push_bracket with type begin always reserves space for the end bracket
                     // so either the user using unbalanced with begin/end, or there
                     // is no way we ran out of memory. therefore, if we did run out of
-                    // memory, it was because the sytem is completely screwed anyway *and* the
+                    // memory, it was because the system is completely screwed anyway *and* the
                     // user is using unbalanced brackets. it's ok to quietly ignore, as the user's
                     // brackets were already unbalanced anyway...
                 }
@@ -288,7 +288,7 @@ private:
         update_after_write(paligned);
     }
 
-    // Declare interface as friend to it can forward calls to the "overriden" methods.
+    // Declare interface as friend to it can forward calls to the "overridden" methods.
     friend i_uarch_state_access<uarch_record_state_access>;
 
     void do_push_bracket(bracket_type &type, const char *text) {

--- a/tests/lua/cartesi-machine-tests.lua
+++ b/tests/lua/cartesi-machine-tests.lua
@@ -476,7 +476,7 @@ local options = {
             if not o or #o < 1 then
                 return false
             end
-            jobs = tonumber(o)
+            jobs = assert(tonumber(o))
             assert(jobs and jobs >= 1, "invalid number of jobs")
             return true
         end,

--- a/tests/lua/cartesi/tests/util.lua
+++ b/tests/lua/cartesi/tests/util.lua
@@ -64,7 +64,7 @@ function test_util.create_test_uarch_program(instructions)
         instructions = test_util.uarch_programs.default
     end
     local file_path = os.tmpname()
-    local f <close> = io.open(file_path, "wb")
+    local f <close> = assert(io.open(file_path, "wb"))
     for _, insn in pairs(instructions) do
         f:write(string.pack("I4", insn))
     end

--- a/tests/lua/htif-cmio.lua
+++ b/tests/lua/htif-cmio.lua
@@ -22,7 +22,7 @@ local test_util = require("cartesi.tests.util")
 local config_base = {
     ram = {
         -- This test will fetch the cmio buffers from the PMA entries; check
-        -- that `rx_buffer` is filled with a byte patern;
+        -- that `rx_buffer` is filled with a byte pattern;
         -- then write a byte pattern into `tx_buffer` to be checked inside.
         image_filename = test_util.tests_path .. "htif_cmio.bin",
         length = 0x4000000,

--- a/tests/lua/machine-bind.lua
+++ b/tests/lua/machine-bind.lua
@@ -328,7 +328,7 @@ do_test("should provide proof for values in registers", function(machine)
     for _, v in pairs(initial_reg_values) do
         for el = cartesi.TREE_LOG2_WORD_SIZE, cartesi.TREE_LOG2_ROOT_SIZE - 1 do
             local a = test_util.align(v, el)
-            assert(test_util.check_proof(assert(machine:get_proof(a, el)), "no proof"), "proof failed")
+            assert(test_util.check_proof(assert(machine:get_proof(a, el), "no proof")), "proof failed")
         end
     end
 end)
@@ -545,7 +545,7 @@ do_test("should error if target mcycle is smaller than current mcycle", function
         machine:run(MAX_MCYCLE - 1)
     end)
     assert(success == false)
-    assert(err:match("mcycle is past"))
+    assert(err and err:match("mcycle is past"))
     assert(machine:read_mcycle() == MAX_MCYCLE)
 end)
 
@@ -556,7 +556,7 @@ do_test("should error if target uarch_cycle is smaller than current uarch_cycle"
         machine:run_uarch(MAX_UARCH_CYCLE - 1)
     end)
     assert(success == false)
-    assert(err:match("uarch_cycle is past"))
+    assert(err and err:match("uarch_cycle is past"))
     assert(machine:read_uarch_cycle() == MAX_UARCH_CYCLE)
 end)
 
@@ -798,8 +798,8 @@ test_util.make_do_test(build_machine, machine_type, { uarch = {} })(
         assert(hash_after_step ~= initial_hash)
         -- reset should restore initial hash
         machine:reset_uarch()
-        local hash_after_2nd_reset = machine:get_root_hash()
-        assert(hash_after_2nd_reset == initial_hash)
+        local hash_after_second_reset = machine:get_root_hash()
+        assert(hash_after_second_reset == initial_hash)
         -- Modifying uarch ram changes hash
         machine:write_memory(cartesi.UARCH_RAM_START_ADDRESS, string.rep("X", 1 << 8))
         local hash_after_write = machine:get_root_hash()
@@ -928,7 +928,7 @@ test_util.make_do_test(build_machine, machine_type, { uarch = test_reset_uarch_c
                 os.remove(tmpname)
             end,
         })
-        local tmp <close> = io.open(tmpname, "w+")
+        local tmp <close> = assert(io.open(tmpname, "w+"))
         util.dump_log(log, tmp)
         tmp:seek("set", 0)
         local actual_dump = tmp:read("*all")
@@ -1367,10 +1367,10 @@ local function test_cmio_buffers_backed_by_files()
         end,
     })
     -- initialize test cmio files
-    local rx = io.open(rx_filename, "w+")
+    local rx = assert(io.open(rx_filename, "w+"))
     rx:write(rx_init_data)
     rx:close()
-    local tx = io.open(tx_filename, "w+")
+    local tx = assert(io.open(tx_filename, "w+"))
     tx:write(tx_init_data)
     tx:close()
     local tx_new_data = string.rep("x", 1 << cartesi.PMA_CMIO_TX_BUFFER_LOG2_SIZE)

--- a/tests/lua/machine-test.lua
+++ b/tests/lua/machine-test.lua
@@ -184,7 +184,7 @@ do_test("machine root hash after step one should match", function(machine)
     local calculated_root_hash = test_util.calculate_emulator_hash(machine)
     assert(root_hash == calculated_root_hash, "Initial root hash does not match")
 
-    -- Perform step and check if hash maches
+    -- Perform step and check if hash matches
     machine:log_step_uarch()
     local root_hash_step1 = machine:get_root_hash()
     local calculated_root_hash_step1 = test_util.calculate_emulator_hash(machine)
@@ -359,7 +359,7 @@ test_util.make_do_test(build_machine, machine_type, {
         .. tostring(rootfs_length)
         .. " "
         .. input_path
-    local p = io.popen(command)
+    local p = assert(io.popen(command))
     p:close()
 
     local flash_address_start = 0x80000000000000
@@ -397,7 +397,7 @@ if machine_type ~= "local" then
             machine:get_root_hash()
         end)
         assert(ret == false)
-        assert(err:match("no machine"))
+        assert(err and err:match("no machine"))
     end)
 
     do_test("timeout mechanism should be respected", function(machine)
@@ -415,7 +415,7 @@ if machine_type ~= "local" then
             machine:get_root_hash()
         end)
         assert(ret == false)
-        assert(err:match("jsonrpc error: timeout"))
+        assert(err and err:match("jsonrpc error: timeout"))
         machine:set_timeout(old_tm)
     end)
 
@@ -443,7 +443,7 @@ if machine_type ~= "local" then
             jsonrpc.connect_server(address)
         end)
         assert(ret == false)
-        assert(err:match("jsonrpc error: post error contacting " .. address))
+        assert(err and err:match("jsonrpc error: post error contacting " .. address))
     end)
 
     do_test("jsonrpc connection error 49 after rapid successive requests ", function(machine)

--- a/tests/lua/mtime-interrupt.lua
+++ b/tests/lua/mtime-interrupt.lua
@@ -57,7 +57,8 @@ do_test("machine:run should interrupt for mtime", function(machine)
     check_state(machine)
 end)
 
-test_util.disabled_test("machine:log_step_uarch should interrupt for mtime", function(machine)
+--[[
+do_test("machine:log_step_uarch should interrupt for mtime", function(machine)
     for _ = 1, EXPECTED_MCYCLE do
         machine:log_step_uarch()
         if machine:read_iflags_H() then
@@ -66,5 +67,6 @@ test_util.disabled_test("machine:log_step_uarch should interrupt for mtime", fun
     end
     check_state(machine)
 end)
+]]
 
 print("passed")

--- a/tests/lua/run-rv64i-arch-test.lua
+++ b/tests/lua/run-rv64i-arch-test.lua
@@ -63,7 +63,7 @@ local s2, _ = string.find(mem, "END_CTSI_SIGNATURE______")
 local sig = string.sub(mem, e1 + 1, s2 - 1)
 
 -- write signature to file, in the format expected by the arch test script
-local fd = io.open(output_signature_file, "w")
+local fd = assert(io.open(output_signature_file, "w"))
 for i = 1, #sig, 4 do
     local w = string.reverse(string.sub(sig, i, i + 3))
     for j = 1, 4, 1 do

--- a/tests/lua/uarch-riscv-tests.lua
+++ b/tests/lua/uarch-riscv-tests.lua
@@ -22,7 +22,7 @@ local test_util = require("cartesi.tests.util")
 local parallel = require("cartesi.parallel")
 
 -- Tests Cases
--- format {"ram_image_file", number_of_uarch_cycles, expectd_error_pattern}
+-- format {"ram_image_file", number_of_uarch_cycles, expected_error_pattern}
 local riscv_tests = {
     { "rv64ui-uarch-simple.bin", 11 },
     { "rv64ui-uarch-add.bin", 440 },
@@ -76,7 +76,7 @@ local riscv_tests = {
     { "rv64ui-uarch-xori.bin", 177 },
     { "rv64ui-uarch-fence.bin", 12 },
     { "rv64ui-uarch-ecall-putchar.bin", 14 },
-    { "rv64ui-uarch-ecall-unsupported.bin", 1, "unsupported ecall functio" },
+    { "rv64ui-uarch-ecall-unsupported.bin", 1, "unsupported ecall function" },
     { "rv64ui-uarch-ebreak.bin", 1, "uarch aborted" },
 }
 
@@ -203,7 +203,7 @@ local options = {
             if not o or #o < 1 then
                 return false
             end
-            jobs = tonumber(o)
+            jobs = assert(tonumber(o))
             assert(jobs and jobs >= 1, "invalid number of jobs")
             return true
         end,

--- a/tests/machine/CONTRIBUTING.md
+++ b/tests/machine/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 Thank you for your interest in Cartesi! We highly appreciate even the smallest of fixes or additions to our project.
 
-Make sure to review our [Contributing License Agreement](https://forms.gle/k3E9ZNkZY6Vy3mkK9), 
-sign and send it to info@cartesi.io with the title of "CLA Signed" before taking part in the project. We are happy to automate 
+Make sure to review our [Contributing License Agreement](https://forms.gle/k3E9ZNkZY6Vy3mkK9),
+sign and send it to info@cartesi.io with the title of "CLA Signed" before taking part in the project. We are happy to automate
 this for you via DocuSign upon request in the Google Form as well.
 
 ## Basic Contributing Guidelines
 
-We use the same guidelines for contributing code to any of our repositories, any developers wanting to contribute to Cartesi must create pull requests. This process is described in the [GitHub documentation](https://help.github.com/en/articles/creating-a-pull-request). Each pull request should be started against the master branch in the respective Cartesi repository. After a pull request is submitted the Cartesi team will review the submission and give feedback via the comments section of the pull request. After the submission is reviewed and approved, it will be merged into the master branch of the source. 
+We use the same guidelines for contributing code to any of our repositories, any developers wanting to contribute to Cartesi must create pull requests. This process is described in the [GitHub documentation](https://help.github.com/en/articles/creating-a-pull-request). Each pull request should be started against the master branch in the respective Cartesi repository. After a pull request is submitted the Cartesi team will review the submission and give feedback via the comments section of the pull request. After the submission is reviewed and approved, it will be merged into the master branch of the source.
 
 Please note the below! We appreciate everyone following the guidelines.
 
@@ -18,5 +18,5 @@ Please note the below! We appreciate everyone following the guidelines.
 
 ## Get in Touch
 
-When contributing in a deeper manner to this repository, please first discuss the change you wish to make via our 
-[Discord channel here](https://discord.gg/Pt2NrnS), or contact us at info@cartesi.io email before working on the change.
+When contributing in a deeper manner to this repository, please first discuss the change you wish to make via our
+[Discord channel here](https://discord.gg/cartesi), or contact us at info@cartesi.io email before working on the change.

--- a/tests/machine/src/htif_util.h
+++ b/tests/machine/src/htif_util.h
@@ -34,7 +34,7 @@
     ((((reason) & 0xffffUL) << 32UL) | (((data) & 0xffffffffUL)))
 
 // Issue a HTIF call with `ireg` as the input, place the output in `oreg`.
-// NOTE: `base` will be used as scrach register
+// NOTE: `base` will be used as scratch register
 #define htif_call(base, ireg, oreg) \
     li base, PMA_HTIF_START_DEF; \
     sd zero, O_FROMHOST (base); \

--- a/tests/uarch/CONTRIBUTING.md
+++ b/tests/uarch/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 Thank you for your interest in Cartesi! We highly appreciate even the smallest of fixes or additions to our project.
 
-Make sure to review our [Contributing License Agreement](https://forms.gle/k3E9ZNkZY6Vy3mkK9), 
-sign and send it to info@cartesi.io with the title of "CLA Signed" before taking part in the project. We are happy to automate 
+Make sure to review our [Contributing License Agreement](https://forms.gle/k3E9ZNkZY6Vy3mkK9),
+sign and send it to info@cartesi.io with the title of "CLA Signed" before taking part in the project. We are happy to automate
 this for you via DocuSign upon request in the Google Form as well.
 
 ## Basic Contributing Guidelines
 
-We use the same guidelines for contributing code to any of our repositories, any developers wanting to contribute to Cartesi must create pull requests. This process is described in the [GitHub documentation](https://help.github.com/en/articles/creating-a-pull-request). Each pull request should be started against the master branch in the respective Cartesi repository. After a pull request is submitted the Cartesi team will review the submission and give feedback via the comments section of the pull request. After the submission is reviewed and approved, it will be merged into the master branch of the source. 
+We use the same guidelines for contributing code to any of our repositories, any developers wanting to contribute to Cartesi must create pull requests. This process is described in the [GitHub documentation](https://help.github.com/en/articles/creating-a-pull-request). Each pull request should be started against the master branch in the respective Cartesi repository. After a pull request is submitted the Cartesi team will review the submission and give feedback via the comments section of the pull request. After the submission is reviewed and approved, it will be merged into the master branch of the source.
 
 Please note the below! We appreciate everyone following the guidelines.
 
@@ -18,5 +18,5 @@ Please note the below! We appreciate everyone following the guidelines.
 
 ## Get in Touch
 
-When contributing in a deeper manner to this repository, please first discuss the change you wish to make via our 
-[Discord channel here](https://discord.gg/Pt2NrnS), or contact us at info@cartesi.io email before working on the change.
+When contributing in a deeper manner to this repository, please first discuss the change you wish to make via our
+[Discord channel here](https://discord.gg/cartesi), or contact us at info@cartesi.io email before working on the change.


### PR DESCRIPTION
I have been experimenting a new IDE to code, where I have enabled the following LSPs:

- typos
- clangd
- lua-language-server

This commit fix all warnings I had with them. Plus you will be able to check for typos across the code base by running `typos` command (if you have it installed in your system).