### PR TITLE
Feature/tools 0.17.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 **/*.o
+**/*.a
 **/*.swp
 **/*.d
 **/*.pb.cc
@@ -7,14 +8,14 @@
 **/*.so
 **/*.dtb
 **/*.bin
+!uarch/uarch-ram.bin
 **/*.md
 **/*.deb
 
 build
 third-party/downloads
-src/cartesi-machine-client
-src/cartesi-machine-server
-src/cartesi-machine-hash
+src/cartesi-jsonrpc-machine
+src/cartesi-merkle-tree-hash
 
 doc/html
 doc/api.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Run jsonrpc lua test scripts
         run: |
-          docker run --rm -t ${{ github.repository_owner }}/machine-emulator:tests /usr/share/cartesi-machine/tests/scripts/test-jsonrpc-server.sh jsonrpc-remote-cartesi-machine cartesi-machine cartesi-machine-tests
+          docker run --rm -t ${{ github.repository_owner }}/machine-emulator:tests /usr/share/cartesi-machine/tests/scripts/test-jsonrpc-server.sh cartesi-jsonrpc-machine cartesi-machine cartesi-machine-tests
 
       - name: Create cmio templates
         run: |
@@ -217,7 +217,7 @@ jobs:
 
       - name: Run cmio lua test scripts
         run: |
-          docker run --rm -t -v cmio-templates:/tmp/cartesi-machine/tests/data cartesi/machine-emulator:tests /usr/share/cartesi-machine/tests/scripts/test-cmio.sh jsonrpc-remote-cartesi-machine cartesi-machine lua
+          docker run --rm -t -v cmio-templates:/tmp/cartesi-machine/tests/data cartesi/machine-emulator:tests /usr/share/cartesi-machine/tests/scripts/test-cmio.sh cartesi-jsonrpc-machine cartesi-machine lua
 
       - name: Run Merkle tree tests
         run: |
@@ -381,7 +381,7 @@ jobs:
 
       - name: Run jsonrpc lua test scripts
         run: |
-          docker run --platform linux/arm64 --rm -t ${{ github.repository_owner }}/machine-emulator:tests /usr/share/cartesi-machine/tests/scripts/test-jsonrpc-server.sh jsonrpc-remote-cartesi-machine cartesi-machine cartesi-machine-tests
+          docker run --platform linux/arm64 --rm -t ${{ github.repository_owner }}/machine-emulator:tests /usr/share/cartesi-machine/tests/scripts/test-jsonrpc-server.sh cartesi-jsonrpc-machine cartesi-machine cartesi-machine-tests
 
       - name: Create cmio templates
         run: |
@@ -389,7 +389,7 @@ jobs:
 
       - name: Run cmio lua test scripts
         run: |
-          docker run --platform linux/arm64 --rm -t -v cmio-templates:/tmp/cartesi-machine/tests/data cartesi/machine-emulator:tests /usr/share/cartesi-machine/tests/scripts/test-cmio.sh jsonrpc-remote-cartesi-machine cartesi-machine lua
+          docker run --platform linux/arm64 --rm -t -v cmio-templates:/tmp/cartesi-machine/tests/data cartesi/machine-emulator:tests /usr/share/cartesi-machine/tests/scripts/test-cmio.sh cartesi-jsonrpc-machine cartesi-machine lua
 
       - name: Run Merkle tree tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,8 +104,8 @@ jobs:
             uarch-pristine-hash.c
             machine-c-version.h
             interpret-jump-table.h
-            cartesi-machine-v${{ env.MACHINE_EMULATOR_VERSION }}_amd64.deb
-            cartesi-machine-v${{ env.MACHINE_EMULATOR_VERSION }}_arm64.deb
+            machine-emulator_amd64.deb
+            machine-emulator_arm64.deb
 
   test_amd64:
     name: Test (linux/amd64)
@@ -278,8 +278,8 @@ jobs:
         with:
           name: tests-amd64
           path: |
-            cartesi-machine-tests-v${{ env.MACHINE_EMULATOR_VERSION }}_amd64.deb
-            cartesi-machine-tests-data-v${{ env.MACHINE_EMULATOR_VERSION }}.deb
+            machine-emulator-tests_amd64.deb
+            machine-emulator-tests-data.deb
 
   test_arm64:
     name: Test (linux/arm64)
@@ -437,7 +437,7 @@ jobs:
         with:
           name: tests-arm64
           path: |
-            cartesi-machine-tests-v${{ env.MACHINE_EMULATOR_VERSION }}_arm64.deb
+            machine-emulator-tests_arm64.deb
 
   static-analysis:
     name: Static Analysis
@@ -716,10 +716,6 @@ jobs:
         uses: actions/download-artifact@v4
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Create uarch json logs TAR
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: mv uarch-logs/uarch-riscv-tests-json-logs.tar.gz uarch-logs/uarch-riscv-tests-json-logs-v${{ env.MACHINE_EMULATOR_VERSION }}.tar.gz
-
       - name: Create generated files patch
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
@@ -735,9 +731,9 @@ jobs:
         with:
           draft: true
           files: |
-            artifacts/cartesi-machine-*.deb
+            artifacts/machine-emulator_*.deb
             artifacts/uarch-ram.bin
             add-generated-files.diff
-            uarch-logs/uarch-riscv-tests-json-logs-*.tar.gz
-            tests-amd64/cartesi-machine-tests-*.deb
-            tests-arm64/cartesi-machine-tests-*.deb
+            uarch-logs/uarch-riscv-tests-json-logs.tar.gz
+            tests-amd64/machine-emulator-tests_*.deb
+            tests-arm64/machine-emulator-tests_*.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,6 @@ jobs:
           tags: ${{ github.repository_owner }}/machine-emulator:devel.build
           push: false
           load: true
-          cache-from: type=gha,scope=debian
-          cache-to: type=gha,mode=max,scope=debian
           build-args: |
             DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
@@ -60,8 +58,6 @@ jobs:
           tags: cartesi/machine-emulator:amd64_deb
           push: false
           load: true
-          cache-from: type=gha,scope=debian
-          cache-to: type=gha,mode=max,scope=debian
           build-args: |
             DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
@@ -82,8 +78,6 @@ jobs:
           tags: cartesi/machine-emulator:arm64_deb
           push: false
           load: true
-          cache-from: type=gha,scope=debian
-          cache-to: type=gha,mode=max,scope=debian
           build-args: |
             DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
@@ -146,8 +140,6 @@ jobs:
           tags: ${{ github.repository_owner }}/machine-emulator:builder
           push: false
           load: true
-          cache-from: type=gha,scope=debian
-          cache-to: type=gha,mode=max,scope=debian
           build-args: |
             DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
@@ -164,8 +156,6 @@ jobs:
           tags: ${{ github.repository_owner }}/machine-emulator:devel
           push: false
           load: true
-          cache-from: type=gha,scope=debian
-          cache-to: type=gha,mode=max,scope=debian
           build-args: |
             DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
@@ -321,8 +311,6 @@ jobs:
           tags: ${{ github.repository_owner }}/machine-emulator:builder
           push: false
           load: true
-          cache-from: type=gha,scope=debian
-          cache-to: type=gha,mode=max,scope=debian
           build-args: |
             DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
@@ -339,8 +327,6 @@ jobs:
           tags: ${{ github.repository_owner }}/machine-emulator:devel
           push: false
           load: true
-          cache-from: type=gha,scope=debian
-          cache-to: type=gha,mode=max,scope=debian
           build-args: |
             DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
@@ -478,8 +464,6 @@ jobs:
           tags: ${{ github.repository_owner }}/machine-emulator:devel
           push: false
           load: true
-          cache-from: type=gha,scope=debian
-          cache-to: type=gha,mode=max,scope=debian
           build-args: |
             DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}
@@ -541,8 +525,6 @@ jobs:
           tags: ${{ github.repository_owner }}/machine-emulator:builder
           push: false
           load: true
-          cache-from: type=gha,scope=debian-coverage
-          cache-to: type=gha,mode=max,scope=debian-coverage
           build-args: |
             GIT_COMMIT=${GITHUB_SHA}
             DEBUG=yes
@@ -623,8 +605,6 @@ jobs:
           tags: ${{ github.repository_owner }}/machine-emulator:builder
           push: false
           load: true
-          cache-from: type=gha,scope=debian-sanitize
-          cache-to: type=gha,mode=max,scope=debian-sanitize
           build-args: |
             DEBUG=yes
             GIT_COMMIT=${GITHUB_SHA}
@@ -703,8 +683,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_image_tags.outputs.tags }}
           push: true
-          cache-from: type=gha,scope=debian
-          cache-to: type=gha,mode=max,scope=debian
           build-args: |
             DEBUG=${{ (startsWith(github.ref, 'refs/tags/v') && 'no' || 'yes') }}
             GIT_COMMIT=${GITHUB_SHA}

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ build
 pkg
 third-party/downloads
 src/cartesi-jsonrpc-machine
-src/merkle-tree-hash
+src/cartesi-merkle-tree-hash
 src/tests/test-machine-c-api
 src/tests/test-merkle-tree-hash
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 build
 pkg
 third-party/downloads
-src/jsonrpc-remote-cartesi-machine
+src/cartesi-jsonrpc-machine
 src/merkle-tree-hash
 src/tests/test-machine-c-api
 src/tests/test-merkle-tree-hash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `--log-uarch-reset` command line option to `--log-reset-uarch`
 - Renamed `--auto-uarch-reset` command line option to `--auto-reset-uarch`
 - Renamed various C API functions, structs, and enumerations
+- Renamed `jsonrpc-remote-cartesi-machine` to `cartesi-jsonrpc-machine`
 - Revamped project README with more up-to-date explanations and simplified instructions
 - Changed help and configs to be printed to `stdout` instead of `stderr`
 - Changed the public C API to require less manual memory management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `--auto-uarch-reset` command line option to `--auto-reset-uarch`
 - Renamed various C API functions, structs, and enumerations
 - Renamed `jsonrpc-remote-cartesi-machine` to `cartesi-jsonrpc-machine`
+- Renamed `merkle-tree-hash` to `cartesi-merkle-tree-hash`
 - Revamped project README with more up-to-date explanations and simplified instructions
 - Changed help and configs to be printed to `stdout` instead of `stderr`
 - Changed the public C API to require less manual memory management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved CI to use more parallel jobs when testing
 - Improved `send_cmio_response` bounds checking
 - Split `iflags` CSR into multiple CSRs
+- Bumped MARCHID version to 19
+- Updated test rootfs to guest tools 0.17.0
 
 ## Removed
 - Removed publishing of Debian package artifacts in favor of official Linux package repositories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed various C API functions, structs, and enumerations
 - Renamed `jsonrpc-remote-cartesi-machine` to `cartesi-jsonrpc-machine`
 - Renamed `merkle-tree-hash` to `cartesi-merkle-tree-hash`
+- Removed `cartesi-` prefix and versioning suffix from CI artifacts names
 - Revamped project README with more up-to-date explanations and simplified instructions
 - Changed help and configs to be printed to `stdout` instead of `stderr`
 - Changed the public C API to require less manual memory management

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,4 +103,4 @@ EXPOSE 5002
 
 USER cartesi
 
-CMD [ "/usr/bin/jsonrpc-remote-cartesi-machine", "--server-address=0.0.0.0:5002"]
+CMD [ "/usr/bin/cartesi-jsonrpc-machine", "--server-address=0.0.0.0:5002"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-20250113 AS toolchain
+FROM debian:bookworm-20250407 AS toolchain
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -80,7 +80,7 @@ FROM builder AS debian-packager
 RUN make install-uarch debian-package DESTDIR=$PWD/_install
 
 ####################################################################################################
-FROM debian:bookworm-20250113-slim
+FROM debian:bookworm-20250407-slim
 ARG TARGETARCH
 
 COPY --from=debian-packager \

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,18 +81,17 @@ RUN make install-uarch debian-package DESTDIR=$PWD/_install
 
 ####################################################################################################
 FROM debian:bookworm-20250113-slim
-ARG MACHINE_EMULATOR_VERSION=0.0.0
 ARG TARGETARCH
 
 COPY --from=debian-packager \
-    /usr/src/emulator/cartesi-machine-v${MACHINE_EMULATOR_VERSION}_${TARGETARCH}.deb \
-    cartesi-machine.deb
+    /usr/src/emulator/machine-emulator_${TARGETARCH}.deb \
+    machine-emulator.deb
 COPY --from=debian-packager /usr/local/lib/lua /usr/local/lib/lua
 COPY --from=debian-packager /usr/local/share/lua /usr/local/share/lua
 
 RUN apt-get update && \
-    apt-get install -y ./cartesi-machine.deb && \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt/* cartesi-machine.deb
+    apt-get install -y ./machine-emulator.deb && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/* machine-emulator.deb
 
 RUN addgroup --system --gid 102 cartesi && \
     adduser --system --uid 102 --ingroup cartesi --disabled-login --no-create-home --home /nonexistent --gecos "cartesi user" --shell /bin/false cartesi

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -19,8 +19,8 @@ This project includes several submodules and dependencies, each with its own lic
 
 The project releases several Debian packages, each subject to its specific licensing terms:
 
-- `cartesi-machine-[VERSION]_[ARCHITECTURE].deb` and `cartesi-machine-tests-[VERSION]_[ARCHITECTURE].deb` packages are licensed under LGPL v3.0 and may include or link to other software components with different licenses.
-- `cartesi-machine-tests-data-[VERSION].deb`: This package contains files that are individually licensed under various terms, including but not limited to Apache-2.0, BSD-3-Clause-Regents, BSD-3-Clause, and GPL-2.0-only. For a comprehensive overview of the licenses applicable to specific files within this package, please refer to its copyright file, e.g., [tools/template/tests-data-copyright.template](tools/template/tests-data-copyright.template).
+- `machine-emulator-[VERSION]_[ARCHITECTURE].deb` and `machine-tests-[VERSION]_[ARCHITECTURE].deb` packages are licensed under LGPL v3.0 and may include or link to other software components with different licenses.
+- `machine-tests-data-[VERSION].deb`: This package contains files that are individually licensed under various terms, including but not limited to Apache-2.0, BSD-3-Clause-Regents, BSD-3-Clause, and GPL-2.0-only. For a comprehensive overview of the licenses applicable to specific files within this package, please refer to its copyright file, e.g., [tools/template/tests-data-copyright.template](tools/template/tests-data-copyright.template).
 
 For detailed licensing information of each Debian package, please refer to the copyright file included within the package.
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ INSTALL_DIR= cp -RP
 SYMLINK= ln -sf
 CHMOD_EXEC= chmod 0755
 
-EMU_TO_BIN= src/cartesi-jsonrpc-machine src/merkle-tree-hash
+EMU_TO_BIN= src/cartesi-jsonrpc-machine src/cartesi-merkle-tree-hash
 EMU_TO_LIB= src/$(LIBCARTESI_SO) src/$(LIBCARTESI_SO_JSONRPC)
 EMU_TO_LIB_A= src/libcartesi.a src/libcartesi_jsonrpc.a src/libluacartesi.a src/libluacartesi_jsonrpc.a
 EMU_LUA_TO_BIN= src/cartesi-machine.lua src/cartesi-machine-stored-hash.lua

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ INSTALL_DIR= cp -RP
 SYMLINK= ln -sf
 CHMOD_EXEC= chmod 0755
 
-EMU_TO_BIN= src/jsonrpc-remote-cartesi-machine src/merkle-tree-hash
+EMU_TO_BIN= src/cartesi-jsonrpc-machine src/merkle-tree-hash
 EMU_TO_LIB= src/$(LIBCARTESI_SO) src/$(LIBCARTESI_SO_JSONRPC)
 EMU_TO_LIB_A= src/libcartesi.a src/libcartesi_jsonrpc.a src/libluacartesi.a src/libluacartesi_jsonrpc.a
 EMU_LUA_TO_BIN= src/cartesi-machine.lua src/cartesi-machine-stored-hash.lua

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ DEB_ARCH?= $(shell dpkg --print-architecture 2>/dev/null || echo amd64)
 PREFIX= /usr
 MACHINE_EMULATOR_VERSION= $(shell make -sC src version)
 MACHINE_EMULATOR_SO_VERSION= $(shell make -sC src so-version)
-DEB_FILENAME= cartesi-machine-v$(MACHINE_EMULATOR_VERSION)_$(DEB_ARCH).deb
+DEB_FILENAME= machine-emulator_$(DEB_ARCH).deb
 BIN_RUNTIME_PATH= $(PREFIX)/bin
 LIB_RUNTIME_PATH= $(PREFIX)/lib
 DOC_RUNTIME_PATH= $(PREFIX)/doc/cartesi-machine
@@ -31,8 +31,8 @@ IMAGES_RUNTIME_PATH= $(SHARE_RUNTIME_PATH)/images
 LUA_RUNTIME_CPATH= $(PREFIX)/lib/lua/5.4
 LUA_RUNTIME_PATH= $(PREFIX)/share/lua/5.4
 
-TESTS_DEB_FILENAME= cartesi-machine-tests-v$(MACHINE_EMULATOR_VERSION)_$(DEB_ARCH).deb
-TESTS_DATA_DEB_FILENAME= cartesi-machine-tests-data-v$(MACHINE_EMULATOR_VERSION).deb
+TESTS_DEB_FILENAME= machine-emulator-tests_$(DEB_ARCH).deb
+TESTS_DATA_DEB_FILENAME= machine-emulator-tests-data.deb
 TESTS_DATA_RUNTIME_PATH= $(SHARE_RUNTIME_PATH)/tests/data
 TESTS_SCRIPTS_RUNTIME_PATH= $(SHARE_RUNTIME_PATH)/tests/scripts
 TESTS_LUA_RUNTIME_PATH= $(SHARE_RUNTIME_PATH)/tests/lua
@@ -174,7 +174,7 @@ help:
 	@echo '  doc                                 - Build the doxygen documentation (requires doxygen)'
 	@echo 'Docker images targets:'
 	@echo '  build-emulator-image                - Build the machine-emulator debian based docker image'
-	@echo '  build-debian-package                - Build the cartesi-machine.deb package from image'
+	@echo '  build-debian-package                - Build the machine-emulator.deb package from image'
 	@echo '  build-toolchain                     - Build the emulator toolchain docker image'
 	@echo '  create-generated-files-patch        - Create patch that adds generated files to source tree'
 	@echo 'Cleaning targets:'
@@ -186,7 +186,7 @@ $(SUBCLEAN): %.clean:
 	@$(MAKE) -C $* clean
 
 clean: $(SUBCLEAN)
-	@rm -rf cartesi-machine-*.deb
+	@rm -rf machine-emulator*.deb
 	@rm -rf $(ADD_GENERATED_FILES_DIFF)
 
 depclean: clean
@@ -256,19 +256,19 @@ build-emulator-toolchain-image build-toolchain:
 	docker build $(DOCKER_PLATFORM) --target toolchain -t cartesi/machine-emulator:toolchain -f Dockerfile .
 
 build-emulator-image:
-	docker build $(DOCKER_PLATFORM) --build-arg DEBUG=$(debug) --build-arg COVERAGE=$(coverage) --build-arg SANITIZE=$(sanitize) --build-arg MACHINE_EMULATOR_VERSION=$(MACHINE_EMULATOR_VERSION) -t cartesi/machine-emulator:$(TAG) -f Dockerfile .
+	docker build $(DOCKER_PLATFORM) --build-arg DEBUG=$(debug) --build-arg COVERAGE=$(coverage) --build-arg SANITIZE=$(sanitize) -t cartesi/machine-emulator:$(TAG) -f Dockerfile .
 
 build-emulator-tests-image: build-emulator-builder-image build-emulator-image
-	docker build $(DOCKER_PLATFORM) --build-arg DEBUG=$(debug) --build-arg COVERAGE=$(coverage) --build-arg SANITIZE=$(sanitize) --build-arg MACHINE_EMULATOR_VERSION=$(MACHINE_EMULATOR_VERSION) --build-arg TAG=$(TAG) -t cartesi/machine-emulator:tests -f tests/Dockerfile .
+	docker build $(DOCKER_PLATFORM) --build-arg DEBUG=$(debug) --build-arg COVERAGE=$(coverage) --build-arg SANITIZE=$(sanitize) --build-arg TAG=$(TAG) -t cartesi/machine-emulator:tests -f tests/Dockerfile .
 
 build-emulator-tests-builder-image: build-emulator-builder-image
-	docker build $(DOCKER_PLATFORM) --target tests-builder --build-arg DEBUG=$(debug) --build-arg COVERAGE=$(coverage) --build-arg SANITIZE=$(sanitize) --build-arg MACHINE_EMULATOR_VERSION=$(MACHINE_EMULATOR_VERSION) --build-arg TAG=$(TAG) -t cartesi/machine-emulator:tests-builder -f tests/Dockerfile .
+	docker build $(DOCKER_PLATFORM) --target tests-builder --build-arg DEBUG=$(debug) --build-arg COVERAGE=$(coverage) --build-arg SANITIZE=$(sanitize) --build-arg TAG=$(TAG) -t cartesi/machine-emulator:tests-builder -f tests/Dockerfile .
 
 build-debian-package:
-	docker build $(DOCKER_PLATFORM) --target debian-packager --build-arg DEBUG=$(debug) --build-arg COVERAGE=$(coverage) --build-arg SANITIZE=$(sanitize) --build-arg MACHINE_EMULATOR_VERSION=$(MACHINE_EMULATOR_VERSION) -t $(DEBIAN_IMG) -f Dockerfile .
+	docker build $(DOCKER_PLATFORM) --target debian-packager --build-arg DEBUG=$(debug) --build-arg COVERAGE=$(coverage) --build-arg SANITIZE=$(sanitize) -t $(DEBIAN_IMG) -f Dockerfile .
 
 build-tests-debian-packages: build-emulator-builder-image
-	docker build $(DOCKER_PLATFORM) --target tests-debian-packager --build-arg MACHINE_EMULATOR_VERSION=$(MACHINE_EMULATOR_VERSION) --build-arg TAG=$(TAG) -t cartesi/machine-emulator:tests-debian-packager -f tests/Dockerfile .
+	docker build $(DOCKER_PLATFORM) --target tests-debian-packager --build-arg TAG=$(TAG) -t cartesi/machine-emulator:tests-debian-packager -f tests/Dockerfile .
 	$(MAKE) copy-tests-debian-packages
 
 copy-tests-debian-packages:

--- a/src/Makefile
+++ b/src/Makefile
@@ -152,7 +152,7 @@ LIBCARTESI_MERKLE_TREE_LIBS=
 LIBCARTESI_JSONRPC_LIBS=
 LUACARTESI_LIBS=$(LIBCARTESI_COMMON_LIBS)
 LUACARTESI_JSONRPC_LIBS=
-JSONRPC_REMOTE_CARTESI_MACHINE_LIBS=$(LIBCARTESI_COMMON_LIBS)
+CARTESI_JSONRPC_MACHINE_LIBS=$(LIBCARTESI_COMMON_LIBS)
 HASH_LIBS=
 
 #DEFS+= -DMT_ALL_DIRTY
@@ -333,11 +333,11 @@ SOLDFLAGS+=$(MYSOLDFLAGS)
 LIBLDFLAGS+=$(MYLIBLDFLAGS)
 EXELDFLAGS+=$(MYEXELDFLAGS)
 
-all: libcartesi libcartesi_merkle_tree libcartesi_jsonrpc c-api luacartesi jsonrpc-remote-cartesi-machine hash
+all: libcartesi libcartesi_merkle_tree libcartesi_jsonrpc c-api luacartesi cartesi-jsonrpc-machine hash
 
 luacartesi: libluacartesi.a cartesi.so libluacartesi_jsonrpc.a cartesi/jsonrpc.so
 
-jsonrpc: cartesi/jsonrpc.so jsonrpc-remote-cartesi-machine
+jsonrpc: cartesi/jsonrpc.so cartesi-jsonrpc-machine
 
 hash: merkle-tree-hash
 
@@ -420,7 +420,7 @@ LUACARTESI_JSONRPC_OBJS:= \
 	clua-cartesi-jsonrpc.o \
 	$(CARTESI_CLUA_OBJS)
 
-JSONRPC_REMOTE_CARTESI_MACHINE_OBJS:= \
+CARTESI_JSONRPC_MACHINE_OBJS:= \
 	jsonrpc-remote-machine.o \
 	jsonrpc-discover.o \
 	slog.o
@@ -532,8 +532,8 @@ endif
 merkle-tree-hash: $(MERKLE_TREE_HASH_OBJS) libcartesi_merkle_tree.a
 	$(CXX) -o $@ $^ $(HASH_LIBS) $(LDFLAGS) $(EXELDFLAGS)
 
-jsonrpc-remote-cartesi-machine: $(JSONRPC_REMOTE_CARTESI_MACHINE_OBJS) libcartesi_jsonrpc.a libcartesi.a
-	$(CXX) -o $@ $^ $(JSONRPC_REMOTE_CARTESI_MACHINE_LIBS) $(LDFLAGS) $(EXELDFLAGS)
+cartesi-jsonrpc-machine: $(CARTESI_JSONRPC_MACHINE_OBJS) libcartesi_jsonrpc.a libcartesi.a
+	$(CXX) -o $@ $^ $(CARTESI_JSONRPC_MACHINE_LIBS) $(LDFLAGS) $(EXELDFLAGS)
 
 clua-%.o clua.o: CXXFLAGS += $(LUA_INC)
 
@@ -605,7 +605,7 @@ clean-libcartesi: clean-objs
 	@rm -f *.so *.a cartesi/*.so *.dylib
 
 clean-executables:
-	@rm -f jsonrpc-remote-cartesi-machine merkle-tree-hash compute-uarch-pristine-hash
+	@rm -f cartesi-jsonrpc-machine merkle-tree-hash compute-uarch-pristine-hash
 
 clean-coverage:
 	@rm -f *.profdata *.profraw *.gcda *.gcov coverage.info coverage.txt

--- a/src/Makefile
+++ b/src/Makefile
@@ -153,7 +153,7 @@ LIBCARTESI_JSONRPC_LIBS=
 LUACARTESI_LIBS=$(LIBCARTESI_COMMON_LIBS)
 LUACARTESI_JSONRPC_LIBS=
 CARTESI_JSONRPC_MACHINE_LIBS=$(LIBCARTESI_COMMON_LIBS)
-HASH_LIBS=
+CARTESI_MERKLE_TREE_HASH_LIBS=
 
 #DEFS+= -DMT_ALL_DIRTY
 
@@ -339,7 +339,7 @@ luacartesi: libluacartesi.a cartesi.so libluacartesi_jsonrpc.a cartesi/jsonrpc.s
 
 jsonrpc: cartesi/jsonrpc.so cartesi-jsonrpc-machine
 
-hash: merkle-tree-hash
+hash: cartesi-merkle-tree-hash
 
 c-api: $(LIBCARTESI) $(LIBCARTESI_MERKLE_TREE) $(LIBCARTESI_JSONRPC)
 
@@ -406,7 +406,7 @@ LIBCARTESI_MERKLE_TREE_OBJS:= \
 	complete-merkle-tree.o \
 	full-merkle-tree.o
 
-MERKLE_TREE_HASH_OBJS:= \
+CARTESI_MERKLE_TREE_HASH_OBJS:= \
 	merkle-tree-hash.o
 
 LIBCARTESI_JSONRPC_OBJS:= \
@@ -529,8 +529,8 @@ $(PROFILE_DATA):
 	llvm-profdata merge -output=default.profdata default*.profraw
 endif
 
-merkle-tree-hash: $(MERKLE_TREE_HASH_OBJS) libcartesi_merkle_tree.a
-	$(CXX) -o $@ $^ $(HASH_LIBS) $(LDFLAGS) $(EXELDFLAGS)
+cartesi-merkle-tree-hash: $(CARTESI_MERKLE_TREE_HASH_OBJS) libcartesi_merkle_tree.a
+	$(CXX) -o $@ $^ $(CARTESI_MERKLE_TREE_HASH_LIBS) $(LDFLAGS) $(EXELDFLAGS)
 
 cartesi-jsonrpc-machine: $(CARTESI_JSONRPC_MACHINE_OBJS) libcartesi_jsonrpc.a libcartesi.a
 	$(CXX) -o $@ $^ $(CARTESI_JSONRPC_MACHINE_LIBS) $(LDFLAGS) $(EXELDFLAGS)
@@ -605,7 +605,7 @@ clean-libcartesi: clean-objs
 	@rm -f *.so *.a cartesi/*.so *.dylib
 
 clean-executables:
-	@rm -f cartesi-jsonrpc-machine merkle-tree-hash compute-uarch-pristine-hash
+	@rm -f cartesi-jsonrpc-machine cartesi-merkle-tree-hash compute-uarch-pristine-hash
 
 clean-coverage:
 	@rm -f *.profdata *.profraw *.gcda *.gcov coverage.info coverage.txt

--- a/src/jsonrpc-machine-c-api.h
+++ b/src/jsonrpc-machine-c-api.h
@@ -55,8 +55,8 @@ typedef enum cm_jsonrpc_cleanup_call {
 /// Use cm_jsonrpc_emancipate_server() to make it leader of its own process group.
 /// \details The machine object is configured to implicitly cleanup with a shutdown during cm_delete().
 /// Use cm_jsonrpc_set_cleanup_call() to change this setting.
-/// \details Unless the desired jsonrpc-remote-cartesi-machine executable is in the path,
-/// the environment variable CARTESI_JSONRPC_REMOTE_MACHINE must point directly to the executable.
+/// \details Unless the desired cartesi-jsonrpc-machine executable is in the path,
+/// the environment variable CARTESI_JSONRPC_MACHINE must point directly to the executable.
 CM_API cm_error cm_jsonrpc_spawn_server(const char *address, int64_t spawn_timeout_ms, cm_machine **new_m,
     const char **bound_address, uint32_t *pid);
 

--- a/src/jsonrpc-remote-machine.cpp
+++ b/src/jsonrpc-remote-machine.cpp
@@ -75,7 +75,7 @@
 #include "slog.h"
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define PROGRAM_NAME "jsonrpc-remote-cartesi-machine"
+#define PROGRAM_NAME "cartesi-jsonrpc-machine"
 
 namespace beast = boost::beast; // from <boost/beast.hpp>
 namespace http = beast::http;   // from <boost/beast/http.hpp>
@@ -1658,7 +1658,7 @@ where options are
         error
         fatal
       the command line option takes precedence over the environment variable
-      REMOTE_CARTESI_MACHINE_LOG_LEVEL
+      CARTESI_JSONRPC_MACHINE_LOG_LEVEL
 
     --help
       prints this message and exits
@@ -1685,7 +1685,7 @@ static void init_logger(const char *strlevel) {
     using namespace slog;
     severity_level level = severity_level::warning;
     if (strlevel == nullptr) {
-        strlevel = std::getenv("CARTESI_REMOTE_MACHINE_LOG_LEVEL");
+        strlevel = std::getenv("CARTESI_JSONRPC_MACHINE_LOG_LEVEL");
     }
     if (strlevel != nullptr) {
         level = from_string(strlevel);

--- a/src/jsonrpc-virtual-machine.cpp
+++ b/src/jsonrpc-virtual-machine.cpp
@@ -458,9 +458,9 @@ jsonrpc_virtual_machine::jsonrpc_virtual_machine(const std::string &address, int
         address_to_endpoint(address)); // NOLINT(clang-analyzer-optin.cplusplus.VirtualCall)
 
     // Determine which remote machine binary to use
-    const char *bin = getenv("CARTESI_JSONRPC_REMOTE_MACHINE");
+    const char *bin = getenv("CARTESI_JSONRPC_MACHINE");
     if (bin == nullptr) { // Fallback to default name if not set
-        bin = "jsonrpc-remote-cartesi-machine";
+        bin = "cartesi-jsonrpc-machine";
     }
 
     // Prepare command-line arguments for the child process

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -23,13 +23,13 @@ ENV CARTESI_CMIO_PATH=/tmp/cartesi-machine/tests/data/cmio
 
 USER root
 
-COPY --from=tests-debian-packager /usr/src/emulator/cartesi-machine-tests-*.deb .
+COPY --from=tests-debian-packager /usr/src/emulator/machine-emulator-tests*.deb .
 RUN <<EOF
 set -e
 export DEBIAN_FRONTEND="noninteractive"
 apt-get update
-apt-get install -y ./cartesi-machine-tests-*.deb
-rm -rf /var/lib/apt/lists/* cartesi-machine-tests-*.deb
+apt-get install -y ./machine-emulator-tests*.deb
+rm -rf /var/lib/apt/lists/* machine-emulator-tests*.deb
 mkdir -p ${CARTESI_CMIO_PATH}
 chown -R cartesi:cartesi ${CARTESI_CMIO_PATH}
 EOF

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -179,7 +179,7 @@ clean-machines:
 	@rm -rf $(CARTESI_CMIO_PATH)
 
 test-cmio: | $(CARTESI_CMIO_PATH)
-	@./scripts/test-cmio.sh ../src/jsonrpc-remote-cartesi-machine '$(LUA) ../src/cartesi-machine.lua'
+	@./scripts/test-cmio.sh ../src/cartesi-jsonrpc-machine '$(LUA) ../src/cartesi-machine.lua'
 
 test-machine:
 	$(LUA) ./lua/cartesi-machine-tests.lua --jobs=$(NUM_JOBS) run
@@ -203,7 +203,7 @@ test-hash:
 	$(LD_PRELOAD_PREFIX) ./build/misc/test-merkle-tree-hash --log2-root-size=30 --log2-leaf-size=12 --input=build/misc/test-merkle-tree-hash
 
 test-jsonrpc:
-	./scripts/test-jsonrpc-server.sh ../src/jsonrpc-remote-cartesi-machine '$(LUA) ../src/cartesi-machine.lua' '$(LUA) ./lua/cartesi-machine-tests.lua' '$(LUA)'
+	./scripts/test-jsonrpc-server.sh ../src/cartesi-jsonrpc-machine '$(LUA) ../src/cartesi-machine.lua' '$(LUA) ./lua/cartesi-machine-tests.lua' '$(LUA)'
 
 test-lua: | $(CARTESI_IMAGES)
 	./scripts/run-lua-tests.sh '$(LUA)'
@@ -251,7 +251,7 @@ coverage-report: $(COVERAGE_OUTPUT_DIR)
 		../src/cartesi.so \
 		-object ../src/cartesi/jsonrpc.so \
 		-object ../src/$(LIBCARTESI_SO) \
-		-object ../src/jsonrpc-remote-cartesi-machine \
+		-object ../src/cartesi-jsonrpc-machine \
 		$(COVERAGE_SOURCES)
 
 export LLVM_PROFILE_FILE=coverage-%p.profraw

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -120,7 +120,7 @@ $(BUILDDIR)/%:
 $(CARTESI_IMAGES): | $(CARTESI_IMAGES_PATH)
 	@wget -nc -i dependencies -P $(CARTESI_IMAGES_PATH)
 	@shasum -ca 256 dependencies.sha256
-	@cd $(CARTESI_IMAGES_PATH) && ln -s rootfs-tools-v0.17.0-test2.ext2 rootfs.ext2
+	@cd $(CARTESI_IMAGES_PATH) && ln -s rootfs-tools.ext2 rootfs.ext2
 	@cd $(CARTESI_IMAGES_PATH) && ln -s linux-6.5.13-ctsi-1-v0.20.0.bin linux.bin
 
 images: | $(CARTESI_IMAGES)

--- a/tests/dependencies
+++ b/tests/dependencies
@@ -1,2 +1,2 @@
-https://github.com/cartesi/machine-guest-tools/releases/download/v0.17.0-test2/rootfs-tools-v0.17.0-test2.ext2
+https://github.com/cartesi/machine-guest-tools/releases/download/v0.17.0-test6/rootfs-tools.ext2
 https://github.com/cartesi/machine-linux-image/releases/download/v0.20.0/linux-6.5.13-ctsi-1-v0.20.0.bin

--- a/tests/dependencies.sha256
+++ b/tests/dependencies.sha256
@@ -1,2 +1,2 @@
 65dd100ff6204346ac2f50f772721358b5c1451450ceb39a154542ee27b4c947  build/images/linux-6.5.13-ctsi-1-v0.20.0.bin
-293f377b0cb32cc477ef2c71be9430bab3a25d54eb0ab9aff07a4e6fac6aa829  build/images/rootfs-tools-v0.17.0-test2.ext2
+104087c1499b5e1ab32599605420b617ae530b4d7987db7864648f6a532de60e  build/images/rootfs-tools.ext2

--- a/tests/lua/machine-bind.lua
+++ b/tests/lua/machine-bind.lua
@@ -46,7 +46,7 @@ where options are:
 
   --test-path=<dir>
     path to test execution folder. In case of jsonrpc tests, path must be
-    working directory of jsonrpc-remote-cartesi-machine and must be locally readable
+    working directory of cartesi-jsonrpc-machine and must be locally readable
     (default: "./")
 
   --concurrency=<key>:<value>[,<key>:<value>[,...]...]

--- a/tests/lua/machine-test.lua
+++ b/tests/lua/machine-test.lua
@@ -20,8 +20,8 @@ local cartesi = require("cartesi")
 local test_util = require("cartesi.tests.util")
 local jsonrpc
 
--- Note: for jsonrpc machine test to work, jsonrpc-remote-cartesi-machine must
--- run on the same computer and jsonrpc-remote-cartesi-machine execution path
+-- Note: for jsonrpc machine test to work, cartesi-jsonrpc-machine must
+-- run on the same computer and cartesi-jsonrpc-machine execution path
 -- must be provided
 
 -- There is no UINT64_MAX in Lua, so we have to use the signed representation
@@ -45,7 +45,7 @@ where options are:
 
   --test-path=<dir>
     path to test execution folder. In case of jsonrpc tests, path must be
-    working directory of jsonrpc-remote-cartesi-machine and must be locally readable
+    working directory of cartesi-jsonrpc-machine and must be locally readable
     (default: "./")
 
 ]=],

--- a/tools/template/control.template
+++ b/tools/template/control.template
@@ -1,12 +1,12 @@
-Package: cartesi-machine
-Source: cartesi-machine
+Package: cartesi-machine-emulator
+Source: cartesi-machine-emulator
 Version: ARG_VERSION
-Homepage: https://docs.cartesi.io/machine/host/cmdline/
+Homepage: https://github.com/cartesi/machine-emulator
 Architecture: ARG_ARCH
-Maintainer: Machine Reference Unit <https://discord.com/channels/600597137524391947/1107965671976992878>
-Provides: machine-emulator
+Maintainer: Cartesi Machine Reference Unit
+Provides: cartesi-machine-emulator
 Depends: lua5.4, libslirp0
 Section: devel
 Priority: optional
 Multi-Arch: foreign
-Description: The Cartesi Machine Emulator is the reference off-chain implementation of the Cartesi Machine Specification. It's written in C/C++ with POSIX dependencies restricted to the terminal, process, and memory-mapping facilities. It is distributed as a library and scriptable in the Lua programming language.
+Description: Cartesi Machine emulator for RISC-V Linux systems

--- a/tools/template/tests-control.template
+++ b/tools/template/tests-control.template
@@ -1,12 +1,12 @@
 Package: cartesi-machine-tests
 Source: cartesi-machine-tests
 Version: ARG_VERSION
-Homepage: https://docs.cartesi.io/machine/host/cmdline/
+Homepage: https://github.com/cartesi/machine-emulator
 Architecture: ARG_ARCH
-Maintainer: Machine Reference Unit <https://discord.com/channels/600597137524391947/1107965671976992878>
-Provides: machine-emulator-tests
-Depends: cartesi-machine (>= ARG_VERSION)
+Maintainer: Cartesi Machine Reference Unit
+Provides: cartesi-machine-tests
+Depends: cartesi-machine-emulator (>= ARG_VERSION)
 Section: devel
 Priority: optional
 Multi-Arch: foreign
-Description: The Cartesi Machine Emulator is the reference off-chain implementation of the Cartesi Machine Specification. It's written in C/C++ with POSIX dependencies restricted to the terminal, process, and memory-mapping facilities. It is distributed as a library and scriptable in the Lua programming language.
+Description: Cartesi Machine emulator tests

--- a/tools/template/tests-data-control.template
+++ b/tools/template/tests-data-control.template
@@ -1,12 +1,12 @@
 Package: cartesi-machine-tests-data
-Source: cartesi-machine
+Source: cartesi-machine-tests-data
 Version: ARG_VERSION
-Homepage: https://docs.cartesi.io/machine/host/cmdline/
+Homepage: https://github.com/cartesi/machine-emulator
 Architecture: all
-Maintainer: Machine Reference Unit <https://discord.com/channels/600597137524391947/1107965671976992878>
-Provides: machine-emulator-tests-data
-Depends: cartesi-machine (>= ARG_VERSION), procps
+Maintainer: Cartesi Machine Reference Unit
+Provides: cartesi-machine-tests-data
+Depends: cartesi-machine-emulator (>= ARG_VERSION), procps
 Section: devel
 Priority: optional
 Multi-Arch: foreign
-Description: The Cartesi Machine Emulator is the reference off-chain implementation of the Cartesi Machine Specification. It's written in C/C++ with POSIX dependencies restricted to the terminal, process, and memory-mapping facilities. It is distributed as a library and scriptable in the Lua programming language.
+Description: Cartesi Machine emulator tests data

--- a/tools/template/tests-data-copyright.template
+++ b/tools/template/tests-data-copyright.template
@@ -55,7 +55,7 @@ Copyright: Various authors, see below
 Source: https://github.com/cartesi/linux/
 License: GPL-2.0-only
 
-Files: /usr/share/cartesi-machine/tests/data/images/rootfs-tools-v0.17.0-test2.ext2
+Files: /usr/share/cartesi-machine/tests/data/images/rootfs-tools.ext2
 Copyright: Various authors, see below
 Source: https://github.com/cartesi/machine-guest-tools/
 License: Various, see below


### PR DESCRIPTION
 Depends on https://github.com/cartesi/machine-emulator/pull/318

- Bump tools to 0.17.0
- Bump Debian bookworm base image
- Removed `cartesi-` prefix and versioning suffix from CI artifacts names
- Renamed `merkle-tree-hash` to `cartesi-merkle-tree-hash`
- Renamed `jsonrpc-remote-cartesi-machine` to `cartesi-jsonrpc-machine`
- Renamed jsonrpc machine environment variables to match the new names
- Fix cache issue in CI