### PR TITLE
fix(doc): sort apt source URIs so license report is deterministic

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -507,7 +507,7 @@ sha256sum /usr/share/cartesi-machine/images/rootfs.ext2
 ```
 
 ``` text
-8794f80142720deb12af21c244eb62f92ad510ddb79d8c7efecc3a5f82f0ed1c  /usr/share/cartesi-machine/images/rootfs.ext2
+36723e8ecb69ef1894d3b3f1695ef228edc5eda18e8518295eca963eeaab8915  /usr/share/cartesi-machine/images/rootfs.ext2
 ```
 
 Note that, if the hashes of the files you are using do not match the
@@ -967,7 +967,7 @@ cartesi-machine \
 produces the output
 
 ``` text
-0: 84ff7b981071b478d1b2b65d87bee69ef51c2843d83a0e9f29091cecc30e36eb
+0: 8d88d5046ac53f5fd86a202e13e0a3673a57d15c777cc08165b5b00d302cc61b
 
          .
         / \
@@ -976,17 +976,17 @@ produces the output
  \       X       \
   \----/  \---/---\
        \    / CARTESI
-37056198: b1e39966051146ff7ed4f2ee2d4df9823292966c3b2afff83ef48b4d0c3a66cb
+37056198: bd519ba2aa3584e90e6b92636207b7cb9619d6ff4cc8bcdf43e14ec4be1d4a47
 ```
 
-The initial state hash `84ff7b98…` is the Merkle tree root hash for the
+The initial state hash `8d88d504…` is the Merkle tree root hash for the
 initial Cartesi Machine state. Since Cartesi Machines are reproducible,
 the initial state hash also works as a *promise* on the result of the
 entire computation.
 
-In other words, the “final state hash” `b1e39966…` is the “only”
+In other words, the “final state hash” `bd519ba2…` is the “only”
 possible outcome for the `--final-hash` at cycle `37056198`, given the
-result of the `--initial-hash` operation was `84ff7b98…`.
+result of the `--initial-hash` operation was `8d88d504…`.
 
 > [!NOTE]
 >
@@ -1016,7 +1016,7 @@ cartesi-machine \
 produces instead the output
 
 ``` text
-0: 84ff7b981071b478d1b2b65d87bee69ef51c2843d83a0e9f29091cecc30e36eb
+0: 8d88d5046ac53f5fd86a202e13e0a3673a57d15c777cc08165b5b00d302cc61b
 
          .
         / \
@@ -1032,15 +1032,15 @@ Nothing to do.
 
 Halted
 Cycles: 41860488
-41860488: 009c5cd36fd3e6a11ca6adf44a37871a75ea79a99ccceebcebae0630450c77ee
+41860488: 50b8042f3e70419f7f4aa5dc948302e603e6b7379143338e10c190604cd4120a
 ```
 
 Naturally, the initial state hash is the same as before.
 
-However, the final state hash `009c5cd3…` now pertains to cycle
+However, the final state hash `50b8042f…` now pertains to cycle
 `41860488`, where the machine is halted. This is the “only” possible
 state hash for a *halted* machine that started from state hash
-`84ff7b98…`.
+`8d88d504…`.
 
 ### Persistent Cartesi Machines
 
@@ -1051,7 +1051,7 @@ command-line option `--store=<directory>`. (In `<directory>`, the `%h`
 escape will be replaced by the state hash in hex.) The machine is stored
 as it was right before `cartesi-machine` returns to the command line.
 For example, to store the machine corresponding to state hash
-`b1e39966…`
+`bd519ba2…`
 
 ``` bash
 cartesi-machine \
@@ -1059,7 +1059,7 @@ cartesi-machine \
     --store="machine-%8h"
 ```
 
-This command creates a directory `machine-b1e39966`, containing a
+This command creates a directory `machine-bd519ba2`, containing a
 variety of files that allow the Cartesi Machine emulator to recreate a
 machine state. Every image file is copied into the directory, so no
 external dependencies remain.
@@ -1080,7 +1080,7 @@ the corresponding Cartesi Machine, use the command-line option
 
 ``` bash
 cartesi-machine \
-    --load="machine-b1e39966" \
+    --load="machine-bd519ba2" \
     --initial-hash \
     --final-hash
 ```
@@ -1089,7 +1089,7 @@ produces the output
 
 ``` text
 Loading machine: please wait
-37056198: b1e39966051146ff7ed4f2ee2d4df9823292966c3b2afff83ef48b4d0c3a66cb
+37056198: bd519ba2aa3584e90e6b92636207b7cb9619d6ff4cc8bcdf43e14ec4be1d4a47
 
         \ /   MACHINE
          '
@@ -1098,16 +1098,16 @@ Nothing to do.
 
 Halted
 Cycles: 41860488
-41860488: 009c5cd36fd3e6a11ca6adf44a37871a75ea79a99ccceebcebae0630450c77ee
+41860488: 50b8042f3e70419f7f4aa5dc948302e603e6b7379143338e10c190604cd4120a
 ```
 
 Note that, other than `--load`, no initialization command-line options
 were used. These initializations were used to define the machine before
 it was stored: their values are implicitly encoded in the stored state.
 The machine continues from where it left off, and reaches the same final
-state hash `009c5cd3…`, as if it had never been interrupted.
+state hash `50b8042f…`, as if it had never been interrupted.
 
-Note also that the initial state hash `b1e39966…` after `--load` matches
+Note also that the initial state hash `bd519ba2…` after `--load` matches
 the final state hash before `--store`. After all, they are state hashes
 concerning the state of the same machine at the same cycle. `--load`
 verifies the archive format version recorded in the stored machine, and
@@ -1118,13 +1118,13 @@ The `cartesi-machine-stored-hash` command-line utility can be used to
 extract the state hash from a stored Cartesi Machine. The command
 
 ``` bash
-cartesi-machine-stored-hash machine-b1e39966
+cartesi-machine-stored-hash machine-bd519ba2
 ```
 
 produces the output
 
 ``` text
-b1e39966051146ff7ed4f2ee2d4df9823292966c3b2afff83ef48b4d0c3a66cb
+bd519ba2aa3584e90e6b92636207b7cb9619d6ff4cc8bcdf43e14ec4be1d4a47
 ```
 
 ### Running as root
@@ -1314,7 +1314,7 @@ cartesi-machine \
 The result is as follows
 
 ``` text
-0: 40e013a285bd582a10737871dbdb9584e6e320d2dd433e55f6ece54bfe39564b
+0: 63ec96cbd560ec29bbeba48b955c5b891974faf8d8a2b222c5003ccb8ce60b0b
 Storing machine: please wait
 ```
 
@@ -1328,10 +1328,10 @@ cartesi-machine-stored-hash calculator-template/
 we can see from the output
 
 ``` text
-40e013a285bd582a10737871dbdb9584e6e320d2dd433e55f6ece54bfe39564b
+63ec96cbd560ec29bbeba48b955c5b891974faf8d8a2b222c5003ccb8ce60b0b
 ```
 
-that the stored template hash is `40e013a2…`.
+that the stored template hash is `63ec96cb…`.
 
 Templates are typically used by programs that control the emulator with
 the C++, Lua, or JSON-RPC interfaces.
@@ -1414,12 +1414,12 @@ The output of the command is
 
 ``` text
 Loading machine: please wait
-0: 40e013a285bd582a10737871dbdb9584e6e320d2dd433e55f6ece54bfe39564b
+0: 63ec96cbd560ec29bbeba48b955c5b891974faf8d8a2b222c5003ccb8ce60b0b
 ```
 
 In addition, the `pristine-input-proof.lua` file now contains a Lua
 table with the requested proof. The value of field `root_hash` is the
-expected initial state hash `0x40e013…` seen in the output of the
+expected initial state hash `0x63ec96…` seen in the output of the
 `cartesi-machine` command. The `target_address` value `0xa0000000` is
 the start of the input NVRAM. The `log2_target_size` value `12` refers
 to the size of the 4KiB input NVRAM. The `target_hash` value `0x292c23…`
@@ -1489,14 +1489,14 @@ This produces the output
 
 ``` text
 Loading machine: please wait
-0: 64742925768fdc59214daf0c21b6658fa949e9c40b6289f8f44f7b060cf55008
+0: 33b2ea2a51ebc59bbd2a4be4598c12f3404dadbf00bb14a055fdf6a98f70d5b1
 ```
 
 In addition, the `input-proof.lua` file now contains a Lua table with
 the requested proof, which is produced after the input NVRAM has been
 replaced. The `target_hash` value `0xd5ea32…` reflects the hash computed
-for the input. The `root_hash` value `0x647429…` differs from
-`40e013a2…` obtained for the template, as expected, and matches the
+for the input. The `root_hash` value `0x33b2ea…` differs from
+`63ec96cb…` obtained for the template, as expected, and matches the
 final hash printed by the utility. Moreover, the `sibling_hashes`
 entries in the template Cartesi Machine and in the instantiated Cartesi
 Machine remain the same, reflecting the fact that there were no other
@@ -1532,10 +1532,10 @@ Loading machine: please wait
 
 Halted
 Cycles: 62993898
-62993898: 4007fa51b738e7a09ff1846f6bfa85013c4cb58cdf55deb6cabf691251f26a95
+62993898: 94f1788d9300b3954bca47bb28b6332d839cdc2441ec142a9560dbf95b0cbff6
 ```
 
-The `root_hash` field in the proof `0x4007fa…` matches the final state
+The `root_hash` field in the proof `0x94f178…` matches the final state
 hash output by the `cartesi-machine` command-line utility. The
 `target_hash` field `0x1beb37…` is the hash of the `output.raw` NVRAM.
 To compute it independently, use the `cartesi-hash-tree-hash`
@@ -1999,8 +1999,8 @@ Manual yield rx-accepted (1) (0x000020 data)
 Cycles: 65021521
 
 Before input 0
-65021521: 214dbc9a05e7f95996ab5f8443be24f3f974d618ae9d1dd66f8e18f1250f077a
-65021521: 0c1fd7582d373256ffd90e06391f45d668370de8189ecae4262923f0d086f356
+65021521: 657dd9ab4952a7bc15b86ac61a33a809659768ec24e6e3b13a7959237f8de71e
+65021521: 4408a78dbb34bb88cad86d2c623e5e081f7340e0260351d79e3d1121021ffb22
 
 Automatic yield tx-output (2) (0x000184 data)
 Cycles: 110102253
@@ -2012,8 +2012,8 @@ Storing input-0-output-hashes-root-hash.bin
 Storing input-0-output-hashes-root-hash-proof.lua
 
 Before input 1
-117064501: 67764fceed3fe7ad48cdfa18e94613e176c73969475f5d203114f95b318a55ec
-117064501: c81b1007f0b1188efd881e65d635635ac1b731d3d4dffdb70ccf8c4074489b12
+117064501: 1d691b2dfdff6092f923be95cc68ede4d665a335ca23b8672a1feb959f74eb3d
+117064501: b05c6f89100d864b6cc026f9634d2afe1ef59718b9c7801e1a3c01522285763d
 
 Automatic yield tx-output (2) (0x000044 data)
 Cycles: 159400749
@@ -2023,8 +2023,8 @@ Cycles: 164038565
 Storing rejected-output-1-input-1.bin
 
 Before input 2
-117064501: 67764fceed3fe7ad48cdfa18e94613e176c73969475f5d203114f95b318a55ec
-117064501: 23b1310063a22b8a09520b151f6a1933205569d6f07c910f5ccb2229646bb1ee
+117064501: 1d691b2dfdff6092f923be95cc68ede4d665a335ca23b8672a1feb959f74eb3d
+117064501: cc9148fc5b90d4b605bf63aeb376a08425f99a455eda9bdf9925489b378609b3
 
 Automatic yield tx-output (2) (0x0002c4 data)
 Cycles: 161579761
@@ -2046,8 +2046,8 @@ transferring information in and out. The first
 the calculator attempted to obtain its first request.
 
 Upon receiving control back, the client prints input index 0 and the
-state hash `214dbc9a…`. It loads `input-0.bin` as the next request,
-prints the modified state hash `0c1fd758…`, and resumes the machine. The
+state hash `657dd9ab…`. It loads `input-0.bin` as the next request,
+prints the modified state hash `4408a78d…`, and resumes the machine. The
 calculator evaluates `6*2^1024 + 3*2^512` and emits the result as a
 notice. That emission is an `automatic yield tx-output` at cycle
 `110102253`, which returns control to the client. The client collects
@@ -2068,7 +2068,7 @@ purposes, the client saves the notice contents as
 `rejected-output-1-input-1.bin`. The resulting
 `manual yield rx-rejected` at cycle `164038565` rolls the machine state
 back to what it was before the input was processed. The state hash
-before input 2, `67764fce…`, is identical to the hash after input 0 was
+before input 2, `1d691b2d…`, is identical to the hash after input 0 was
 accepted, which confirms the rejected input left no trace.
 
 Input index 2, with payload `2^2048`, is accepted like the first, so the
@@ -2126,8 +2126,8 @@ Manual yield rx-accepted (1) (0x000020 data)
 Cycles: 168093684
 
 Before input 3
-168093684: 42f585d3a46be80ceefbb8b966c4477ae832eb14ddc895c201259915719453be
-168093684: 65303733bcff3e86f0bc97e9ff9f0cbadd07b44791de4b23c0fef839406df341
+168093684: 1cc8c39511c3286b50b70c815fd08ade6af494167a634fbff1d250e063333421
+168093684: a9b235697c56825c86a7bdfcaec9621879ee31b41ace7f46ce3b38fa830fbe34
 
 Automatic yield tx-output (2) (0x0000e4 data)
 Cycles: 210706520
@@ -2139,8 +2139,8 @@ Storing input-3-output-hashes-root-hash.bin
 Storing input-3-output-hashes-root-hash-proof.lua
 
 Before input 4
-217387728: e22a39916744390190b5dd2ad3e831c0e67b997e187e5fc2e68dfb6e242df09e
-217387728: 009a9ab1b7982d5dba525fa08a20a42aeaa140458eec81d75dbafc9ee323118c
+217387728: d5203a382abd55438750222b91e5bac8078064a20bdf870f3754a4ac2661a5bc
+217387728: aa335f8154cd3e912553d4aaca5c87cafa7145aebf13ec708dd3aa1c1a6b3535
 
 Automatic yield tx-output (2) (0x0000a4 data)
 Cycles: 260280768
@@ -2152,8 +2152,8 @@ Storing input-4-output-hashes-root-hash.bin
 Storing input-4-output-hashes-root-hash-proof.lua
 
 Before input 5
-267072123: e34f79995ee165faa54538b16820653c202e2ccab59ad58c0099d15a47bf3dc9
-267072123: 0f65ffc9762b1eaafddd0d96fdc1aa74db516a4501ec3a94a0bd76fcfaaab4c4
+267072123: c90f7b347c10f6874af1867466b7f860566220e4c09c55681bce6817d7bae69d
+267072123: ecbd5ecaa364f7390e9bd8984ad89bf225ae1bdac3f4577e2e4b3d7c9ee11fe5
 
 Automatic yield tx-output (2) (0x0000c4 data)
 Cycles: 309565093
@@ -2168,8 +2168,8 @@ Storing output-3-input-4-proof.lua
 Storing output-4-input-5-proof.lua
 
 Before query
-316271326: 03d17b4f3cd7573f6f0d13be9326107c5f144193d7891891c208b329e7e00114
-316271326: d5a0b21f240eb4d2f9e8da19b9eeaaef675ce7ba0518b0b03792e5a6505889b4
+316271326: 3ab72ed3828e9729c3cc5fa3a38077a58ea7bbb2469d0078154e01b460a0fe07
+316271326: e0ce8fb9136aa14744184da0bf7c22b75b3079d7e75dd3f93533d35dc702faa9
 
 Automatic yield tx-report (4) (0x000048 data)
 Cycles: 358930035
@@ -2283,7 +2283,7 @@ is as follows
 
 Manual yield rx-accepted (1) (0x000020 data)
 Cycles: 65021521
-65021521: 214dbc9a05e7f95996ab5f8443be24f3f974d618ae9d1dd66f8e18f1250f077a
+65021521: 657dd9ab4952a7bc15b86ac61a33a809659768ec24e6e3b13a7959237f8de71e
 Storing machine: please wait
 ```
 
@@ -2335,8 +2335,8 @@ Manual yield rx-accepted (1) (0x000020 data)
 Cycles: 65021521
 
 Before input 0
-65021521: 214dbc9a05e7f95996ab5f8443be24f3f974d618ae9d1dd66f8e18f1250f077a
-65021521: 0c1fd7582d373256ffd90e06391f45d668370de8189ecae4262923f0d086f356
+65021521: 657dd9ab4952a7bc15b86ac61a33a809659768ec24e6e3b13a7959237f8de71e
+65021521: 4408a78dbb34bb88cad86d2c623e5e081f7340e0260351d79e3d1121021ffb22
 
 Automatic yield tx-output (2) (0x000184 data)
 Cycles: 110102253
@@ -2553,21 +2553,21 @@ The output is
 
 ``` text
 Loading machine: please wait
-0: 64742925768fdc59214daf0c21b6658fa949e9c40b6289f8f44f7b060cf55008
-62993888: 95f32d3869fd6c6f37452e5d2de320886dfc4df2c1e1784c95616dc92d5c5f45
-62993889: 5d7e028d5f7068444e1993f5f8404dbb9665028fd4819b35f730f415930212f5
-62993890: 0a56408743064067b692c18c4535191924bbd40fe008f8b9d329c5ad7edc339e
-62993891: 24fad0bd5f3b4da8dd7ed60aa7d855dbae353122fdab21882c0471c456a1ead4
-62993892: 15fe2beffd2360daabd608f43e3d644064de64d45205a1cd32bc102bc6c80fe1
-62993893: c169fdda1f98217efd7a724145322c1d4b563d3d6fc6f82d5b2062b5e7aee41e
-62993894: 444737647d58b94bd6647c8531672d075213ad7cca5f5ea654ba8fd9b1771e4e
-62993895: c30f2db2729bb1b6ebf0298cd36bab2a99c4ca769e02c4d924081a207d82c92f
-62993896: f2f942085c99501e0d4476623d52b1b08aea3aec6a28e3297500db9c92dc40f7
-62993897: 3835949454a302f5e179a3ab82bb27679767ffaa0cb3d7db3ca8550ff50adb99
+0: 33b2ea2a51ebc59bbd2a4be4598c12f3404dadbf00bb14a055fdf6a98f70d5b1
+62993888: 045572a6f3efcd8dfc83b72278bc56dc2d896b3b7ac831f06737b05c92b0d173
+62993889: 92d541bc64c57c949f9c1e0611d3684c3e67b19148a789e1e1294306c49bbcda
+62993890: ff40d6c19e9aa66e7a655f4283c9f04ed189cc9fca0d8e330767466d457888b6
+62993891: 1ffee068c5043e2379786d7f53e10566631911413fa93be3cae391c15c6e67ce
+62993892: 5b42b95f25f099c8c7c476330fd5bcc5fcbc9af1d7d42a0e6ec6c79c9a01c734
+62993893: 10cebe4de7c5687d215d355ec1a0964df29ebf6fc435aa7bc619bb4d51ea86a3
+62993894: 5b5cf85210ad71c141f1fc3d701db83f5c00cea9c17007c36c4f2d4367f06846
+62993895: ba6c3a4443ea5ce5945d8bd096bb5f030b645f01e5e5b3e4325102c5e4557603
+62993896: 92cf3125b641524d61b06ddd75fa947ccff40c2c9c82d4acd1013eee20834678
+62993897: 3f6db4b5de27f8108ad5987ce2e088494c66b13c81be89d5904f818926fe738c
 
 Halted
 Cycles: 62993898
-62993898: 4007fa51b738e7a09ff1846f6bfa85013c4cb58cdf55deb6cabf691251f26a95
+62993898: 94f1788d9300b3954bca47bb28b6332d839cdc2441ec142a9560dbf95b0cbff6
 ```
 
 The command-line option `--dump-memory-ranges[=<dir>]` causes the
@@ -4092,7 +4092,7 @@ cartesi-machine \
 ```
 
 ``` text
-0: 84ff7b981071b478d1b2b65d87bee69ef51c2843d83a0e9f29091cecc30e36eb
+0: 8d88d5046ac53f5fd86a202e13e0a3673a57d15c777cc08165b5b00d302cc61b
 
          .
         / \
@@ -4108,7 +4108,7 @@ Nothing to do.
 
 Halted
 Cycles: 41860488
-41860488: 009c5cd36fd3e6a11ca6adf44a37871a75ea79a99ccceebcebae0630450c77ee
+41860488: 50b8042f3e70419f7f4aa5dc948302e603e6b7379143338e10c190604cd4120a
 ```
 
 Note that the initial state hashes and the final state hashes match, as
@@ -6298,8 +6298,8 @@ Manual yield rx-accepted (1) (0x000020 data)
 Cycles: 48382208
 
 Before input 0
-48382208: 5f4ad6f759ce8ad60abe2bb090860365f04d1b160d97f4c35ed94cffe1b2aa83
-48382208: 7c69273fd8ca1837fea1650fe3d1cfe7fba946140c87d48f25a3c0bec8130f9f
+48382208: 80bee29897080c5cf5d01546670f508b5071c8f112a2434e87acab86b09f489d
+48382208: 8a86c4bb3a6ca3774100755ac6425046cd92350b441274b6b036a006041a5b33
 
 Automatic yield tx-output (2) (0x000064 data)
 Cycles: 48400380
@@ -6311,16 +6311,16 @@ Storing input-0-output-hashes-root-hash.bin
 Storing input-0-output-hashes-root-hash-proof.lua
 
 Before input 1
-50514460: 9c906340f96ad871fd0d0fb721262f72aebcfa47048555aeeb8355785ad09f4c
-50514460: 9f6bea31aa00e5073a55fe929013be28c5a02eb74b71e87eafd2d3b47004e2e7
+50514460: 94b70627e2ebf51f472febbfae594ac3705c6d04ac67579986c83a980cf2ec0a
+50514460: 81b2b68ac513f81da8b5b332297e15a0de9cbdb1b38df400ec935feb0e115d29
 
 Manual yield rx-rejected (2) (0x000000 data)
 Cycles: 50518409
 Storing output-0-input-0-proof.lua
 
 Before query
-50514460: 9c906340f96ad871fd0d0fb721262f72aebcfa47048555aeeb8355785ad09f4c
-50514460: bc087724f1f75f02e6e79cb97d11c36de7148c91f19415fe8f074a4defcadc7e
+50514460: 94b70627e2ebf51f472febbfae594ac3705c6d04ac67579986c83a980cf2ec0a
+50514460: 20007f93068d3ab5f573d8d0b9e5602211d7f5175f0d1480da3422980c201759
 
 Automatic yield tx-report (4) (0x000011 data)
 Cycles: 50515672
@@ -6330,7 +6330,7 @@ Manual yield rx-accepted (1) (0x000020 data)
 Cycles: 50516762
 
 After query
-50514460: 9c906340f96ad871fd0d0fb721262f72aebcfa47048555aeeb8355785ad09f4c
+50514460: 94b70627e2ebf51f472febbfae594ac3705c6d04ac67579986c83a980cf2ec0a
 Shutdown JSONRPC remote cartesi machine at '127.0.0.1:8086'
 ```
 
@@ -8413,8 +8413,8 @@ lua5.4 verification-game.lua dishonest 127.0.0.1:8087 "6*2^1024 + 3*2^512" 25 7 
 The referee narrates the dispute from start to finish:
 
 ``` text
-Player 1 posted final state hash 0x4007fa51....
-Player 2 posted final state hash 0x4e62a182....
+Player 1 posted final state hash 0x94f1788d....
+Player 2 posted final state hash 0x08a94038....
 mcycle bisection round 1, interval of disagreement is [0x0, 0x7fffffffffffffff]
 mcycle bisection round 2, interval of disagreement is [0x0, 0x3fffffffffffffff]
 mcycle bisection round 3, interval of disagreement is [0x0, 0x1fffffffffffffff]
@@ -8432,7 +8432,7 @@ uarch_cycle bisection round 20, interval of disagreement is [0x7, 0x8]
 Player 1 posted log
 Verifying uarch step log!
 Log is valid!
-Player 1 wins! Final state hash is 0x4007fa51....
+Player 1 wins! Final state hash is 0x94f1788d....
 Result posted:
 4
 Rejected!
@@ -8475,7 +8475,7 @@ Player 1 posted log
 Verifying uarch step log!
 Verifying uarch reset log!
 Log is valid!
-Player 1 wins! Final state hash is 0x4007fa51....
+Player 1 wins! Final state hash is 0x94f1788d....
 ```
 
 ## Rolling verification game
@@ -8846,8 +8846,8 @@ lua5.4 rolling-verification-game.lua honest 127.0.0.1:8090 \
 The referee narrates the dispute from start to finish:
 
 ``` text
-Player 1 posted final state hash 0x108a8373....
-Player 2 posted final state hash 0x42f585d3....
+Player 1 posted final state hash 0xcb4326b5....
+Player 2 posted final state hash 0x1cc8c395....
 input bisection round 1, interval of disagreement is [0x0, 0x8000]
 input bisection round 2, interval of disagreement is [0x0, 0x4000]
 input bisection round 3, interval of disagreement is [0x0, 0x2000]
@@ -8872,7 +8872,7 @@ uarch_cycle bisection round 20, interval of disagreement is [0x0, 0x1]
 Player 1 posted logs
 Verifying input inclusion log!
 Log is invalid!
-Player 2 wins! Final state hash is 0x42f585d3....
+Player 2 wins! Final state hash is 0x1cc8c395....
 Result posted:
 179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137216Rejected!
 Result posted:
@@ -8926,7 +8926,7 @@ Player 1 posted logs
 Verifying uarch step log!
 Verifying uarch reset log!
 Log is invalid!
-Player 2 wins! Final state hash is 0x42f585d3....
+Player 2 wins! Final state hash is 0x1cc8c395....
 ```
 
 The uarch step in player 1’s logs verifies, but the reset replays to the
@@ -8964,7 +8964,7 @@ uarch_cycle bisection round 20, interval of disagreement is [0x7, 0x8]
 Player 1 posted logs
 Verifying uarch step log!
 Log is invalid!
-Player 2 wins! Final state hash is 0x42f585d3....
+Player 2 wins! Final state hash is 0x1cc8c395....
 ```
 
 The last dishonest player claims the epoch received a fourth input, a
@@ -8991,7 +8991,7 @@ input bisection round 16, interval of disagreement is [0x3, 0x4]
 Player 1 posted logs
 Verifying uarch step log!
 Log is invalid!
-Player 2 wins! Final state hash is 0x42f585d3....
+Player 2 wins! Final state hash is 0x1cc8c395....
 ```
 
 The dishonest player posts the logs of including its extra input. The

--- a/doc/recipes/rootfs-docs.ext2
+++ b/doc/recipes/rootfs-docs.ext2
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8794f80142720deb12af21c244eb62f92ad510ddb79d8c7efecc3a5f82f0ed1c
+oid sha256:36723e8ecb69ef1894d3b3f1695ef228edc5eda18e8518295eca963eeaab8915
 size 156119040

--- a/doc/recipes/rootfs-docs.licenses.md
+++ b/doc/recipes/rootfs-docs.licenses.md
@@ -20,10 +20,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris acl=2.3.2-1build1.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/acl/acl_2.3.2.orig.tar.xz' acl_2.3.2.orig.tar.xz 371680
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/acl/acl_2.3.2.orig.tar.xz.asc' acl_2.3.2.orig.tar.xz.asc 833
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/acl/acl_2.3.2-1build1.1.debian.tar.xz' acl_2.3.2-1build1.1.debian.tar.xz 23472
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/acl/acl_2.3.2-1build1.1.dsc' acl_2.3.2-1build1.1.dsc 2616
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/acl/acl_2.3.2.orig.tar.xz' acl_2.3.2.orig.tar.xz 371680
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/acl/acl_2.3.2.orig.tar.xz.asc' acl_2.3.2.orig.tar.xz.asc 833
 ```
 
 ### `dpkg` source package: `apt=2.8.3`
@@ -44,8 +44,8 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris apt=2.8.3
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/apt/apt_2.8.3.tar.xz' apt_2.8.3.tar.xz 2354680
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/apt/apt_2.8.3.dsc' apt_2.8.3.dsc 2973
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/apt/apt_2.8.3.tar.xz' apt_2.8.3.tar.xz 2354680
 ```
 
 ### `dpkg` source package: `attr=1:2.5.2-1build1.1`
@@ -65,10 +65,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris attr=1:2.5.2-1build1.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/attr/attr_2.5.2.orig.tar.xz' attr_2.5.2.orig.tar.xz 334180
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/attr/attr_2.5.2.orig.tar.xz.asc' attr_2.5.2.orig.tar.xz.asc 833
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/attr/attr_2.5.2-1build1.1.debian.tar.xz' attr_2.5.2-1build1.1.debian.tar.xz 26032
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/attr/attr_2.5.2-1build1.1.dsc' attr_2.5.2-1build1.1.dsc 2588
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/attr/attr_2.5.2.orig.tar.xz' attr_2.5.2.orig.tar.xz 334180
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/attr/attr_2.5.2.orig.tar.xz.asc' attr_2.5.2.orig.tar.xz.asc 833
 ```
 
 ### `dpkg` source package: `audit=1:3.1.2-2.1build1.1`
@@ -88,9 +88,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris audit=1:3.1.2-2.1build1.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/audit/audit_3.1.2.orig.tar.gz' audit_3.1.2.orig.tar.gz 1219860
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/audit/audit_3.1.2-2.1build1.1.debian.tar.xz' audit_3.1.2-2.1build1.1.debian.tar.xz 18860
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/audit/audit_3.1.2-2.1build1.1.dsc' audit_3.1.2-2.1build1.1.dsc 2848
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/a/audit/audit_3.1.2.orig.tar.gz' audit_3.1.2.orig.tar.gz 1219860
 ```
 
 ### `dpkg` source package: `base-files=13ubuntu10.4`
@@ -107,8 +107,8 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris base-files=13ubuntu10.4
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/base-files/base-files_13ubuntu10.4.tar.xz' base-files_13ubuntu10.4.tar.xz 94240
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/base-files/base-files_13ubuntu10.4.dsc' base-files_13ubuntu10.4.dsc 1642
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/base-files/base-files_13ubuntu10.4.tar.xz' base-files_13ubuntu10.4.tar.xz 94240
 ```
 
 ### `dpkg` source package: `base-passwd=3.6.3build1`
@@ -154,9 +154,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris bash=5.2.21-2ubuntu4
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bash/bash_5.2.21-2ubuntu4.debian.tar.xz' bash_5.2.21-2ubuntu4.debian.tar.xz 94124
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bash/bash_5.2.21-2ubuntu4.dsc' bash_5.2.21-2ubuntu4.dsc 2437
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bash/bash_5.2.21.orig.tar.xz' bash_5.2.21.orig.tar.xz 5598816
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bash/bash_5.2.21-2ubuntu4.debian.tar.xz' bash_5.2.21-2ubuntu4.debian.tar.xz 94124
 ```
 
 ### `dpkg` source package: `bc=1.07.1-3ubuntu4`
@@ -179,9 +179,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris bc=1.07.1-3ubuntu4
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bc/bc_1.07.1-3ubuntu4.debian.tar.xz' bc_1.07.1-3ubuntu4.debian.tar.xz 23888
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bc/bc_1.07.1-3ubuntu4.dsc' bc_1.07.1-3ubuntu4.dsc 2018
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bc/bc_1.07.1.orig.tar.gz' bc_1.07.1.orig.tar.gz 419850
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bc/bc_1.07.1-3ubuntu4.debian.tar.xz' bc_1.07.1-3ubuntu4.debian.tar.xz 23888
 ```
 
 ### `dpkg` source package: `brotli=1.1.0-2build2`
@@ -198,9 +198,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris brotli=1.1.0-2build2
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/brotli/brotli_1.1.0-2build2.debian.tar.xz' brotli_1.1.0-2build2.debian.tar.xz 5644
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/brotli/brotli_1.1.0-2build2.dsc' brotli_1.1.0-2build2.dsc 2401
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/brotli/brotli_1.1.0.orig.tar.gz' brotli_1.1.0.orig.tar.gz 512036
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/brotli/brotli_1.1.0-2build2.debian.tar.xz' brotli_1.1.0-2build2.debian.tar.xz 5644
 ```
 
 ### `dpkg` source package: `busybox=1:1.36.1-6ubuntu3.1`
@@ -217,10 +217,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris busybox=1:1.36.1-6ubuntu3.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/busybox/busybox_1.36.1.orig.tar.bz2' busybox_1.36.1.orig.tar.bz2 2525473
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/busybox/busybox_1.36.1.orig.tar.bz2.asc' busybox_1.36.1.orig.tar.bz2.asc 195
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/busybox/busybox_1.36.1-6ubuntu3.1.debian.tar.xz' busybox_1.36.1-6ubuntu3.1.debian.tar.xz 84488
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/busybox/busybox_1.36.1-6ubuntu3.1.dsc' busybox_1.36.1-6ubuntu3.1.dsc 2711
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/busybox/busybox_1.36.1.orig.tar.bz2' busybox_1.36.1.orig.tar.bz2 2525473
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/busybox/busybox_1.36.1.orig.tar.bz2.asc' busybox_1.36.1.orig.tar.bz2.asc 195
 ```
 
 ### `dpkg` source package: `bzip2=1.0.8-5.1build0.1`
@@ -238,9 +238,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris bzip2=1.0.8-5.1build0.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bzip2/bzip2_1.0.8.orig.tar.gz' bzip2_1.0.8.orig.tar.gz 810029
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bzip2/bzip2_1.0.8-5.1build0.1.debian.tar.bz2' bzip2_1.0.8-5.1build0.1.debian.tar.bz2 26927
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bzip2/bzip2_1.0.8-5.1build0.1.dsc' bzip2_1.0.8-5.1build0.1.dsc 2220
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/b/bzip2/bzip2_1.0.8.orig.tar.gz' bzip2_1.0.8.orig.tar.gz 810029
 ```
 
 ### `dpkg` source package: `cdebconf=0.271ubuntu3`
@@ -284,9 +284,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris coreutils=9.4-3ubuntu6.2
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/coreutils/coreutils_9.4.orig.tar.xz' coreutils_9.4.orig.tar.xz 5979200
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/coreutils/coreutils_9.4-3ubuntu6.2.debian.tar.xz' coreutils_9.4-3ubuntu6.2.debian.tar.xz 42032
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/coreutils/coreutils_9.4-3ubuntu6.2.dsc' coreutils_9.4-3ubuntu6.2.dsc 2030
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/coreutils/coreutils_9.4.orig.tar.xz' coreutils_9.4.orig.tar.xz 5979200
 ```
 
 ### `dpkg` source package: `curl=8.5.0-2ubuntu10.8`
@@ -315,9 +315,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris curl=8.5.0-2ubuntu10.8
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/curl/curl_8.5.0-2ubuntu10.8.debian.tar.xz' curl_8.5.0-2ubuntu10.8.debian.tar.xz 68580
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/curl/curl_8.5.0-2ubuntu10.8.dsc' curl_8.5.0-2ubuntu10.8.dsc 3051
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/curl/curl_8.5.0.orig.tar.gz' curl_8.5.0.orig.tar.gz 4372979
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/curl/curl_8.5.0-2ubuntu10.8.debian.tar.xz' curl_8.5.0-2ubuntu10.8.debian.tar.xz 68580
 ```
 
 ### `dpkg` source package: `cyrus-sasl2=2.1.28+dfsg1-5ubuntu3.1`
@@ -350,9 +350,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris cyrus-sasl2=2.1.28+dfsg1-5ubuntu3.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/cyrus-sasl2/cyrus-sasl2_2.1.28%2bdfsg1.orig.tar.xz' cyrus-sasl2_2.1.28+dfsg1.orig.tar.xz 794540
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/cyrus-sasl2/cyrus-sasl2_2.1.28%2bdfsg1-5ubuntu3.1.debian.tar.xz' cyrus-sasl2_2.1.28+dfsg1-5ubuntu3.1.debian.tar.xz 98324
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/cyrus-sasl2/cyrus-sasl2_2.1.28%2bdfsg1-5ubuntu3.1.dsc' cyrus-sasl2_2.1.28+dfsg1-5ubuntu3.1.dsc 3501
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/c/cyrus-sasl2/cyrus-sasl2_2.1.28%2bdfsg1.orig.tar.xz' cyrus-sasl2_2.1.28+dfsg1.orig.tar.xz 794540
 ```
 
 ### `dpkg` source package: `dash=0.5.12-6ubuntu5`
@@ -373,9 +373,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris dash=0.5.12-6ubuntu5
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/dash/dash_0.5.12-6ubuntu5.debian.tar.xz' dash_0.5.12-6ubuntu5.debian.tar.xz 39616
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/dash/dash_0.5.12-6ubuntu5.dsc' dash_0.5.12-6ubuntu5.dsc 2124
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/dash/dash_0.5.12.orig.tar.gz' dash_0.5.12.orig.tar.gz 246054
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/dash/dash_0.5.12-6ubuntu5.debian.tar.xz' dash_0.5.12-6ubuntu5.debian.tar.xz 39616
 ```
 
 ### `dpkg` source package: `db5.3=5.3.28+dfsg2-7`
@@ -402,9 +402,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris db5.3=5.3.28+dfsg2-7
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/db5.3/db5.3_5.3.28%2bdfsg2-7.debian.tar.xz' db5.3_5.3.28+dfsg2-7.debian.tar.xz 35232
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/db5.3/db5.3_5.3.28%2bdfsg2-7.dsc' db5.3_5.3.28+dfsg2-7.dsc 2374
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/db5.3/db5.3_5.3.28%2bdfsg2.orig.tar.xz' db5.3_5.3.28+dfsg2.orig.tar.xz 21287688
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/db5.3/db5.3_5.3.28%2bdfsg2-7.debian.tar.xz' db5.3_5.3.28+dfsg2-7.debian.tar.xz 35232
 ```
 
 ### `dpkg` source package: `debconf=1.5.86ubuntu1`
@@ -464,9 +464,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris device-tree-compiler=1.7.0-2build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/device-tree-compiler/device-tree-compiler_1.7.0-2build1.debian.tar.xz' device-tree-compiler_1.7.0-2build1.debian.tar.xz 14536
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/device-tree-compiler/device-tree-compiler_1.7.0-2build1.dsc' device-tree-compiler_1.7.0-2build1.dsc 2590
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/device-tree-compiler/device-tree-compiler_1.7.0.orig.tar.gz' device-tree-compiler_1.7.0.orig.tar.gz 211526
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/device-tree-compiler/device-tree-compiler_1.7.0-2build1.debian.tar.xz' device-tree-compiler_1.7.0-2build1.debian.tar.xz 14536
 ```
 
 ### `dpkg` source package: `diffutils=1:3.10-1build1`
@@ -500,10 +500,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris diffutils=1:3.10-1build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/diffutils/diffutils_3.10-1build1.debian.tar.xz' diffutils_3.10-1build1.debian.tar.xz 14068
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/diffutils/diffutils_3.10-1build1.dsc' diffutils_3.10-1build1.dsc 2192
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/diffutils/diffutils_3.10.orig.tar.xz' diffutils_3.10.orig.tar.xz 1624240
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/diffutils/diffutils_3.10.orig.tar.xz.asc' diffutils_3.10.orig.tar.xz.asc 833
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/d/diffutils/diffutils_3.10-1build1.debian.tar.xz' diffutils_3.10-1build1.debian.tar.xz 14068
 ```
 
 ### `dpkg` source package: `dpkg=1.22.6ubuntu6.5`
@@ -554,10 +554,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris e2fsprogs=1.47.0-2.4~exp1ubuntu4.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/e/e2fsprogs/e2fsprogs_1.47.0.orig.tar.gz' e2fsprogs_1.47.0.orig.tar.gz 9637717
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/e/e2fsprogs/e2fsprogs_1.47.0.orig.tar.gz.asc' e2fsprogs_1.47.0.orig.tar.gz.asc 488
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/e/e2fsprogs/e2fsprogs_1.47.0-2.4%7eexp1ubuntu4.1.debian.tar.xz' e2fsprogs_1.47.0-2.4~exp1ubuntu4.1.debian.tar.xz 90580
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/e/e2fsprogs/e2fsprogs_1.47.0-2.4%7eexp1ubuntu4.1.dsc' e2fsprogs_1.47.0-2.4~exp1ubuntu4.1.dsc 3294
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/e/e2fsprogs/e2fsprogs_1.47.0.orig.tar.gz' e2fsprogs_1.47.0.orig.tar.gz 9637717
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/e/e2fsprogs/e2fsprogs_1.47.0.orig.tar.gz.asc' e2fsprogs_1.47.0.orig.tar.gz.asc 488
 ```
 
 ### `dpkg` source package: `emacsen-common=3.0.5`
@@ -592,9 +592,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris expat=2.6.1-2ubuntu0.4
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/e/expat/expat_2.6.1.orig.tar.gz' expat_2.6.1.orig.tar.gz 8414649
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/e/expat/expat_2.6.1-2ubuntu0.4.debian.tar.xz' expat_2.6.1-2ubuntu0.4.debian.tar.xz 31092
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/e/expat/expat_2.6.1-2ubuntu0.4.dsc' expat_2.6.1-2ubuntu0.4.dsc 1945
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/e/expat/expat_2.6.1.orig.tar.gz' expat_2.6.1.orig.tar.gz 8414649
 ```
 
 ### `dpkg` source package: `findutils=4.9.0-5build1`
@@ -634,10 +634,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris findutils=4.9.0-5build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/f/findutils/findutils_4.9.0-5build1.debian.tar.xz' findutils_4.9.0-5build1.debian.tar.xz 32864
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/f/findutils/findutils_4.9.0-5build1.dsc' findutils_4.9.0-5build1.dsc 2404
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/f/findutils/findutils_4.9.0.orig.tar.xz' findutils_4.9.0.orig.tar.xz 2046252
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/f/findutils/findutils_4.9.0.orig.tar.xz.asc' findutils_4.9.0.orig.tar.xz.asc 488
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/f/findutils/findutils_4.9.0-5build1.debian.tar.xz' findutils_4.9.0-5build1.debian.tar.xz 32864
 ```
 
 ### `dpkg` source package: `gcc-14=14.2.0-4ubuntu2~24.04.1`
@@ -660,9 +660,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris gcc-14=14.2.0-4ubuntu2~24.04.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gcc-14/gcc-14_14.2.0.orig.tar.gz' gcc-14_14.2.0.orig.tar.gz 97158172
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gcc-14/gcc-14_14.2.0-4ubuntu2%7e24.04.1.debian.tar.xz' gcc-14_14.2.0-4ubuntu2~24.04.1.debian.tar.xz 1950432
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gcc-14/gcc-14_14.2.0-4ubuntu2%7e24.04.1.dsc' gcc-14_14.2.0-4ubuntu2~24.04.1.dsc 46930
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gcc-14/gcc-14_14.2.0.orig.tar.gz' gcc-14_14.2.0.orig.tar.gz 97158172
 ```
 
 ### `dpkg` source package: `gforth=0.7.3+dfsg-9build4.1`
@@ -692,9 +692,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris gforth=0.7.3+dfsg-9build4.1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/universe/g/gforth/gforth_0.7.3%2bdfsg-9build4.1.debian.tar.xz' gforth_0.7.3+dfsg-9build4.1.debian.tar.xz 38408
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/universe/g/gforth/gforth_0.7.3%2bdfsg-9build4.1.dsc' gforth_0.7.3+dfsg-9build4.1.dsc 2232
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/universe/g/gforth/gforth_0.7.3%2bdfsg.orig.tar.xz' gforth_0.7.3+dfsg.orig.tar.xz 705716
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/universe/g/gforth/gforth_0.7.3%2bdfsg-9build4.1.debian.tar.xz' gforth_0.7.3+dfsg-9build4.1.debian.tar.xz 38408
 ```
 
 ### `dpkg` source package: `glibc=2.39-0ubuntu8.7`
@@ -714,10 +714,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris glibc=2.39-0ubuntu8.7
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/glibc/glibc_2.39.orig.tar.xz' glibc_2.39.orig.tar.xz 18520988
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/glibc/glibc_2.39.orig.tar.xz.asc' glibc_2.39.orig.tar.xz.asc 833
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/glibc/glibc_2.39-0ubuntu8.7.debian.tar.xz' glibc_2.39-0ubuntu8.7.debian.tar.xz 469880
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/glibc/glibc_2.39-0ubuntu8.7.dsc' glibc_2.39-0ubuntu8.7.dsc 9257
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/glibc/glibc_2.39.orig.tar.xz' glibc_2.39.orig.tar.xz 18520988
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/glibc/glibc_2.39.orig.tar.xz.asc' glibc_2.39.orig.tar.xz.asc 833
 ```
 
 ### `dpkg` source package: `gmp=2:6.3.0+dfsg-2ubuntu6.1`
@@ -740,9 +740,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris gmp=2:6.3.0+dfsg-2ubuntu6.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gmp/gmp_6.3.0%2bdfsg.orig.tar.xz' gmp_6.3.0+dfsg.orig.tar.xz 1870556
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gmp/gmp_6.3.0%2bdfsg-2ubuntu6.1.debian.tar.xz' gmp_6.3.0+dfsg-2ubuntu6.1.debian.tar.xz 38908
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gmp/gmp_6.3.0%2bdfsg-2ubuntu6.1.dsc' gmp_6.3.0+dfsg-2ubuntu6.1.dsc 2345
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gmp/gmp_6.3.0%2bdfsg.orig.tar.xz' gmp_6.3.0+dfsg.orig.tar.xz 1870556
 ```
 
 ### `dpkg` source package: `gnupg2=2.4.4-2ubuntu17.4`
@@ -772,10 +772,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris gnupg2=2.4.4-2ubuntu17.4
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnupg2/gnupg2_2.4.4.orig.tar.bz2' gnupg2_2.4.4.orig.tar.bz2 7886036
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnupg2/gnupg2_2.4.4.orig.tar.bz2.asc' gnupg2_2.4.4.orig.tar.bz2.asc 386
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnupg2/gnupg2_2.4.4-2ubuntu17.4.debian.tar.xz' gnupg2_2.4.4-2ubuntu17.4.debian.tar.xz 97376
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnupg2/gnupg2_2.4.4-2ubuntu17.4.dsc' gnupg2_2.4.4-2ubuntu17.4.dsc 3984
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnupg2/gnupg2_2.4.4.orig.tar.bz2' gnupg2_2.4.4.orig.tar.bz2 7886036
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnupg2/gnupg2_2.4.4.orig.tar.bz2.asc' gnupg2_2.4.4.orig.tar.bz2.asc 386
 ```
 
 ### `dpkg` source package: `gnutls28=3.8.3-1.1ubuntu3.5`
@@ -804,10 +804,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris gnutls28=3.8.3-1.1ubuntu3.5
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnutls28/gnutls28_3.8.3-1.1ubuntu3.5.debian.tar.xz' gnutls28_3.8.3-1.1ubuntu3.5.debian.tar.xz 109884
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnutls28/gnutls28_3.8.3-1.1ubuntu3.5.dsc' gnutls28_3.8.3-1.1ubuntu3.5.dsc 3397
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnutls28/gnutls28_3.8.3.orig.tar.xz' gnutls28_3.8.3.orig.tar.xz 6463720
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnutls28/gnutls28_3.8.3.orig.tar.xz.asc' gnutls28_3.8.3.orig.tar.xz.asc 854
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gnutls28/gnutls28_3.8.3-1.1ubuntu3.5.debian.tar.xz' gnutls28_3.8.3-1.1ubuntu3.5.debian.tar.xz 109884
 ```
 
 ### `dpkg` source package: `grep=3.11-4build1`
@@ -825,10 +825,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris grep=3.11-4build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/grep/grep_3.11-4build1.debian.tar.xz' grep_3.11-4build1.debian.tar.xz 20584
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/grep/grep_3.11-4build1.dsc' grep_3.11-4build1.dsc 2379
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/grep/grep_3.11.orig.tar.xz' grep_3.11.orig.tar.xz 1703776
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/grep/grep_3.11.orig.tar.xz.asc' grep_3.11.orig.tar.xz.asc 833
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/grep/grep_3.11-4build1.debian.tar.xz' grep_3.11-4build1.debian.tar.xz 20584
 ```
 
 ### `dpkg` source package: `gzip=1.12-1ubuntu3.1`
@@ -849,9 +849,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris gzip=1.12-1ubuntu3.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gzip/gzip_1.12.orig.tar.xz' gzip_1.12.orig.tar.xz 825548
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gzip/gzip_1.12-1ubuntu3.1.debian.tar.xz' gzip_1.12-1ubuntu3.1.debian.tar.xz 21180
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gzip/gzip_1.12-1ubuntu3.1.dsc' gzip_1.12-1ubuntu3.1.dsc 2042
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/g/gzip/gzip_1.12.orig.tar.xz' gzip_1.12.orig.tar.xz 825548
 ```
 
 ### `dpkg` source package: `hostname=3.23+nmu2ubuntu2`
@@ -911,9 +911,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris jq=1.7.1-3ubuntu0.24.04.1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/j/jq/jq_1.7.1-3ubuntu0.24.04.1.debian.tar.xz' jq_1.7.1-3ubuntu0.24.04.1.debian.tar.xz 18772
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/j/jq/jq_1.7.1-3ubuntu0.24.04.1.dsc' jq_1.7.1-3ubuntu0.24.04.1.dsc 2139
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/j/jq/jq_1.7.1.orig.tar.gz' jq_1.7.1.orig.tar.gz 1323338
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/j/jq/jq_1.7.1-3ubuntu0.24.04.1.debian.tar.xz' jq_1.7.1-3ubuntu0.24.04.1.debian.tar.xz 18772
 ```
 
 ### `dpkg` source package: `keyutils=1.6.3-3build1`
@@ -933,9 +933,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris keyutils=1.6.3-3build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/k/keyutils/keyutils_1.6.3-3build1.debian.tar.xz' keyutils_1.6.3-3build1.debian.tar.xz 13456
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/k/keyutils/keyutils_1.6.3-3build1.dsc' keyutils_1.6.3-3build1.dsc 2211
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/k/keyutils/keyutils_1.6.3.orig.tar.gz' keyutils_1.6.3.orig.tar.gz 137022
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/k/keyutils/keyutils_1.6.3-3build1.debian.tar.xz' keyutils_1.6.3-3build1.debian.tar.xz 13456
 ```
 
 ### `dpkg` source package: `krb5=1.20.1-6ubuntu2.6`
@@ -955,10 +955,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris krb5=1.20.1-6ubuntu2.6
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/k/krb5/krb5_1.20.1.orig.tar.gz' krb5_1.20.1.orig.tar.gz 8661660
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/k/krb5/krb5_1.20.1.orig.tar.gz.asc' krb5_1.20.1.orig.tar.gz.asc 833
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/k/krb5/krb5_1.20.1-6ubuntu2.6.debian.tar.xz' krb5_1.20.1-6ubuntu2.6.debian.tar.xz 122284
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/k/krb5/krb5_1.20.1-6ubuntu2.6.dsc' krb5_1.20.1-6ubuntu2.6.dsc 4125
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/k/krb5/krb5_1.20.1.orig.tar.gz' krb5_1.20.1.orig.tar.gz 8661660
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/k/krb5/krb5_1.20.1.orig.tar.gz.asc' krb5_1.20.1.orig.tar.gz.asc 833
 ```
 
 ### `dpkg` source package: `libassuan=2.5.6-1build1`
@@ -985,10 +985,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libassuan=2.5.6-1build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/liba/libassuan/libassuan_2.5.6-1build1.debian.tar.xz' libassuan_2.5.6-1build1.debian.tar.xz 14412
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/liba/libassuan/libassuan_2.5.6-1build1.dsc' libassuan_2.5.6-1build1.dsc 2734
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/liba/libassuan/libassuan_2.5.6.orig.tar.bz2' libassuan_2.5.6.orig.tar.bz2 577012
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/liba/libassuan/libassuan_2.5.6.orig.tar.bz2.asc' libassuan_2.5.6.orig.tar.bz2.asc 228
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/liba/libassuan/libassuan_2.5.6-1build1.debian.tar.xz' libassuan_2.5.6-1build1.debian.tar.xz 14412
 ```
 
 ### `dpkg` source package: `libcap-ng=0.8.4-2build2`
@@ -1009,9 +1009,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libcap-ng=0.8.4-2build2
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libc/libcap-ng/libcap-ng_0.8.4-2build2.debian.tar.xz' libcap-ng_0.8.4-2build2.debian.tar.xz 7384
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libc/libcap-ng/libcap-ng_0.8.4-2build2.dsc' libcap-ng_0.8.4-2build2.dsc 2351
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libc/libcap-ng/libcap-ng_0.8.4.orig.tar.gz' libcap-ng_0.8.4.orig.tar.gz 59317
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libc/libcap-ng/libcap-ng_0.8.4-2build2.debian.tar.xz' libcap-ng_0.8.4-2build2.debian.tar.xz 7384
 ```
 
 ### `dpkg` source package: `libcap2=1:2.66-5ubuntu2.2`
@@ -1030,9 +1030,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libcap2=1:2.66-5ubuntu2.2
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libc/libcap2/libcap2_2.66-5ubuntu2.2.debian.tar.xz' libcap2_2.66-5ubuntu2.2.debian.tar.xz 23076
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libc/libcap2/libcap2_2.66-5ubuntu2.2.dsc' libcap2_2.66-5ubuntu2.2.dsc 2319
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libc/libcap2/libcap2_2.66.orig.tar.xz' libcap2_2.66.orig.tar.xz 181592
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libc/libcap2/libcap2_2.66-5ubuntu2.2.debian.tar.xz' libcap2_2.66-5ubuntu2.2.debian.tar.xz 23076
 ```
 
 ### `dpkg` source package: `libffi=3.4.6-1build1`
@@ -1056,9 +1056,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libffi=3.4.6-1build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libf/libffi/libffi_3.4.6-1build1.debian.tar.xz' libffi_3.4.6-1build1.debian.tar.xz 10736
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libf/libffi/libffi_3.4.6-1build1.dsc' libffi_3.4.6-1build1.dsc 2055
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libf/libffi/libffi_3.4.6.orig.tar.gz' libffi_3.4.6.orig.tar.gz 598175
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libf/libffi/libffi_3.4.6-1build1.debian.tar.xz' libffi_3.4.6-1build1.debian.tar.xz 10736
 ```
 
 ### `dpkg` source package: `libgcrypt20=1.10.3-2build1`
@@ -1076,10 +1076,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libgcrypt20=1.10.3-2build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2build1.debian.tar.xz' libgcrypt20_1.10.3-2build1.debian.tar.xz 36604
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2build1.dsc' libgcrypt20_1.10.3-2build1.dsc 2931
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3.orig.tar.bz2' libgcrypt20_1.10.3.orig.tar.bz2 3783827
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3.orig.tar.bz2.asc' libgcrypt20_1.10.3.orig.tar.bz2.asc 390
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2build1.debian.tar.xz' libgcrypt20_1.10.3-2build1.debian.tar.xz 36604
 ```
 
 ### `dpkg` source package: `libgpg-error=1.47-3build2.1`
@@ -1101,10 +1101,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libgpg-error=1.47-3build2.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgpg-error/libgpg-error_1.47.orig.tar.bz2' libgpg-error_1.47.orig.tar.bz2 1020862
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgpg-error/libgpg-error_1.47.orig.tar.bz2.asc' libgpg-error_1.47.orig.tar.bz2.asc 228
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgpg-error/libgpg-error_1.47-3build2.1.debian.tar.xz' libgpg-error_1.47-3build2.1.debian.tar.xz 18776
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgpg-error/libgpg-error_1.47-3build2.1.dsc' libgpg-error_1.47-3build2.1.dsc 3007
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgpg-error/libgpg-error_1.47.orig.tar.bz2' libgpg-error_1.47.orig.tar.bz2 1020862
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libg/libgpg-error/libgpg-error_1.47.orig.tar.bz2.asc' libgpg-error_1.47.orig.tar.bz2.asc 228
 ```
 
 ### `dpkg` source package: `libidn2=2.3.7-2build1.1`
@@ -1127,10 +1127,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libidn2=2.3.7-2build1.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libi/libidn2/libidn2_2.3.7.orig.tar.gz' libidn2_2.3.7.orig.tar.gz 2155214
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libi/libidn2/libidn2_2.3.7.orig.tar.gz.asc' libidn2_2.3.7.orig.tar.gz.asc 228
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libi/libidn2/libidn2_2.3.7-2build1.1.debian.tar.xz' libidn2_2.3.7-2build1.1.debian.tar.xz 16468
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libi/libidn2/libidn2_2.3.7-2build1.1.dsc' libidn2_2.3.7-2build1.1.dsc 2651
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libi/libidn2/libidn2_2.3.7.orig.tar.gz' libidn2_2.3.7.orig.tar.gz 2155214
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libi/libidn2/libidn2_2.3.7.orig.tar.gz.asc' libidn2_2.3.7.orig.tar.gz.asc 228
 ```
 
 ### `dpkg` source package: `libmd=1.1.0-2build1.1`
@@ -1155,10 +1155,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libmd=1.1.0-2build1.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libm/libmd/libmd_1.1.0.orig.tar.xz' libmd_1.1.0.orig.tar.xz 271228
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libm/libmd/libmd_1.1.0.orig.tar.xz.asc' libmd_1.1.0.orig.tar.xz.asc 833
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libm/libmd/libmd_1.1.0-2build1.1.debian.tar.xz' libmd_1.1.0-2build1.1.debian.tar.xz 8448
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libm/libmd/libmd_1.1.0-2build1.1.dsc' libmd_1.1.0-2build1.1.dsc 2391
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libm/libmd/libmd_1.1.0.orig.tar.xz' libmd_1.1.0.orig.tar.xz 271228
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libm/libmd/libmd_1.1.0.orig.tar.xz.asc' libmd_1.1.0.orig.tar.xz.asc 833
 ```
 
 ### `dpkg` source package: `libonig=6.9.9-1build1`
@@ -1177,9 +1177,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libonig=6.9.9-1build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libo/libonig/libonig_6.9.9-1build1.debian.tar.xz' libonig_6.9.9-1build1.debian.tar.xz 9084
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libo/libonig/libonig_6.9.9-1build1.dsc' libonig_6.9.9-1build1.dsc 1994
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libo/libonig/libonig_6.9.9.orig.tar.gz' libonig_6.9.9.orig.tar.gz 645616
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libo/libonig/libonig_6.9.9-1build1.debian.tar.xz' libonig_6.9.9-1build1.debian.tar.xz 9084
 ```
 
 ### `dpkg` source package: `libpsl=0.21.2-1.1build1`
@@ -1198,9 +1198,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libpsl=0.21.2-1.1build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libp/libpsl/libpsl_0.21.2-1.1build1.debian.tar.xz' libpsl_0.21.2-1.1build1.debian.tar.xz 12244
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libp/libpsl/libpsl_0.21.2-1.1build1.dsc' libpsl_0.21.2-1.1build1.dsc 2425
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libp/libpsl/libpsl_0.21.2.orig.tar.xz' libpsl_0.21.2.orig.tar.xz 1870352
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libp/libpsl/libpsl_0.21.2-1.1build1.debian.tar.xz' libpsl_0.21.2-1.1build1.debian.tar.xz 12244
 ```
 
 ### `dpkg` source package: `libselinux=3.5-2ubuntu2.1`
@@ -1218,10 +1218,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libselinux=3.5-2ubuntu2.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libselinux/libselinux_3.5.orig.tar.gz' libselinux_3.5.orig.tar.gz 211453
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libselinux/libselinux_3.5.orig.tar.gz.asc' libselinux_3.5.orig.tar.gz.asc 981
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libselinux/libselinux_3.5-2ubuntu2.1.debian.tar.xz' libselinux_3.5-2ubuntu2.1.debian.tar.xz 38112
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libselinux/libselinux_3.5-2ubuntu2.1.dsc' libselinux_3.5-2ubuntu2.1.dsc 3098
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libselinux/libselinux_3.5.orig.tar.gz' libselinux_3.5.orig.tar.gz 211453
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libselinux/libselinux_3.5.orig.tar.gz.asc' libselinux_3.5.orig.tar.gz.asc 981
 ```
 
 ### `dpkg` source package: `libsemanage=3.5-1build5`
@@ -1241,10 +1241,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libsemanage=3.5-1build5
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libsemanage/libsemanage_3.5-1build5.debian.tar.xz' libsemanage_3.5-1build5.debian.tar.xz 30188
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libsemanage/libsemanage_3.5-1build5.dsc' libsemanage_3.5-1build5.dsc 3105
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libsemanage/libsemanage_3.5.orig.tar.gz' libsemanage_3.5.orig.tar.gz 185060
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libsemanage/libsemanage_3.5.orig.tar.gz.asc' libsemanage_3.5.orig.tar.gz.asc 981
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libsemanage/libsemanage_3.5-1build5.debian.tar.xz' libsemanage_3.5-1build5.debian.tar.xz 30188
 ```
 
 ### `dpkg` source package: `libsepol=3.5-2build1`
@@ -1265,10 +1265,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libsepol=3.5-2build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libsepol/libsepol_3.5-2build1.debian.tar.xz' libsepol_3.5-2build1.debian.tar.xz 27716
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libsepol/libsepol_3.5-2build1.dsc' libsepol_3.5-2build1.dsc 2458
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libsepol/libsepol_3.5.orig.tar.gz' libsepol_3.5.orig.tar.gz 497522
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libsepol/libsepol_3.5.orig.tar.gz.asc' libsepol_3.5.orig.tar.gz.asc 981
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libsepol/libsepol_3.5-2build1.debian.tar.xz' libsepol_3.5-2build1.debian.tar.xz 27716
 ```
 
 ### `dpkg` source package: `libssh=0.10.6-2ubuntu0.4`
@@ -1289,10 +1289,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libssh=0.10.6-2ubuntu0.4
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libssh/libssh_0.10.6.orig.tar.xz' libssh_0.10.6.orig.tar.xz 561036
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libssh/libssh_0.10.6.orig.tar.xz.asc' libssh_0.10.6.orig.tar.xz.asc 833
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libssh/libssh_0.10.6-2ubuntu0.4.debian.tar.xz' libssh_0.10.6-2ubuntu0.4.debian.tar.xz 56400
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libssh/libssh_0.10.6-2ubuntu0.4.dsc' libssh_0.10.6-2ubuntu0.4.dsc 2723
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libssh/libssh_0.10.6.orig.tar.xz' libssh_0.10.6.orig.tar.xz 561036
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libs/libssh/libssh_0.10.6.orig.tar.xz.asc' libssh_0.10.6.orig.tar.xz.asc 833
 ```
 
 ### `dpkg` source package: `libtasn1-6=4.19.0-3ubuntu0.24.04.2`
@@ -1312,10 +1312,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libtasn1-6=4.19.0-3ubuntu0.24.04.2
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0.orig.tar.gz' libtasn1-6_4.19.0.orig.tar.gz 1786576
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0.orig.tar.gz.asc' libtasn1-6_4.19.0.orig.tar.gz.asc 228
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0-3ubuntu0.24.04.2.debian.tar.xz' libtasn1-6_4.19.0-3ubuntu0.24.04.2.debian.tar.xz 25112
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0-3ubuntu0.24.04.2.dsc' libtasn1-6_4.19.0-3ubuntu0.24.04.2.dsc 2801
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0.orig.tar.gz' libtasn1-6_4.19.0.orig.tar.gz 1786576
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0.orig.tar.gz.asc' libtasn1-6_4.19.0.orig.tar.gz.asc 228
 ```
 
 ### `dpkg` source package: `libtool=2.4.7-7build1`
@@ -1335,9 +1335,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libtool=2.4.7-7build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libt/libtool/libtool_2.4.7-7build1.debian.tar.xz' libtool_2.4.7-7build1.debian.tar.xz 41052
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libt/libtool/libtool_2.4.7-7build1.dsc' libtool_2.4.7-7build1.dsc 2389
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libt/libtool/libtool_2.4.7.orig.tar.xz' libtool_2.4.7.orig.tar.xz 1026028
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libt/libtool/libtool_2.4.7-7build1.debian.tar.xz' libtool_2.4.7-7build1.debian.tar.xz 41052
 ```
 
 ### `dpkg` source package: `libunistring=1.1-2build1.1`
@@ -1365,10 +1365,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libunistring=1.1-2build1.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libu/libunistring/libunistring_1.1.orig.tar.xz' libunistring_1.1.orig.tar.xz 2397676
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libu/libunistring/libunistring_1.1.orig.tar.xz.asc' libunistring_1.1.orig.tar.xz.asc 833
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libu/libunistring/libunistring_1.1-2build1.1.debian.tar.xz' libunistring_1.1-2build1.1.debian.tar.xz 14188
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libu/libunistring/libunistring_1.1-2build1.1.dsc' libunistring_1.1-2build1.1.dsc 2292
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libu/libunistring/libunistring_1.1.orig.tar.xz' libunistring_1.1.orig.tar.xz 2397676
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libu/libunistring/libunistring_1.1.orig.tar.xz.asc' libunistring_1.1.orig.tar.xz.asc 833
 ```
 
 ### `dpkg` source package: `libxcrypt=1:4.4.36-4build1`
@@ -1385,9 +1385,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libxcrypt=1:4.4.36-4build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libx/libxcrypt/libxcrypt_4.4.36-4build1.debian.tar.xz' libxcrypt_4.4.36-4build1.debian.tar.xz 8356
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libx/libxcrypt/libxcrypt_4.4.36-4build1.dsc' libxcrypt_4.4.36-4build1.dsc 2300
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libx/libxcrypt/libxcrypt_4.4.36.orig.tar.xz' libxcrypt_4.4.36.orig.tar.xz 392732
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libx/libxcrypt/libxcrypt_4.4.36-4build1.debian.tar.xz' libxcrypt_4.4.36-4build1.debian.tar.xz 8356
 ```
 
 ### `dpkg` source package: `libyaml=0.2.5-1build1`
@@ -1405,9 +1405,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libyaml=0.2.5-1build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/liby/libyaml/libyaml_0.2.5-1build1.debian.tar.xz' libyaml_0.2.5-1build1.debian.tar.xz 5496
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/liby/libyaml/libyaml_0.2.5-1build1.dsc' libyaml_0.2.5-1build1.dsc 2203
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/liby/libyaml/libyaml_0.2.5.orig.tar.gz' libyaml_0.2.5.orig.tar.gz 85055
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/liby/libyaml/libyaml_0.2.5-1build1.debian.tar.xz' libyaml_0.2.5-1build1.debian.tar.xz 5496
 ```
 
 ### `dpkg` source package: `libzstd=1.5.5+dfsg2-2build1.1`
@@ -1427,9 +1427,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris libzstd=1.5.5+dfsg2-2build1.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libz/libzstd/libzstd_1.5.5%2bdfsg2.orig.tar.xz' libzstd_1.5.5+dfsg2.orig.tar.xz 1784164
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libz/libzstd/libzstd_1.5.5%2bdfsg2-2build1.1.debian.tar.xz' libzstd_1.5.5+dfsg2-2build1.1.debian.tar.xz 21288
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libz/libzstd/libzstd_1.5.5%2bdfsg2-2build1.1.dsc' libzstd_1.5.5+dfsg2-2build1.1.dsc 2485
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/libz/libzstd/libzstd_1.5.5%2bdfsg2.orig.tar.xz' libzstd_1.5.5+dfsg2.orig.tar.xz 1784164
 ```
 
 ### `dpkg` source package: `lua5.4=5.4.6-3build2`
@@ -1446,9 +1446,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris lua5.4=5.4.6-3build2
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/l/lua5.4/lua5.4_5.4.6-3build2.debian.tar.xz' lua5.4_5.4.6-3build2.debian.tar.xz 13240
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/l/lua5.4/lua5.4_5.4.6-3build2.dsc' lua5.4_5.4.6-3build2.dsc 2191
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/l/lua5.4/lua5.4_5.4.6.orig.tar.gz' lua5.4_5.4.6.orig.tar.gz 363329
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/l/lua5.4/lua5.4_5.4.6-3build2.debian.tar.xz' lua5.4_5.4.6-3build2.debian.tar.xz 13240
 ```
 
 ### `dpkg` source package: `luasocket=3.1.0-1`
@@ -1465,9 +1465,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris luasocket=3.1.0-1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/universe/l/luasocket/luasocket_3.1.0-1.debian.tar.xz' luasocket_3.1.0-1.debian.tar.xz 7092
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/universe/l/luasocket/luasocket_3.1.0-1.dsc' luasocket_3.1.0-1.dsc 1498
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/universe/l/luasocket/luasocket_3.1.0.orig.tar.gz' luasocket_3.1.0.orig.tar.gz 336570
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/universe/l/luasocket/luasocket_3.1.0-1.debian.tar.xz' luasocket_3.1.0-1.debian.tar.xz 7092
 ```
 
 ### `dpkg` source package: `lz4=1.9.4-1build1.1`
@@ -1486,9 +1486,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris lz4=1.9.4-1build1.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/l/lz4/lz4_1.9.4.orig.tar.gz' lz4_1.9.4.orig.tar.gz 354063
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/l/lz4/lz4_1.9.4-1build1.1.debian.tar.xz' lz4_1.9.4-1build1.1.debian.tar.xz 8356
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/l/lz4/lz4_1.9.4-1build1.1.dsc' lz4_1.9.4-1build1.1.dsc 2061
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/l/lz4/lz4_1.9.4.orig.tar.gz' lz4_1.9.4.orig.tar.gz 354063
 ```
 
 ### `dpkg` source package: `machine-guest-tools=0.18.0test-1`
@@ -1521,10 +1521,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris mawk=1.3.4.20240123-1build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/m/mawk/mawk_1.3.4.20240123-1build1.debian.tar.xz' mawk_1.3.4.20240123-1build1.debian.tar.xz 15704
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/m/mawk/mawk_1.3.4.20240123-1build1.dsc' mawk_1.3.4.20240123-1build1.dsc 2312
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/m/mawk/mawk_1.3.4.20240123.orig.tar.gz' mawk_1.3.4.20240123.orig.tar.gz 413943
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/m/mawk/mawk_1.3.4.20240123.orig.tar.gz.asc' mawk_1.3.4.20240123.orig.tar.gz.asc 729
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/m/mawk/mawk_1.3.4.20240123-1build1.debian.tar.xz' mawk_1.3.4.20240123-1build1.debian.tar.xz 15704
 ```
 
 ### `dpkg` source package: `ncurses=6.4+20240113-1ubuntu2`
@@ -1546,10 +1546,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris ncurses=6.4+20240113-1ubuntu2
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/ncurses/ncurses_6.4%2b20240113-1ubuntu2.debian.tar.xz' ncurses_6.4+20240113-1ubuntu2.debian.tar.xz 49372
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/ncurses/ncurses_6.4%2b20240113-1ubuntu2.dsc' ncurses_6.4+20240113-1ubuntu2.dsc 3963
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/ncurses/ncurses_6.4%2b20240113.orig.tar.gz' ncurses_6.4+20240113.orig.tar.gz 3688489
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/ncurses/ncurses_6.4%2b20240113.orig.tar.gz.asc' ncurses_6.4+20240113.orig.tar.gz.asc 729
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/ncurses/ncurses_6.4%2b20240113-1ubuntu2.debian.tar.xz' ncurses_6.4+20240113-1ubuntu2.debian.tar.xz 49372
 ```
 
 ### `dpkg` source package: `nettle=3.9.1-2.2build1.1`
@@ -1577,10 +1577,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris nettle=3.9.1-2.2build1.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/nettle/nettle_3.9.1.orig.tar.gz' nettle_3.9.1.orig.tar.gz 2396741
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/nettle/nettle_3.9.1.orig.tar.gz.asc' nettle_3.9.1.orig.tar.gz.asc 573
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/nettle/nettle_3.9.1-2.2build1.1.debian.tar.xz' nettle_3.9.1-2.2build1.1.debian.tar.xz 24848
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/nettle/nettle_3.9.1-2.2build1.1.dsc' nettle_3.9.1-2.2build1.1.dsc 2325
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/nettle/nettle_3.9.1.orig.tar.gz' nettle_3.9.1.orig.tar.gz 2396741
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/nettle/nettle_3.9.1.orig.tar.gz.asc' nettle_3.9.1.orig.tar.gz.asc 573
 ```
 
 ### `dpkg` source package: `nghttp2=1.59.0-1ubuntu0.2`
@@ -1602,9 +1602,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris nghttp2=1.59.0-1ubuntu0.2
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/nghttp2/nghttp2_1.59.0-1ubuntu0.2.debian.tar.xz' nghttp2_1.59.0-1ubuntu0.2.debian.tar.xz 14204
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/nghttp2/nghttp2_1.59.0-1ubuntu0.2.dsc' nghttp2_1.59.0-1ubuntu0.2.dsc 2624
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/nghttp2/nghttp2_1.59.0.orig.tar.gz' nghttp2_1.59.0.orig.tar.gz 1055492
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/nghttp2/nghttp2_1.59.0-1ubuntu0.2.debian.tar.xz' nghttp2_1.59.0-1ubuntu0.2.debian.tar.xz 14204
 ```
 
 ### `dpkg` source package: `npth=1.6-3.1build1`
@@ -1622,9 +1622,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris npth=1.6-3.1build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/npth/npth_1.6-3.1build1.debian.tar.xz' npth_1.6-3.1build1.debian.tar.xz 11036
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/npth/npth_1.6-3.1build1.dsc' npth_1.6-3.1build1.dsc 2107
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/npth/npth_1.6.orig.tar.bz2' npth_1.6.orig.tar.bz2 300486
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/n/npth/npth_1.6-3.1build1.debian.tar.xz' npth_1.6-3.1build1.debian.tar.xz 11036
 ```
 
 ### `dpkg` source package: `openldap=2.6.10+dfsg-0ubuntu0.24.04.1`
@@ -1664,9 +1664,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris openldap=2.6.10+dfsg-0ubuntu0.24.04.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/o/openldap/openldap_2.6.10%2bdfsg.orig.tar.xz' openldap_2.6.10+dfsg.orig.tar.xz 3754560
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/o/openldap/openldap_2.6.10%2bdfsg-0ubuntu0.24.04.1.debian.tar.xz' openldap_2.6.10+dfsg-0ubuntu0.24.04.1.debian.tar.xz 191132
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/o/openldap/openldap_2.6.10%2bdfsg-0ubuntu0.24.04.1.dsc' openldap_2.6.10+dfsg-0ubuntu0.24.04.1.dsc 3653
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/o/openldap/openldap_2.6.10%2bdfsg.orig.tar.xz' openldap_2.6.10+dfsg.orig.tar.xz 3754560
 ```
 
 ### `dpkg` source package: `openssl=3.0.13-0ubuntu3.11`
@@ -1686,9 +1686,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris openssl=3.0.13-0ubuntu3.11
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/o/openssl/openssl_3.0.13.orig.tar.gz' openssl_3.0.13.orig.tar.gz 15294843
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/o/openssl/openssl_3.0.13-0ubuntu3.11.debian.tar.xz' openssl_3.0.13-0ubuntu3.11.debian.tar.xz 195932
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/o/openssl/openssl_3.0.13-0ubuntu3.11.dsc' openssl_3.0.13-0ubuntu3.11.dsc 2516
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/o/openssl/openssl_3.0.13.orig.tar.gz' openssl_3.0.13.orig.tar.gz 15294843
 ```
 
 ### `dpkg` source package: `p11-kit=0.25.3-4ubuntu2.1`
@@ -1716,9 +1716,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris p11-kit=0.25.3-4ubuntu2.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/p11-kit/p11-kit_0.25.3.orig.tar.xz' p11-kit_0.25.3.orig.tar.xz 991528
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/p11-kit/p11-kit_0.25.3-4ubuntu2.1.debian.tar.xz' p11-kit_0.25.3-4ubuntu2.1.debian.tar.xz 26028
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/p11-kit/p11-kit_0.25.3-4ubuntu2.1.dsc' p11-kit_0.25.3-4ubuntu2.1.dsc 2405
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/p11-kit/p11-kit_0.25.3.orig.tar.xz' p11-kit_0.25.3.orig.tar.xz 991528
 ```
 
 ### `dpkg` source package: `pam=1.5.3-5ubuntu5.5`
@@ -1748,9 +1748,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris pam=1.5.3-5ubuntu5.5
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/pam/pam_1.5.3.orig.tar.xz' pam_1.5.3.orig.tar.xz 1020076
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/pam/pam_1.5.3-5ubuntu5.5.debian.tar.xz' pam_1.5.3-5ubuntu5.5.debian.tar.xz 204688
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/pam/pam_1.5.3-5ubuntu5.5.dsc' pam_1.5.3-5ubuntu5.5.dsc 2727
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/pam/pam_1.5.3.orig.tar.xz' pam_1.5.3.orig.tar.xz 1020076
 ```
 
 ### `dpkg` source package: `pcre2=10.42-4ubuntu2.1`
@@ -1771,9 +1771,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris pcre2=10.42-4ubuntu2.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/pcre2/pcre2_10.42.orig.tar.gz' pcre2_10.42.orig.tar.gz 2397194
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/pcre2/pcre2_10.42-4ubuntu2.1.diff.gz' pcre2_10.42-4ubuntu2.1.diff.gz 8431
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/pcre2/pcre2_10.42-4ubuntu2.1.dsc' pcre2_10.42-4ubuntu2.1.dsc 2277
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/pcre2/pcre2_10.42.orig.tar.gz' pcre2_10.42.orig.tar.gz 2397194
 ```
 
 ### `dpkg` source package: `perl=5.38.2-3.2ubuntu0.2`
@@ -1814,10 +1814,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris perl=5.38.2-3.2ubuntu0.2
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/perl/perl_5.38.2-3.2ubuntu0.2.debian.tar.xz' perl_5.38.2-3.2ubuntu0.2.debian.tar.xz 171736
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/perl/perl_5.38.2-3.2ubuntu0.2.dsc' perl_5.38.2-3.2ubuntu0.2.dsc 3036
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/perl/perl_5.38.2.orig-regen-configure.tar.xz' perl_5.38.2.orig-regen-configure.tar.xz 418808
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/perl/perl_5.38.2.orig.tar.xz' perl_5.38.2.orig.tar.xz 13679524
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/perl/perl_5.38.2-3.2ubuntu0.2.debian.tar.xz' perl_5.38.2-3.2ubuntu0.2.debian.tar.xz 171736
 ```
 
 ### `dpkg` source package: `procps=2:4.0.4-4ubuntu3.2`
@@ -1840,9 +1840,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris procps=2:4.0.4-4ubuntu3.2
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/procps/procps_4.0.4.orig.tar.xz' procps_4.0.4.orig.tar.xz 1401540
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/procps/procps_4.0.4-4ubuntu3.2.debian.tar.xz' procps_4.0.4-4ubuntu3.2.debian.tar.xz 38784
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/procps/procps_4.0.4-4ubuntu3.2.dsc' procps_4.0.4-4ubuntu3.2.dsc 2251
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/procps/procps_4.0.4.orig.tar.xz' procps_4.0.4.orig.tar.xz 1401540
 ```
 
 ### `dpkg` source package: `python3-defaults=3.12.3-0ubuntu2.1`
@@ -1859,8 +1859,8 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris python3-defaults=3.12.3-0ubuntu2.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/python3-defaults/python3-defaults_3.12.3-0ubuntu2.1.tar.gz' python3-defaults_3.12.3-0ubuntu2.1.tar.gz 147765
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/python3-defaults/python3-defaults_3.12.3-0ubuntu2.1.dsc' python3-defaults_3.12.3-0ubuntu2.1.dsc 3116
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/python3-defaults/python3-defaults_3.12.3-0ubuntu2.1.tar.gz' python3-defaults_3.12.3-0ubuntu2.1.tar.gz 147765
 ```
 
 ### `dpkg` source package: `python3.12=3.12.3-1ubuntu0.12`
@@ -1894,9 +1894,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris python3.12=3.12.3-1ubuntu0.12
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/python3.12/python3.12_3.12.3-1ubuntu0.12.debian.tar.xz' python3.12_3.12.3-1ubuntu0.12.debian.tar.xz 271148
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/python3.12/python3.12_3.12.3-1ubuntu0.12.dsc' python3.12_3.12.3-1ubuntu0.12.dsc 3311
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/python3.12/python3.12_3.12.3.orig.tar.xz' python3.12_3.12.3.orig.tar.xz 20625068
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/p/python3.12/python3.12_3.12.3-1ubuntu0.12.debian.tar.xz' python3.12_3.12.3-1ubuntu0.12.debian.tar.xz 271148
 ```
 
 ### `dpkg` source package: `readline=8.2-4build1`
@@ -1920,9 +1920,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris readline=8.2-4build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/r/readline/readline_8.2-4build1.debian.tar.xz' readline_8.2-4build1.debian.tar.xz 33816
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/r/readline/readline_8.2-4build1.dsc' readline_8.2-4build1.dsc 2926
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/r/readline/readline_8.2.orig.tar.gz' readline_8.2.orig.tar.gz 3043952
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/r/readline/readline_8.2-4build1.debian.tar.xz' readline_8.2-4build1.debian.tar.xz 33816
 ```
 
 ### `dpkg` source package: `rtmpdump=2.4+20151223.gitfa8646d.1-2build7`
@@ -1940,9 +1940,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris rtmpdump=2.4+20151223.gitfa8646d.1-2build7
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/r/rtmpdump/rtmpdump_2.4%2b20151223.gitfa8646d.1-2build7.debian.tar.xz' rtmpdump_2.4+20151223.gitfa8646d.1-2build7.debian.tar.xz 8464
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/r/rtmpdump/rtmpdump_2.4%2b20151223.gitfa8646d.1-2build7.dsc' rtmpdump_2.4+20151223.gitfa8646d.1-2build7.dsc 2439
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/r/rtmpdump/rtmpdump_2.4%2b20151223.gitfa8646d.1.orig.tar.gz' rtmpdump_2.4+20151223.gitfa8646d.1.orig.tar.gz 142213
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/r/rtmpdump/rtmpdump_2.4%2b20151223.gitfa8646d.1-2build7.debian.tar.xz' rtmpdump_2.4+20151223.gitfa8646d.1-2build7.debian.tar.xz 8464
 ```
 
 ### `dpkg` source package: `sed=4.9-2build1`
@@ -1967,9 +1967,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris sed=4.9-2build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/sed/sed_4.9-2build1.debian.tar.xz' sed_4.9-2build1.debian.tar.xz 62896
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/sed/sed_4.9-2build1.dsc' sed_4.9-2build1.dsc 1992
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/sed/sed_4.9.orig.tar.xz' sed_4.9.orig.tar.xz 1397092
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/sed/sed_4.9-2build1.debian.tar.xz' sed_4.9-2build1.debian.tar.xz 62896
 ```
 
 ### `dpkg` source package: `sensible-utils=0.0.22`
@@ -2014,9 +2014,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris shadow=1:4.13+dfsg1-4ubuntu3.2
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/shadow/shadow_4.13%2bdfsg1.orig.tar.xz' shadow_4.13+dfsg1.orig.tar.xz 1811752
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/shadow/shadow_4.13%2bdfsg1-4ubuntu3.2.debian.tar.xz' shadow_4.13+dfsg1-4ubuntu3.2.debian.tar.xz 96392
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/shadow/shadow_4.13%2bdfsg1-4ubuntu3.2.dsc' shadow_4.13+dfsg1-4ubuntu3.2.dsc 2400
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/shadow/shadow_4.13%2bdfsg1.orig.tar.xz' shadow_4.13+dfsg1.orig.tar.xz 1811752
 ```
 
 ### `dpkg` source package: `systemd=255.4-1ubuntu8.15`
@@ -2041,9 +2041,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris systemd=255.4-1ubuntu8.15
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/systemd/systemd_255.4-1ubuntu8.15.debian.tar.xz' systemd_255.4-1ubuntu8.15.debian.tar.xz 264648
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/systemd/systemd_255.4-1ubuntu8.15.dsc' systemd_255.4-1ubuntu8.15.dsc 7324
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/systemd/systemd_255.4.orig.tar.gz' systemd_255.4.orig.tar.gz 14952427
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/systemd/systemd_255.4-1ubuntu8.15.debian.tar.xz' systemd_255.4-1ubuntu8.15.debian.tar.xz 264648
 ```
 
 ### `dpkg` source package: `sysvinit=3.08-6ubuntu3`
@@ -2066,9 +2066,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris sysvinit=3.08-6ubuntu3
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/sysvinit/sysvinit_3.08-6ubuntu3.debian.tar.xz' sysvinit_3.08-6ubuntu3.debian.tar.xz 140128
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/sysvinit/sysvinit_3.08-6ubuntu3.dsc' sysvinit_3.08-6ubuntu3.dsc 2495
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/sysvinit/sysvinit_3.08.orig.tar.gz' sysvinit_3.08.orig.tar.gz 513674
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/s/sysvinit/sysvinit_3.08-6ubuntu3.debian.tar.xz' sysvinit_3.08-6ubuntu3.debian.tar.xz 140128
 ```
 
 ### `dpkg` source package: `tar=1.35+dfsg-3build1`
@@ -2093,9 +2093,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris tar=1.35+dfsg-3build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tar/tar_1.35%2bdfsg-3build1.debian.tar.xz' tar_1.35+dfsg-3build1.debian.tar.xz 20948
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tar/tar_1.35%2bdfsg-3build1.dsc' tar_1.35+dfsg-3build1.dsc 2141
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tar/tar_1.35%2bdfsg.orig.tar.xz' tar_1.35+dfsg.orig.tar.xz 2111608
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tar/tar_1.35%2bdfsg-3build1.debian.tar.xz' tar_1.35+dfsg-3build1.debian.tar.xz 20948
 ```
 
 ### `dpkg` source package: `tcl8.6=8.6.14+dfsg-1build1`
@@ -2113,9 +2113,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris tcl8.6=8.6.14+dfsg-1build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tcl8.6/tcl8.6_8.6.14%2bdfsg-1build1.debian.tar.xz' tcl8.6_8.6.14+dfsg-1build1.debian.tar.xz 14484
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tcl8.6/tcl8.6_8.6.14%2bdfsg-1build1.dsc' tcl8.6_8.6.14+dfsg-1build1.dsc 2260
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tcl8.6/tcl8.6_8.6.14%2bdfsg.orig.tar.gz' tcl8.6_8.6.14+dfsg.orig.tar.gz 7091313
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tcl8.6/tcl8.6_8.6.14%2bdfsg-1build1.debian.tar.xz' tcl8.6_8.6.14+dfsg-1build1.debian.tar.xz 14484
 ```
 
 ### `dpkg` source package: `tcltk-defaults=8.6.14build1`
@@ -2151,10 +2151,10 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris tzdata=2026a-0ubuntu0.24.04.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tzdata/tzdata_2026a.orig.tar.gz' tzdata_2026a.orig.tar.gz 471812
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tzdata/tzdata_2026a.orig.tar.gz.asc' tzdata_2026a.orig.tar.gz.asc 833
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tzdata/tzdata_2026a-0ubuntu0.24.04.1.debian.tar.xz' tzdata_2026a-0ubuntu0.24.04.1.debian.tar.xz 188416
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tzdata/tzdata_2026a-0ubuntu0.24.04.1.dsc' tzdata_2026a-0ubuntu0.24.04.1.dsc 2728
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tzdata/tzdata_2026a.orig.tar.gz' tzdata_2026a.orig.tar.gz 471812
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/t/tzdata/tzdata_2026a.orig.tar.gz.asc' tzdata_2026a.orig.tar.gz.asc 833
 ```
 
 ### `dpkg` source package: `ubuntu-keyring=2023.11.28.1`
@@ -2190,8 +2190,8 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris unminimize=0.2.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/u/unminimize/unminimize_0.2.1.tar.xz' unminimize_0.2.1.tar.xz 9400
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/u/unminimize/unminimize_0.2.1.dsc' unminimize_0.2.1.dsc 1554
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/u/unminimize/unminimize_0.2.1.tar.xz' unminimize_0.2.1.tar.xz 9400
 ```
 
 ### `dpkg` source package: `util-linux=2.39.3-9ubuntu6.5`
@@ -2229,9 +2229,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris util-linux=2.39.3-9ubuntu6.5
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/u/util-linux/util-linux_2.39.3.orig.tar.xz' util-linux_2.39.3.orig.tar.xz 8526168
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/u/util-linux/util-linux_2.39.3-9ubuntu6.5.debian.tar.xz' util-linux_2.39.3-9ubuntu6.5.debian.tar.xz 148016
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/u/util-linux/util-linux_2.39.3-9ubuntu6.5.dsc' util-linux_2.39.3-9ubuntu6.5.dsc 4726
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/u/util-linux/util-linux_2.39.3.orig.tar.xz' util-linux_2.39.3.orig.tar.xz 8526168
 ```
 
 ### `dpkg` source package: `xxhash=0.8.2-2build1`
@@ -2250,9 +2250,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris xxhash=0.8.2-2build1
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/x/xxhash/xxhash_0.8.2-2build1.debian.tar.xz' xxhash_0.8.2-2build1.debian.tar.xz 5048
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/x/xxhash/xxhash_0.8.2-2build1.dsc' xxhash_0.8.2-2build1.dsc 2076
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/x/xxhash/xxhash_0.8.2.orig.tar.gz' xxhash_0.8.2.orig.tar.gz 1141188
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/x/xxhash/xxhash_0.8.2-2build1.debian.tar.xz' xxhash_0.8.2-2build1.debian.tar.xz 5048
 ```
 
 ### `dpkg` source package: `xz-utils=5.6.1+really5.4.5-1ubuntu0.2`
@@ -2283,9 +2283,9 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris xz-utils=5.6.1+really5.4.5-1ubuntu0.2
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/x/xz-utils/xz-utils_5.6.1%2breally5.4.5-1ubuntu0.2.debian.tar.xz' xz-utils_5.6.1+really5.4.5-1ubuntu0.2.debian.tar.xz 30776
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/x/xz-utils/xz-utils_5.6.1%2breally5.4.5-1ubuntu0.2.dsc' xz-utils_5.6.1+really5.4.5-1ubuntu0.2.dsc 2639
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/x/xz-utils/xz-utils_5.6.1%2breally5.4.5.orig.tar.xz' xz-utils_5.6.1+really5.4.5.orig.tar.xz 1680520
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/x/xz-utils/xz-utils_5.6.1%2breally5.4.5-1ubuntu0.2.debian.tar.xz' xz-utils_5.6.1+really5.4.5-1ubuntu0.2.debian.tar.xz 30776
 ```
 
 ### `dpkg` source package: `zlib=1:1.3.dfsg-3.1ubuntu2.1`
@@ -2302,7 +2302,7 @@ Source:
 
 ```console
 $ apt-get -o APT::Architecture=riscv64 -o APT::Architectures=riscv64 --snapshot=20260421T000000Z source -qq --print-uris zlib=1:1.3.dfsg-3.1ubuntu2.1
-'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/z/zlib/zlib_1.3.dfsg.orig.tar.xz' zlib_1.3.dfsg.orig.tar.xz 1128572
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/z/zlib/zlib_1.3.dfsg-3.1ubuntu2.1.debian.tar.xz' zlib_1.3.dfsg-3.1ubuntu2.1.debian.tar.xz 61028
 'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/z/zlib/zlib_1.3.dfsg-3.1ubuntu2.1.dsc' zlib_1.3.dfsg-3.1ubuntu2.1.dsc 3116
+'https://snapshot.ubuntu.com/ubuntu/20260421T000000Z/pool/main/z/zlib/zlib_1.3.dfsg.orig.tar.xz' zlib_1.3.dfsg.orig.tar.xz 1128572
 ```

--- a/doc/recipes/third-party/repo-info/gather-dpkg.sh
+++ b/doc/recipes/third-party/repo-info/gather-dpkg.sh
@@ -195,13 +195,14 @@ for src in "${sortedSources[@]}"; do
 	# cannot be reconciled because they use different algorithms. Rewrite
 	# every URL to the durable snapshot host and drop the digest field so
 	# the output changes only when the committed rootfs or the snapshot pin
-	# does.
+	# does. apt also emits the files (.dsc, .orig.tar, .debian.tar) of a
+	# source package in no particular order, so sort the lines as well.
 	if [ -n "$aptSource" ]; then
 		sedArgs=( -E -e 's/ [A-Za-z0-9]+:[0-9a-fA-F]+$//' )
 		if [ -n "${APT_SNAPSHOT:-}" ]; then
 			sedArgs+=( -e "s#'[^']*/pool/#'https://snapshot.ubuntu.com/ubuntu/${APT_SNAPSHOT}/pool/#" )
 		fi
-		aptSource="$(printf '%s\n' "$aptSource" | sed "${sedArgs[@]}")"
+		aptSource="$(printf '%s\n' "$aptSource" | sed "${sedArgs[@]}" | sort)"
 	fi
 
 	if [ -n "$aptSource" ]; then


### PR DESCRIPTION
apt-get source --print-uris emits a source package's files (.dsc, .orig.tar.*, .debian.tar.*) in no guaranteed order, so regenerating rootfs-docs.licenses.md could reorder lines within Source: blocks and fail the CI sync check. Sort the URI lines in the normalization pass of gather-dpkg.sh and regenerate the report (pure reordering, no content change).