### PR TITLE
Remove third-party/ directory from code statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+third-party/** linguist-vendored


### PR DESCRIPTION
Github language statistics are taking third-party/ into consideration, which skews the statistics towards the many, many risc-v tests written in assembly. This (allegedly) fixes the issue. 