### PR TITLE
Fix boost url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ doc:
 bundle-boost: $(DEPDIR)/downloads/boost
 $(DEPDIR)/downloads/boost:
 	mkdir -p $(DOWNLOADDIR)
-	wget -O $(DEPDIR)/downloads/boost_1_81_0.tar.gz https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.gz
+	wget -O $(DEPDIR)/downloads/boost_1_81_0.tar.gz https://archives.boost.io/release/1.81.0/source/boost_1_81_0.tar.gz
 	tar -C $(DEPDIR)/downloads -xzf $(DEPDIR)/downloads/boost_1_81_0.tar.gz boost_1_81_0/boost
 	mv $(DEPDIR)/downloads/boost_1_81_0/boost $(DEPDIR)/downloads/boost
 	rm -rf $(DEPDIR)/downloads/boost_1_81_0.tar.gz $(DEPDIR)/downloads/boost_1_81_0


### PR DESCRIPTION
Fix boost url from @stskeeps [message](https://discord.com/channels/600597137524391947/1107965671976992878/1324101229474742302):
```md
[16:45]Carsten | Zippie: https://github.com/cartesi/machine-emulator/blob/main/Makefile#L213C1-L214C1 - the boost url no longer works

official one is https://archives.boost.io/release/1.81.0/source/boost_1_81_0.tar.gz
GitHub
[machine-emulator/Makefile at main · cartesi/machine-emulator](https://github.com/cartesi/machine-emulator/blob/main/Makefile)
The off-chain implementation of the Cartesi Machine - cartesi/machine-emulator
```
