### PR TITLE
Remove tests/ from language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 third-party/** linguist-vendored
+tests/** linguist-vendored


### PR DESCRIPTION
Seems like tests/ has a lot of lines of ASM tests for floating point.
