### PR TITLE
ci: fix GitHub API rate limit errors when installing risc0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1030,7 +1030,7 @@ jobs:
 
       - name: Install rzup
         run: |
-          cargo install --locked --git https://github.com/risc0/risc0 rzup
+          cargo install --locked rzup
           rzup install cargo-risczero 3.0.5
           rzup install r0vm 3.0.5
           rzup install cpp 2024.1.5


### PR DESCRIPTION
Our CI is sometimes failing due to GitHub API rate limits when installing risc0 using cargo, this PR fix the issue by avoiding downloading through GitHub.